### PR TITLE
Ensure C++17 for track playlist tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if(BUILD_TESTING)
   FetchContent_MakeAvailable(googletest)
 
   add_executable(track_playlist_test sdk/track_playlist/track_playlist_test.cpp)
+  target_compile_features(track_playlist_test PRIVATE cxx_std_17)
   target_link_libraries(track_playlist_test track_playlist GTest::gtest_main)
   add_test(NAME track_playlist_test COMMAND track_playlist_test)
 endif()


### PR DESCRIPTION
## Summary
- ensure track_playlist_test compiles with C++17

## Testing
- `cmake -S . -B build-macos2 -DBUILD_TESTING=ON -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_STANDARD=14`
- `cmake --build build-macos2 --target track_playlist_test -- -j 2`
- `ctest --test-dir build-macos2 --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68975e8526fc832c9028f33a1f83d0e5