### PR TITLE
Add thread-safe TextLane and pluggable STT engine API

### DIFF
--- a/reaper-plugins/reaper_stt/stt_engine.h
+++ b/reaper-plugins/reaper_stt/stt_engine.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include "../../sdk/reaper_plugin.h"
+
+// Abstract interface for speech-to-text engines. Implementations can
+// perform synchronous or asynchronous transcription.
+class STTEngine {
+public:
+  virtual ~STTEngine() = default;
+  virtual std::string Transcribe(const ReaSample *samples,
+                                 int nch, int length,
+                                 double samplerate) = 0;
+};
+
+// Set a custom STT engine. Passing nullptr restores the default stub
+// implementation. The caller must ensure that the supplied engine
+// remains valid for the duration of its use.
+void STT_SetEngine(STTEngine *engine);
+


### PR DESCRIPTION
## Summary
- Encapsulated global text lane in a thread-safe `TextLane` class with add/find/replace/clear methods.
- Introduced `STTEngine` interface and `STT_SetEngine` API so external back ends can supply real STT implementations.
- Updated STT processing to use the pluggable engine and new lane manager.

## Testing
- `cmake -S . -B build`
- `cmake --build build --target reaper_stt` (fails: conflicting declarations in `stt_stubs.h` vs WDL)

------
https://chatgpt.com/codex/tasks/task_e_68976203ca9c832c8c914b6fb16cef13