### PR TITLE
Validate playlist header and handle CRLF chunks

### DIFF
--- a/sdk/track_playlist/track_playlist.cpp
+++ b/sdk/track_playlist/track_playlist.cpp
@@ -41,10 +41,21 @@ Track Track::Deserialize(const std::string &chunk) {
   std::istringstream iss(chunk);
   std::string header;
   size_t count = 0;
-  iss >> header >> count >> t.active_index_;
+  ID active = -1;
+  if (!(iss >> header >> count >> active) || header != "PLAYLISTS")
+    return t;
+  t.active_index_ = active;
+
+  auto trim_cr = [](std::string &s) {
+    if (!s.empty() && s.back() == '\r')
+      s.pop_back();
+  };
+
   std::string line;
   std::getline(iss, line); // consume endline
+  trim_cr(line);
   for (size_t i = 0; i < count && std::getline(iss, line); ++i) {
+    trim_cr(line);
     std::istringstream pl(line);
     std::string name;
     std::getline(pl, name, '|');

--- a/sdk/track_playlist/track_playlist_test.cpp
+++ b/sdk/track_playlist/track_playlist_test.cpp
@@ -48,3 +48,21 @@ TEST(TrackPlaylistTest, SerializeDeserializeDuplicateConsolidate) {
   EXPECT_EQ(c->name, "Consolidated");
   EXPECT_EQ(c->lanes, std::vector<std::string>({"L1", "L2", "L3"}));
 }
+
+TEST(TrackPlaylistTest, DeserializeBadHeader) {
+  std::string chunk = "NOTPLAYLISTS 1 0\nFoo|L1\n";
+  Track t = Track::Deserialize(chunk);
+  EXPECT_EQ(t.Serialize(), Track().Serialize());
+}
+
+TEST(TrackPlaylistTest, DeserializeCRLF) {
+  std::string chunk =
+      "PLAYLISTS 2 1\r\nOne|L1|L2\r\nTwo|L3\r\n";
+  Track t = Track::Deserialize(chunk);
+  std::string expected = "PLAYLISTS 2 1\nOne|L1|L2\nTwo|L3\n";
+  EXPECT_EQ(t.Serialize(), expected);
+  const Playlist *p = t.GetPlaylist(1);
+  ASSERT_NE(p, nullptr);
+  ASSERT_EQ(p->lanes.size(), 1u);
+  EXPECT_EQ(p->lanes[0], "L3");
+}


### PR DESCRIPTION
## Summary
- ensure Track::Deserialize checks for "PLAYLISTS" header and trims CR terminators
- add tests for bad headers and CRLF-terminated chunks

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68975bc24148832cae69110348fd5d20