### PR TITLE
Normalize platform includes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,9 @@
+Checks: '-*,bugprone-*,performance-*,readability-*'
+
+CheckOptions:
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: '^i$|^j$|^k$|^id$|^pl$|^t$|^p$|^c$'
+  - key: readability-identifier-length.MinimumVariableNameLength
+    value: '3'
+  - key: readability-identifier-length.MinimumParameterNameLength
+    value: '3'

--- a/sdk/config_ini.h
+++ b/sdk/config_ini.h
@@ -1,9 +1,11 @@
 #ifndef CONFIG_INI_H
 #define CONFIG_INI_H
 
-#ifdef _WIN32
-#include <windows.h>
+#if defined(_WIN32)
+# include <windows.h>
+#endif
 
+#ifdef _WIN32
 namespace config_ini {
 inline int getInt(const char *fn, const char *section, const char *key, int defval) {
   return (int)GetPrivateProfileInt(section, key, defval, fn);

--- a/sdk/example_m3u/import_m3u.cpp
+++ b/sdk/example_m3u/import_m3u.cpp
@@ -26,15 +26,15 @@
 
   */
 
-#ifdef _WIN32
-#include <windows.h>
-#include <string.h>
+#if defined(_WIN32)
+# include <windows.h>
 #else
-#include "../../WDL/swell/swell.h"
-#include <strings.h>
+# include "../../WDL/swell/swell.h"
+# include <strings.h>
 #endif
-#include <stdio.h>
-#include <math.h>
+#include <cstring>
+#include <cstdio>
+#include <cmath>
 
 
 #include "../reaper_plugin.h"

--- a/sdk/example_raw/pcmsink_raw.cpp
+++ b/sdk/example_raw/pcmsink_raw.cpp
@@ -25,15 +25,15 @@
 */
 
 
-#ifdef _WIN32
-#include <windows.h>
+#if defined(_WIN32)
+# include <windows.h>
 #else
-#include "../../WDL/swell/swell.h"
-#include "../../WDL/swell/swell-dlggen.h"
+# include "../../WDL/swell/swell.h"
+# include "../../WDL/swell/swell-dlggen.h"
 #endif
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 #include <sys/stat.h>
 
 #include "resource.h"

--- a/sdk/example_raw/pcmsrc_raw.cpp
+++ b/sdk/example_raw/pcmsrc_raw.cpp
@@ -26,14 +26,14 @@
 */
 
 
-#ifdef _WIN32
-#include <windows.h>
+#if defined(_WIN32)
+# include <windows.h>
 #else
-#include "../../WDL/swell/swell.h"
+# include "../../WDL/swell/swell.h"
 #endif
 
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 
 #include "resource.h"
 #include "../reaper_api_loader.hpp"

--- a/sdk/example_stream/basic_stream.cpp
+++ b/sdk/example_stream/basic_stream.cpp
@@ -3,10 +3,10 @@
   Simple example demonstrating the reaper_stream API.
 */
 
-#ifdef _WIN32
-#include <windows.h>
+#if defined(_WIN32)
+# include <windows.h>
 #else
-#include "../../WDL/swell/swell.h"
+# include "../../WDL/swell/swell.h"
 #endif
 
 #include "../reaper_api_loader.hpp"

--- a/sdk/otio/otio.cpp
+++ b/sdk/otio/otio.cpp
@@ -1,7 +1,7 @@
-#ifdef _WIN32
-#include <windows.h>
+#if defined(_WIN32)
+# include <windows.h>
 #else
-#include "../../WDL/swell/swell.h"
+# include "../../WDL/swell/swell.h"
 #endif
 
 #include "../../WDL/wdltypes.h"

--- a/sdk/reaper_plugin.h
+++ b/sdk/reaper_plugin.h
@@ -39,9 +39,13 @@ typedef double ReaSample;
 #endif
 
 
+#if defined(_WIN32)
+# include <windows.h>
+#else
+# include <pthread.h>
+#endif
 
 #ifdef _WIN32
-#include <windows.h>
 
 #if defined(__GNUC__) || defined(__clang__)
 #define REAPER_PLUGIN_DLL_EXPORT __attribute__((dllexport))
@@ -52,7 +56,6 @@ typedef double ReaSample;
 
 #else
 #include "../WDL/swell/swell.h"
-#include <pthread.h>
 
 #define REAPER_PLUGIN_DLL_EXPORT __attribute__((visibility("default")))
 #define REAPER_PLUGIN_HINSTANCE void *


### PR DESCRIPTION
## Summary
- guard Windows and pthread headers to improve portability
- use C++ standard headers in sample code
- add clang-tidy identifier length configuration

## Testing
- `SYSROOT=$(xcrun --show-sdk-path)`
- `python3 ./run-clang-tidy.py -p build -j "$(sysctl -n hw.logicalcpu)" -header-filter='^sdk/.*' -checks='-*,bugprone-*,performance-*,readability-*' -extra-arg-before=-isysroot -extra-arg-before="$SYSROOT" > .tidy.log 2>&1`
- `cppcheck --project=build/compile_commands.json --enable=warning,performance,portability,style --inconclusive --std=c++17 --inline-suppr --suppress=missingIncludeSystem --suppress='*:*WDL/*' --suppress='*:*reaper-plugins/*' --suppress='*:*build/*' 2> .cppcheck.log || true`


------
https://chatgpt.com/codex/tasks/task_e_6897fefb179c832cbb8a3a22c2507981