### PR TITLE
Add unit tests for track playlist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,25 @@
 cmake_minimum_required(VERSION 3.15)
 project(reaper_sdk_examples)
 
+include(CTest)
+
 # Verify that the WDL headers are available
 set(WDL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/WDL/WDL")
 if(EXISTS "${WDL_ROOT}/wdltypes.h")
-  add_library(track_playlist STATIC sdk/track_playlist/track_playlist.cpp)
-  target_compile_features(track_playlist PUBLIC cxx_std_17)
-  target_include_directories(track_playlist PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk)
+  set(WDL_FOUND ON)
+else()
+  set(WDL_FOUND OFF)
+  message(WARNING "WDL not found; sample plug-ins will not be built")
+endif()
 
-  add_executable(track_playlist_demo sdk/track_playlist/track_playlist_demo.cpp)
-  target_link_libraries(track_playlist_demo track_playlist)
+add_library(track_playlist STATIC sdk/track_playlist/track_playlist.cpp)
+target_compile_features(track_playlist PUBLIC cxx_std_17)
+target_include_directories(track_playlist PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk)
 
+add_executable(track_playlist_demo sdk/track_playlist/track_playlist_demo.cpp)
+target_link_libraries(track_playlist_demo track_playlist)
+
+if(WDL_FOUND)
   # Sample plug-ins
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins)
 
@@ -31,6 +40,17 @@ if(EXISTS "${WDL_ROOT}/wdltypes.h")
   if(BUILD_REAPER_STT)
     add_subdirectory(reaper-plugins/reaper_stt)
   endif()
-else()
-  message(FATAL_ERROR "WDL not found")
+endif()
+
+if(BUILD_TESTING)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+  )
+  FetchContent_MakeAvailable(googletest)
+
+  add_executable(track_playlist_test sdk/track_playlist/track_playlist_test.cpp)
+  target_link_libraries(track_playlist_test track_playlist GTest::gtest_main)
+  add_test(NAME track_playlist_test COMMAND track_playlist_test)
 endif()

--- a/sdk/track_playlist/track_playlist_test.cpp
+++ b/sdk/track_playlist/track_playlist_test.cpp
@@ -1,0 +1,50 @@
+#include "track_playlist.h"
+#include <gtest/gtest.h>
+
+using namespace rpr;
+
+TEST(TrackPlaylistTest, CreateAndSetActive) {
+  Track t;
+  auto first = t.CreateTrackPlaylist("First");
+  auto second = t.CreateTrackPlaylist("Second");
+  EXPECT_EQ(first, 0);
+  EXPECT_EQ(second, 1);
+
+  std::vector<std::string> names;
+  std::vector<bool> actives;
+  t.EnumTrackPlaylists([&](const Playlist &pl, bool active) {
+    names.push_back(pl.name);
+    actives.push_back(active);
+  });
+  EXPECT_EQ(names, std::vector<std::string>({"First", "Second"}));
+  EXPECT_EQ(actives, std::vector<bool>({true, false}));
+
+  EXPECT_TRUE(t.SetActiveTrackPlaylist(second));
+  actives.clear();
+  t.EnumTrackPlaylists(
+      [&](const Playlist &, bool active) { actives.push_back(active); });
+  EXPECT_EQ(actives, std::vector<bool>({false, true}));
+}
+
+TEST(TrackPlaylistTest, SerializeDeserializeDuplicateConsolidate) {
+  std::string chunk = "PLAYLISTS 2 1\nOne|L1|L2\nTwo|L3\n";
+  Track t = Track::Deserialize(chunk);
+  EXPECT_EQ(t.Serialize(), chunk);
+
+  std::vector<bool> actives;
+  t.EnumTrackPlaylists(
+      [&](const Playlist &, bool active) { actives.push_back(active); });
+  EXPECT_EQ(actives, std::vector<bool>({false, true}));
+
+  Track dup = t.DuplicatePlaylistToNewTrack(1);
+  const Playlist *p = dup.GetPlaylist(0);
+  ASSERT_NE(p, nullptr);
+  EXPECT_EQ(p->name, "Two");
+  EXPECT_EQ(p->lanes, std::vector<std::string>({"L3"}));
+
+  Track cons = t.ConsolidatePlaylistsToNewTrack();
+  const Playlist *c = cons.GetPlaylist(0);
+  ASSERT_NE(c, nullptr);
+  EXPECT_EQ(c->name, "Consolidated");
+  EXPECT_EQ(c->lanes, std::vector<std::string>({"L1", "L2", "L3"}));
+}


### PR DESCRIPTION
## Summary
- integrate CTest and fetch GoogleTest
- verify track playlist creation, serialization/deserialization, duplication and consolidation

## Testing
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_689754da4520832c8595f6d911829787