### PR TITLE
Warn when mac resource tools missing

### DIFF
--- a/README
+++ b/README
@@ -145,8 +145,8 @@ The resulting `reaper_csurf.dll` will be in the current directory.
    export WDL_PATH="$REAPER_SDK/WDL"
    ```
 
-3. Generate macOS resource files for any plug-in that includes a
-   `res.rc`:
+3. Optionally generate macOS resource files for plug-ins that include a
+   `res.rc` (plug-ins without such resources can skip this step):
 
    ```sh
    "$WDL_PATH/WDL/swell/swell_dlggen" reaper-plugins/reaper_csurf/res.rc

--- a/scripts/gen_mac_resources.sh
+++ b/scripts/gen_mac_resources.sh
@@ -15,6 +15,11 @@ DLGGEN="$SWELL_DIR/swell_dlggen"
 MENU="$SWELL_DIR/swell_menu"
 RESGEN="$SWELL_DIR/swell_resgen.sh"
 
+if [[ ! ( -x "$DLGGEN" && -x "$MENU" ) && ! -x "$RESGEN" ]]; then
+  echo "warning: swell tools not found in $SWELL_DIR, skipping resource generation" >&2
+  exit 0
+fi
+
 for rc in "$REPO_ROOT"/reaper-plugins/*/res.rc; do
   [ -e "$rc" ] || continue
   plugindir=$(dirname "$rc")
@@ -23,8 +28,5 @@ for rc in "$REPO_ROOT"/reaper-plugins/*/res.rc; do
     "$MENU" "$rc" "$plugindir/res.rc_mac_menu"
   elif [[ -x "$RESGEN" ]]; then
     "$RESGEN" "$rc"
-  else
-    echo "swell tools not found in $SWELL_DIR" >&2
-    exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- warn and skip mac resource generation if required swell tools aren't available
- clarify that resource generation is only needed for plug-ins with `res.rc`

## Testing
- `bash -n scripts/gen_mac_resources.sh`
- `./scripts/gen_mac_resources.sh && echo success`


------
https://chatgpt.com/codex/tasks/task_e_68975e97e518832c92585d597ab8810c