### PR TITLE
Add GitHub Actions workflow for cross-platform CMake builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Collect plug-ins
+        run: |
+          mkdir -p plugins
+          find build -type f \( -name '*.vst3' -o -name '*.dll' -o -name '*.so' -o -name '*.dylib' \) -exec cp {} plugins/ \;
+      - name: Upload plug-ins
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugins-${{ matrix.os }}
+          path: plugins


### PR DESCRIPTION
## Summary
- add build workflow with Windows, macOS, and Linux runners
- archive compiled plug-ins for inspection

## Testing
- `yamllint .github/workflows/build.yml` *(fails: command not found)*
- `cmake -S . -B build` *(fails: WDL not found)*

------
https://chatgpt.com/codex/tasks/task_e_689752c9103c832cb221b62ae784bf4f