### PR TITLE
refactor: phase 1 roundtrip latency cleanup

### DIFF
--- a/docs/REFACTOR-PHASE-1.md
+++ b/docs/REFACTOR-PHASE-1.md
@@ -1,0 +1,9 @@
+# Phase 1 Refactor Notes
+## Changes
+- Simplified roundtrip latency helper and removed unused headers.
+- Replaced nested loops with `std::inner_product`.
+## Micro Perf
+- `find_ping_offset` (64 sample ping, 50ms delay, 1000 runs) avg **166.7µs → 161.9µs**.
+## Phase 2 Follow-Ups
+- Normalize WDL include paths across plug-ins.
+- Explore broader header de-duplication.

--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -1,0 +1,14 @@
+# Phase 1 Refactor Plan
+## Inventory
+- Modules: sdk, reaper-plugins, scripts
+- Hotspots: reaper-plugins/roundtrip_latency.cpp
+- Smells: long nested loops, unused headers
+## Proposed Changes
+- No-risk: remove unused headers and cache vector sizes in roundtrip latency utility
+- Low-risk: replace manual cross-correlation loops with std::inner_product
+- Requires review: audit broader plug-ins for duplication and header bloat
+## Expected Impact
+- Build/compile: slightly reduced header includes and potential faster rebuilds
+- Runtime: inner_product may improve cross-correlation speed
+## Test/CI Considerations
+- configure and build via cmake -S . -B build && cmake --build build

--- a/reaper-plugins/roundtrip_latency.cpp
+++ b/reaper-plugins/roundtrip_latency.cpp
@@ -1,7 +1,6 @@
 #include "roundtrip_latency.h"
 #include <vector>
-#include <algorithm>
-#include <cmath>
+#include <numeric>
 #include <cstdio>
 
 static double g_roundtrip_latency = 0.0;
@@ -10,14 +9,15 @@ static double g_roundtrip_latency = 0.0;
 static size_t find_ping_offset(const std::vector<float>& ping,
                                const std::vector<float>& capture)
 {
-  if (capture.size() < ping.size()) return 0;
+  const size_t ping_size = ping.size();
+  const size_t capture_size = capture.size();
+  if (capture_size < ping_size) return 0;
   size_t best_offset = 0;
   double best_val = -1.0;
-  for (size_t o = 0; o <= capture.size() - ping.size(); ++o)
+  const size_t max_offset = capture_size - ping_size;
+  for (size_t o = 0; o <= max_offset; ++o)
   {
-    double v = 0.0;
-    for (size_t i = 0; i < ping.size(); ++i)
-      v += ping[i] * capture[o + i];
+    double v = std::inner_product(ping.begin(), ping.end(), capture.begin() + o, 0.0);
     if (v > best_val)
     {
       best_val = v;


### PR DESCRIPTION
## Summary
- document phase 1 refactor plan
- trim unused headers and cache sizes in roundtrip latency helper
- streamline cross-correlation with `std::inner_product`

## Testing
- `cmake -S . -B build` *(fails: WDL not found)*
- `cmake --build build` *(fails: ../../WDL/db2val.h missing)*
- `g++ -O2 -std=c++17 -I/tmp /tmp/bench_old.cpp -o /tmp/bench_old`
- `/tmp/bench_old`
- `g++ -O2 -std=c++17 -I/tmp /tmp/bench_new.cpp -o /tmp/bench_new`
- `/tmp/bench_new`


------
https://chatgpt.com/codex/tasks/task_e_6896c822886c832cb8324050aad9140c