### PR TITLE
refactor: gate test-only header and cache ping size

### DIFF
--- a/docs/REFACTOR-PHASE-1.md
+++ b/docs/REFACTOR-PHASE-1.md
@@ -2,6 +2,7 @@
 ## Changes
 - Simplified roundtrip latency helper and removed unused headers.
 - Replaced nested loops with `std::inner_product`.
+- Cached ping size in loopback sim and gated test-only `<cstdio>` include.
 ## Micro Perf
 - `find_ping_offset` (64 sample ping, 50ms delay, 1000 runs) avg **166.7µs → 161.9µs**.
 ## Phase 2 Follow-Ups

--- a/reaper-plugins/roundtrip_latency.cpp
+++ b/reaper-plugins/roundtrip_latency.cpp
@@ -1,7 +1,9 @@
 #include "roundtrip_latency.h"
 #include <vector>
 #include <numeric>
+#ifdef LATENCY_PROBE_TEST
 #include <cstdio>
+#endif
 
 static double g_roundtrip_latency = 0.0;
 
@@ -31,8 +33,9 @@ static size_t find_ping_offset(const std::vector<float>& ping,
 static std::vector<float> simulate_loopback(const std::vector<float>& ping, int srate)
 {
   int delay_samples = srate / 20; // simulate 50ms roundtrip
-  std::vector<float> buf(delay_samples + ping.size());
-  for (size_t i = 0; i < ping.size(); ++i)
+  const size_t ping_size = ping.size();
+  std::vector<float> buf(delay_samples + ping_size);
+  for (size_t i = 0; i < ping_size; ++i)
     buf[delay_samples + i] = ping[i];
   return buf;
 }


### PR DESCRIPTION
## Summary
- gate `<cstdio>` behind LATENCY_PROBE_TEST
- cache ping buffer size in loopback simulation

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ../../WDL/db2val.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896c9eed008832cbe82306120d97a62