### PR TITLE
Implement WebSocket transport for reaper_stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 set(DOWNLOAD_EXTRACT_TIMESTAMP true)
 
 include(CTest)
+include(FetchContent)
 
 # Verify that the WDL headers are available
 set(WDL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/WDL/WDL")
@@ -57,6 +58,24 @@ else()
   message(WARNING "WDL not found; sample plug-ins will not be built")
 endif()
 
+# Third-party dependencies
+set(IXWEBSOCKET_USE_TLS OFF CACHE BOOL "Use OpenSSL for TLS support")
+set(IXWEBSOCKET_ENABLE_MBED_TLS OFF CACHE BOOL "Disable mbed TLS" FORCE)
+set(IXWEBSOCKET_ENABLE_OPEN_SSL OFF CACHE BOOL "Disable optional OpenSSL helpers")
+set(IXWEBSOCKET_BUILD_TESTS OFF CACHE BOOL "Disable ixwebsocket tests" FORCE)
+set(IXWEBSOCKET_INSTALL OFF CACHE BOOL "Skip ixwebsocket install rules" FORCE)
+
+FetchContent_Declare(
+  ixwebsocket
+  URL https://github.com/machinezone/IXWebSocket/archive/refs/tags/v11.4.6.zip
+)
+FetchContent_MakeAvailable(ixwebsocket)
+
+or_safe_add_library(reaper_stream STATIC sdk/reaper_stream/reaper_stream.cpp)
+target_link_libraries(reaper_stream PUBLIC ixwebsocket::ixwebsocket)
+target_include_directories(reaper_stream PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk)
+target_compile_features(reaper_stream PUBLIC cxx_std_17)
+
 or_safe_add_library(track_playlist STATIC sdk/track_playlist/track_playlist.cpp)
 target_compile_features(track_playlist PUBLIC cxx_std_17)
 target_include_directories(track_playlist PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/sdk)
@@ -65,7 +84,6 @@ or_safe_add_executable(track_playlist_demo sdk/track_playlist/track_playlist_dem
 target_link_libraries(track_playlist_demo PRIVATE track_playlist)
 
 if(BUILD_TESTING AND ORPHEUS_ENABLE_TESTS)
-  include(FetchContent)
   FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip

--- a/docs/reaper_stream.md
+++ b/docs/reaper_stream.md
@@ -1,11 +1,47 @@
 # Network audio streaming
 
 The `reaper_stream` module provides a minimal API for sending and receiving
-`PCM_source_transfer_t` audio blocks over a network transport.
-Connections are specified using a URL with either a WebSocket (`ws://` or
-`wss://`) or SRT (`srt://`) scheme.
+`PCM_source_transfer_t` audio blocks over real network transports.  The initial
+implementation focuses on WebSocket clients built on top of
+[`ixwebsocket`](https://github.com/machinezone/IXWebSocket); additional
+transports can be added behind the same API in the future.
 
-## API
+## Supported transports
+
+* **WebSocket (`ws://`)** – Enabled by default and implemented with
+  `ixwebsocket`.  Connections are opened asynchronously and data frames are
+  transferred using a compact binary container that preserves the fields of
+  `PCM_source_transfer_t`.
+* **Secure WebSocket (`wss://`)** – Available when the SDK is configured with
+  TLS support for `ixwebsocket` (see the build notes below).
+
+SRT (`srt://`) and other schemes are reserved for later expansion and currently
+return an error from `stream_open`.
+
+## Building the SDK with networking support
+
+The top-level CMake project now fetches `ixwebsocket` automatically via
+`FetchContent` and builds the `reaper_stream` static library.  No manual setup
+is required for plain `ws://` support—simply configure and build the project as
+usual:
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Secure WebSocket connections rely on TLS.  To enable them, pass the
+`IXWEBSOCKET_USE_TLS=ON` option when configuring CMake.  If OpenSSL is available
+on your system you can also enable the helper routines with
+`IXWEBSOCKET_ENABLE_OPEN_SSL=ON`:
+
+```bash
+cmake -S . -B build \
+  -DIXWEBSOCKET_USE_TLS=ON \
+  -DIXWEBSOCKET_ENABLE_OPEN_SSL=ON
+```
+
+## API reference
 
 ```c
 int stream_open(const char *url);
@@ -13,13 +49,49 @@ int stream_send(int handle, const PCM_source_transfer_t *block);
 int stream_receive(int handle, PCM_source_transfer_t *block);
 ```
 
-1. Call `stream_open()` with the desired URL to create a connection. The
-   return value is a handle used for subsequent calls.
-2. Use `stream_send()` to transmit an audio block to the remote peer.
-3. Use `stream_receive()` to fetch the next available audio block from the
-   connection. The caller must allocate a buffer for `block->samples`.
+1. **`stream_open`** – Creates a client connection for the supplied URL.  A
+   non-zero handle indicates success.  The function blocks briefly while the
+   WebSocket handshake completes (up to ~5 seconds by default).
+2. **`stream_send`** – Serialises an audio block and queues it for transmission.
+   The call is non-blocking with respect to network I/O.  A return value of `0`
+   indicates an error such as a disconnected transport or an invalid block.
+3. **`stream_receive`** – Retrieves the next decoded block, if one is available.
+   The caller must pre-allocate `block->samples` with enough storage for
+   `block->length * block->nch` `ReaSample` values.  The function returns the
+   number of sample frames copied (or `0` when no data is ready).
 
-The provided implementation performs a simple loopback of sent audio blocks
-and is intended as a reference for building more sophisticated transports.
+Incoming frames are buffered on a per-connection queue with a modest depth
+(currently 32 blocks) to absorb jitter.  When the queue is full, the oldest
+block is dropped to keep the stream moving forward.
 
-See `sdk/example_stream` for a basic example extension.
+## Example: basic echo round-trip
+
+The `sdk/example_stream/basic_stream.cpp` extension demonstrates a minimal
+end-to-end exchange.  To try it out you will need a WebSocket server that echoes
+binary payloads.  One option is to use
+[`websocat`](https://github.com/vi/websocat):
+
+```bash
+websocat --binary ws-l:0.0.0.0:9000 reuseport:1 mirror:
+```
+
+Alternatively, any WebSocket implementation that relays binary frames unchanged
+will work.
+
+After starting the echo server, build the extension and load it into REAPER.
+The example opens `ws://127.0.0.1:9000`, sends a short mono buffer and attempts
+to read the echoed data back into the same structure.  Inspect the source for
+additional details on buffer sizing and error handling.
+
+## Troubleshooting
+
+* `stream_open` returns `0`: verify the URL scheme and confirm that the remote
+  server is reachable.  When using `wss://`, ensure that TLS support was enabled
+  at configure time.
+* `stream_send`/`stream_receive` return `0`: check that the handle is valid and
+  that you provided non-null sample buffers.  Network errors are latched inside
+  the connection and will cause subsequent calls to fail until the handle is
+  reopened.
+
+With these primitives in place you can build higher-level streaming workflows on
+ top of the REAPER SDK while relying on well-tested networking infrastructure.

--- a/sdk/example_stream/basic_stream.cpp
+++ b/sdk/example_stream/basic_stream.cpp
@@ -11,6 +11,9 @@
 
 #include "../reaper_api_loader.hpp"
 
+#include <chrono>
+#include <thread>
+
 #define REAPERAPI_IMPLEMENT
 #define REAPERAPI_MINIMAL
 #define REAPER_PLUGIN_FUNCTIONS_IMPL_LOADFUNC
@@ -29,7 +32,8 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE in
   {
     if (REAPERAPI_LoadAPI(rec->GetFunc)) return 0;
 
-    int handle = stream_open("ws://localhost:9000");
+    ShowConsoleMsg("basic_stream: opening ws://127.0.0.1:9000...\n");
+    int handle = stream_open("ws://127.0.0.1:9000");
     if (handle)
     {
       const int ns = 512;
@@ -39,7 +43,50 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE in
       block.nch = 1;
       block.length = ns;
       block.samples = buf;
-      stream_send(handle, &block);
+      // Fill the buffer with a short ramp for demonstration purposes.
+      for (int i = 0; i < ns; ++i)
+      {
+        buf[i] = (ReaSample)i / (ReaSample)ns;
+      }
+
+      if (!stream_send(handle, &block))
+      {
+        ShowConsoleMsg("basic_stream: failed to send audio block.\n");
+      }
+      else
+      {
+        ShowConsoleMsg("basic_stream: block sent, waiting for echo...\n");
+        for (int i = 0; i < ns; ++i)
+        {
+          buf[i] = 0.0;
+        }
+
+        PCM_source_transfer_t recv = {};
+        recv.samplerate = block.samplerate;
+        recv.nch = block.nch;
+        recv.length = block.length;
+        recv.samples = buf;
+
+        int received = 0;
+        for (int attempt = 0; attempt < 50 && received == 0; ++attempt)
+        {
+          std::this_thread::sleep_for(std::chrono::milliseconds(40));
+          received = stream_receive(handle, &recv);
+        }
+
+        if (received > 0)
+        {
+          ShowConsoleMsg("basic_stream: received echoed audio block.\n");
+        }
+        else
+        {
+          ShowConsoleMsg("basic_stream: no audio received before timeout.\n");
+        }
+      }
+    }
+    else
+    {
+      ShowConsoleMsg("basic_stream: failed to open stream.\n");
     }
     return 1;
   }

--- a/sdk/reaper_stream/pcm_types.h
+++ b/sdk/reaper_stream/pcm_types.h
@@ -1,0 +1,35 @@
+#ifndef REAPER_STREAM_PCM_TYPES_H
+#define REAPER_STREAM_PCM_TYPES_H
+
+#ifndef _REAPER_PLUGIN_H_
+
+#ifndef REASAMPLE_SIZE
+#define REASAMPLE_SIZE 8
+#endif
+
+#if REASAMPLE_SIZE == 4
+typedef float ReaSample;
+#else
+typedef double ReaSample;
+#endif
+
+struct MIDI_eventlist;
+
+typedef struct _PCM_source_transfer_t
+{
+  double time_s;
+  double samplerate;
+  int nch;
+  int length;
+  ReaSample *samples;
+  int samples_out;
+  MIDI_eventlist *midi_events;
+  double approximate_playback_latency;
+  double roundtrip_latency;
+  double absolute_time_s;
+  double force_bpm;
+} PCM_source_transfer_t;
+
+#endif // !_REAPER_PLUGIN_H_
+
+#endif // REAPER_STREAM_PCM_TYPES_H

--- a/sdk/reaper_stream/reaper_stream.cpp
+++ b/sdk/reaper_stream/reaper_stream.cpp
@@ -1,76 +1,635 @@
 #include "reaper_stream.h"
 
-#include <unordered_map>
-#include <queue>
-#include <mutex>
-#include <vector>
-#include <string>
-#include <cstring>
+#include <ixwebsocket/IXNetSystem.h>
+#include <ixwebsocket/IXWebSocket.h>
 
-struct BlockData {
-  PCM_source_transfer_t meta;
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <climits>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+struct NetSystemInitializer
+{
+  NetSystemInitializer() { ix::initNetSystem(); }
+  ~NetSystemInitializer() { ix::uninitNetSystem(); }
+};
+
+NetSystemInitializer g_netSystemInitializer;
+
+constexpr uint32_t makeMagic()
+{
+  return static_cast<uint32_t>('R') |
+         (static_cast<uint32_t>('S') << 8) |
+         (static_cast<uint32_t>('T') << 16) |
+         (static_cast<uint32_t>('M') << 24);
+}
+
+constexpr uint32_t kPacketMagic = makeMagic();
+constexpr uint16_t kPacketVersion = 1;
+constexpr uint32_t kHeaderSizeBytes = 80;
+constexpr size_t kMaxQueuedBlocks = 32;
+const std::chrono::milliseconds kConnectTimeout{5000};
+
+template <typename T>
+void appendLE(std::string &buffer, T value)
+{
+  if constexpr (std::is_integral<T>::value)
+  {
+    using UnsignedT = typename std::make_unsigned<T>::type;
+    UnsignedT uvalue = static_cast<UnsignedT>(value);
+    for (size_t i = 0; i < sizeof(T); ++i)
+    {
+      buffer.push_back(static_cast<char>(uvalue & 0xFF));
+      uvalue >>= 8;
+    }
+  }
+  else if constexpr (std::is_floating_point<T>::value)
+  {
+    static_assert(sizeof(T) == 4 || sizeof(T) == 8, "unexpected floating point size");
+    using UnsignedT = typename std::conditional<sizeof(T) == 8, uint64_t, uint32_t>::type;
+    UnsignedT bits = 0;
+    std::memcpy(&bits, &value, sizeof(T));
+    appendLE(buffer, bits);
+  }
+  else
+  {
+    static_assert(std::is_arithmetic<T>::value, "unsupported type");
+  }
+}
+
+template <typename T>
+bool readLE(const uint8_t *data, size_t size, size_t &offset, T &out)
+{
+  if (offset + sizeof(T) > size)
+    return false;
+
+  if constexpr (std::is_integral<T>::value)
+  {
+    using UnsignedT = typename std::make_unsigned<T>::type;
+    UnsignedT value = 0;
+    for (size_t i = 0; i < sizeof(T); ++i)
+    {
+      value |= static_cast<UnsignedT>(data[offset + i]) << (8 * i);
+    }
+    out = static_cast<T>(value);
+  }
+  else if constexpr (std::is_floating_point<T>::value)
+  {
+    static_assert(sizeof(T) == 4 || sizeof(T) == 8, "unexpected floating point size");
+    using UnsignedT = typename std::conditional<sizeof(T) == 8, uint64_t, uint32_t>::type;
+    UnsignedT bits = 0;
+    for (size_t i = 0; i < sizeof(T); ++i)
+    {
+      bits |= static_cast<UnsignedT>(data[offset + i]) << (8 * i);
+    }
+    std::memcpy(&out, &bits, sizeof(T));
+  }
+  else
+  {
+    static_assert(std::is_arithmetic<T>::value, "unsupported type");
+  }
+
+  offset += sizeof(T);
+  return true;
+}
+
+struct BlockData
+{
+  PCM_source_transfer_t meta{};
   std::vector<ReaSample> samples;
 };
 
-struct StreamConnection {
-  enum Type { WS, SRT } type;
-  std::mutex mtx;
-  std::queue<BlockData> incoming; // simple loopback queue
+enum class StreamType
+{
+  kWebSocket,
+  kUnsupported,
 };
 
-static std::unordered_map<int, StreamConnection> g_streams;
-static int g_nextHandle = 1;
-
-static StreamConnection::Type parseType(const std::string &url)
+StreamType parseType(const std::string &url)
 {
-  if (url.rfind("srt://",0) == 0) return StreamConnection::SRT;
-  return StreamConnection::WS;
+  if (url.rfind("ws://", 0) == 0 || url.rfind("wss://", 0) == 0)
+    return StreamType::kWebSocket;
+  return StreamType::kUnsupported;
 }
+
+class StreamConnection : public std::enable_shared_from_this<StreamConnection>
+{
+public:
+  StreamConnection(StreamType type, std::string url)
+      : type_(type), url_(std::move(url))
+  {
+  }
+
+  ~StreamConnection()
+  {
+    if (websocket_)
+    {
+      websocket_->stop();
+    }
+  }
+
+  StreamType type() const { return type_; }
+  const std::string &url() const { return url_; }
+
+  bool waitForOpen(std::chrono::milliseconds timeout)
+  {
+    std::unique_lock<std::mutex> lock(stateMutex_);
+    if (open_)
+      return true;
+    stateCv_.wait_for(lock, timeout, [this]() { return open_ || failed_; });
+    return open_;
+  }
+
+  bool isOpen() const
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    return open_;
+  }
+
+  void enqueue(BlockData &&data)
+  {
+    std::lock_guard<std::mutex> lock(incomingMutex_);
+    if (incoming_.size() >= kMaxQueuedBlocks)
+    {
+      incoming_.pop();
+    }
+    incoming_.push(std::move(data));
+  }
+
+  bool pop(BlockData &out)
+  {
+    std::lock_guard<std::mutex> lock(incomingMutex_);
+    if (incoming_.empty())
+      return false;
+    out = std::move(incoming_.front());
+    incoming_.pop();
+    return true;
+  }
+
+  void reportError(const std::string &reason)
+  {
+    markFailed(reason);
+  }
+
+  std::string error() const
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    return lastError_;
+  }
+
+  std::unique_ptr<ix::WebSocket> websocket_;
+
+private:
+  void markOpen()
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    open_ = true;
+    failed_ = false;
+    lastError_.clear();
+    stateCv_.notify_all();
+  }
+
+  void markClosed(const std::string &reason)
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    open_ = false;
+    failed_ = true;
+    if (!reason.empty())
+      lastError_ = reason;
+    stateCv_.notify_all();
+  }
+
+  void markFailed(const std::string &reason)
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    failed_ = true;
+    open_ = false;
+    if (!reason.empty())
+      lastError_ = reason;
+    stateCv_.notify_all();
+  }
+
+  friend void setupWebSocket(const std::shared_ptr<StreamConnection> &);
+
+  StreamType type_;
+  std::string url_;
+
+  mutable std::mutex stateMutex_;
+  std::condition_variable stateCv_;
+  bool open_ = false;
+  bool failed_ = false;
+  std::string lastError_;
+
+  mutable std::mutex incomingMutex_;
+  std::queue<BlockData> incoming_;
+};
+
+std::mutex g_streamMutex;
+std::unordered_map<int, std::shared_ptr<StreamConnection>> g_streams;
+std::atomic<int> g_nextHandle{1};
+
+std::shared_ptr<StreamConnection> lookupConnection(int handle)
+{
+  std::lock_guard<std::mutex> lock(g_streamMutex);
+  auto it = g_streams.find(handle);
+  if (it == g_streams.end())
+    return nullptr;
+  return it->second;
+}
+
+bool encodeBlock(const PCM_source_transfer_t *block, std::string &payload, std::string &error)
+{
+  if (!block)
+  {
+    error = "null block";
+    return false;
+  }
+  if (!block->samples)
+  {
+    error = "null sample buffer";
+    return false;
+  }
+  if (block->nch <= 0)
+  {
+    error = "channel count must be positive";
+    return false;
+  }
+
+  const int frames = block->samples_out > 0 ? block->samples_out : block->length;
+  if (frames <= 0)
+  {
+    error = "no samples to send";
+    return false;
+  }
+
+  const size_t channels = static_cast<size_t>(block->nch);
+  const size_t frameCount = static_cast<size_t>(frames);
+  if (frameCount > std::numeric_limits<size_t>::max() / channels)
+  {
+    error = "sample count overflow";
+    return false;
+  }
+
+  const size_t totalSamples = frameCount * channels;
+  if (totalSamples > std::numeric_limits<size_t>::max() / sizeof(ReaSample))
+  {
+    error = "payload too large";
+    return false;
+  }
+
+  const size_t payloadBytes = totalSamples * sizeof(ReaSample);
+  if (payloadBytes > std::numeric_limits<uint32_t>::max())
+  {
+    error = "payload exceeds protocol limit";
+    return false;
+  }
+
+  payload.clear();
+  payload.reserve(kHeaderSizeBytes + payloadBytes);
+
+  appendLE<uint32_t>(payload, kPacketMagic);
+  appendLE<uint16_t>(payload, kPacketVersion);
+  appendLE<uint16_t>(payload, 0); // reserved
+  appendLE<uint32_t>(payload, kHeaderSizeBytes);
+  appendLE<uint32_t>(payload, 0); // flags
+  appendLE<uint32_t>(payload, static_cast<uint32_t>(block->length));
+  appendLE<uint32_t>(payload, static_cast<uint32_t>(frames));
+  appendLE<uint32_t>(payload, static_cast<uint32_t>(block->nch));
+  appendLE<uint32_t>(payload, static_cast<uint32_t>(payloadBytes));
+  appendLE<double>(payload, block->time_s);
+  appendLE<double>(payload, block->samplerate);
+  appendLE<double>(payload, block->approximate_playback_latency);
+  appendLE<double>(payload, block->roundtrip_latency);
+  appendLE<double>(payload, block->absolute_time_s);
+  appendLE<double>(payload, block->force_bpm);
+
+  payload.append(reinterpret_cast<const char *>(block->samples), payloadBytes);
+  return true;
+}
+
+bool decodeBlock(const std::string &payload, BlockData &out, std::string &error)
+{
+  const auto *data = reinterpret_cast<const uint8_t *>(payload.data());
+  const size_t size = payload.size();
+  size_t offset = 0;
+
+  uint32_t magic = 0;
+  if (!readLE(data, size, offset, magic) || magic != kPacketMagic)
+  {
+    error = "invalid packet magic";
+    return false;
+  }
+
+  uint16_t version = 0;
+  if (!readLE(data, size, offset, version) || version != kPacketVersion)
+  {
+    error = "unsupported packet version";
+    return false;
+  }
+
+  uint16_t reserved = 0;
+  if (!readLE(data, size, offset, reserved))
+  {
+    error = "truncated header";
+    return false;
+  }
+
+  (void)reserved;
+
+  uint32_t headerBytes = 0;
+  if (!readLE(data, size, offset, headerBytes) || headerBytes != kHeaderSizeBytes)
+  {
+    error = "unexpected header size";
+    return false;
+  }
+
+  uint32_t flags = 0;
+  if (!readLE(data, size, offset, flags))
+  {
+    error = "truncated flags";
+    return false;
+  }
+  (void)flags;
+
+  uint32_t lengthFrames = 0;
+  uint32_t framesOut = 0;
+  uint32_t channels = 0;
+  uint32_t payloadBytes = 0;
+  if (!readLE(data, size, offset, lengthFrames) ||
+      !readLE(data, size, offset, framesOut) ||
+      !readLE(data, size, offset, channels) ||
+      !readLE(data, size, offset, payloadBytes))
+  {
+    error = "truncated header fields";
+    return false;
+  }
+
+  double time_s = 0.0;
+  double samplerate = 0.0;
+  double approx_latency = 0.0;
+  double roundtrip_latency = 0.0;
+  double absolute_time = 0.0;
+  double force_bpm = 0.0;
+
+  if (!readLE(data, size, offset, time_s) ||
+      !readLE(data, size, offset, samplerate) ||
+      !readLE(data, size, offset, approx_latency) ||
+      !readLE(data, size, offset, roundtrip_latency) ||
+      !readLE(data, size, offset, absolute_time) ||
+      !readLE(data, size, offset, force_bpm))
+  {
+    error = "truncated metadata";
+    return false;
+  }
+
+  if (offset + payloadBytes > size)
+  {
+    error = "payload size mismatch";
+    return false;
+  }
+
+  if (channels == 0)
+  {
+    error = "invalid channel count";
+    return false;
+  }
+
+  if (payloadBytes % sizeof(ReaSample) != 0)
+  {
+    error = "payload not aligned to sample size";
+    return false;
+  }
+
+  const size_t sampleCount = payloadBytes / sizeof(ReaSample);
+  const size_t framesAvailable = sampleCount / channels;
+
+  out.samples.resize(sampleCount);
+  std::memcpy(out.samples.data(), data + offset, payloadBytes);
+
+  out.meta.time_s = time_s;
+  out.meta.samplerate = samplerate;
+  out.meta.nch = static_cast<int>(std::min<uint32_t>(channels, static_cast<uint32_t>(INT_MAX)));
+  out.meta.length = static_cast<int>(std::min<uint32_t>(lengthFrames, static_cast<uint32_t>(INT_MAX)));
+  out.meta.samples_out = static_cast<int>(std::min<uint32_t>(framesOut ? framesOut : static_cast<uint32_t>(framesAvailable), static_cast<uint32_t>(INT_MAX)));
+  out.meta.samples = out.samples.data();
+  out.meta.midi_events = nullptr;
+  out.meta.approximate_playback_latency = approx_latency;
+  out.meta.roundtrip_latency = roundtrip_latency;
+  out.meta.absolute_time_s = absolute_time;
+  out.meta.force_bpm = force_bpm;
+
+  return true;
+}
+
+void setupWebSocket(const std::shared_ptr<StreamConnection> &conn)
+{
+  if (!conn || !conn->websocket_)
+    return;
+
+  std::weak_ptr<StreamConnection> weakConn = conn;
+  conn->websocket_->disableAutomaticReconnection();
+
+  auto handshakeSeconds = std::max<int>(1, static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(kConnectTimeout).count()));
+  conn->websocket_->setHandshakeTimeout(handshakeSeconds);
+
+  conn->websocket_->setOnMessageCallback([weakConn](const ix::WebSocketMessagePtr &msg) {
+    if (auto locked = weakConn.lock())
+    {
+      switch (msg->type)
+      {
+      case ix::WebSocketMessageType::Open:
+        locked->markOpen();
+        break;
+      case ix::WebSocketMessageType::Close:
+      {
+        std::ostringstream oss;
+        oss << "connection closed";
+        if (!msg->closeInfo.reason.empty())
+          oss << ": " << msg->closeInfo.reason;
+        locked->markClosed(oss.str());
+        break;
+      }
+      case ix::WebSocketMessageType::Error:
+      {
+        std::ostringstream oss;
+        if (!msg->errorInfo.reason.empty())
+        {
+          oss << msg->errorInfo.reason;
+        }
+        else
+        {
+          oss << "websocket error";
+        }
+        if (msg->errorInfo.http_status)
+        {
+          oss << " (HTTP " << msg->errorInfo.http_status << ")";
+        }
+        locked->markFailed(oss.str());
+        break;
+      }
+      case ix::WebSocketMessageType::Message:
+      {
+        if (!msg->binary)
+        {
+          locked->markFailed("received non-binary frame");
+          break;
+        }
+        BlockData data;
+        std::string error;
+        if (!decodeBlock(msg->str, data, error))
+        {
+          locked->markFailed("decode error: " + error);
+          break;
+        }
+        data.meta.samples = data.samples.data();
+        locked->enqueue(std::move(data));
+        break;
+      }
+      default:
+        break;
+      }
+    }
+  });
+}
+
+} // namespace
 
 int stream_open(const char *url)
 {
-  if (!url) return 0;
-  StreamConnection conn;
-  conn.type = parseType(url);
-  int handle = g_nextHandle++;
-  g_streams.emplace(handle, std::move(conn));
+  if (!url || !*url)
+    return 0;
+
+  std::string urlStr(url);
+  StreamType type = parseType(urlStr);
+  if (type != StreamType::kWebSocket)
+    return 0;
+
+  auto conn = std::make_shared<StreamConnection>(type, urlStr);
+  conn->websocket_ = std::make_unique<ix::WebSocket>();
+  conn->websocket_->setUrl(urlStr);
+  conn->websocket_->setAutoThreadName(false);
+
+  setupWebSocket(conn);
+
+  const int handle = g_nextHandle.fetch_add(1);
+  {
+    std::lock_guard<std::mutex> lock(g_streamMutex);
+    g_streams.emplace(handle, conn);
+  }
+
+  conn->websocket_->start();
+
+  if (!conn->waitForOpen(kConnectTimeout))
+  {
+    conn->reportError(conn->error().empty() ? std::string("connection timeout") : conn->error());
+    conn->websocket_->stop();
+    std::lock_guard<std::mutex> lock(g_streamMutex);
+    g_streams.erase(handle);
+    return 0;
+  }
+
   return handle;
 }
 
 int stream_send(int handle, const PCM_source_transfer_t *block)
 {
-  auto it = g_streams.find(handle);
-  if (it == g_streams.end() || !block || !block->samples) return 0;
+  if (!block || !block->samples)
+    return 0;
 
-  BlockData bd;
-  bd.meta = *block;
-  size_t n = (size_t)block->length * (size_t)block->nch;
-  bd.samples.assign(block->samples, block->samples + n);
-  bd.meta.samples = bd.samples.data();
+  auto conn = lookupConnection(handle);
+  if (!conn || conn->type() != StreamType::kWebSocket)
+    return 0;
 
+  if (!conn->isOpen())
+    return 0;
+
+  std::string payload;
+  std::string error;
+  if (!encodeBlock(block, payload, error))
   {
-    std::lock_guard<std::mutex> lock(it->second.mtx);
-    it->second.incoming.push(std::move(bd));
+    conn->reportError("encode error: " + error);
+    return 0;
   }
+
+  ix::WebSocketSendInfo info = conn->websocket_->sendBinary(payload);
+  if (!info.success)
+  {
+    conn->reportError("websocket send failed");
+    return 0;
+  }
+
   return 1;
 }
 
 int stream_receive(int handle, PCM_source_transfer_t *block)
 {
-  auto it = g_streams.find(handle);
-  if (it == g_streams.end() || !block || !block->samples) return 0;
-  std::lock_guard<std::mutex> lock(it->second.mtx);
-  if (it->second.incoming.empty()) return 0;
+  if (!block || !block->samples)
+    return 0;
 
-  BlockData bd = std::move(it->second.incoming.front());
-  it->second.incoming.pop();
+  auto conn = lookupConnection(handle);
+  if (!conn || conn->type() != StreamType::kWebSocket)
+    return 0;
 
-  size_t n = (size_t)bd.meta.length * (size_t)bd.meta.nch;
-  size_t requested = (size_t)block->length * (size_t)block->nch;
-  if (requested < n) n = requested;
-  std::memcpy(block->samples, bd.samples.data(), n * sizeof(ReaSample));
-  *block = bd.meta;
-  block->samples = block->samples; // keep caller buffer
-  block->samples_out = (int)(n / block->nch);
+  BlockData data;
+  if (!conn->pop(data))
+    return 0;
+
+  if (data.meta.nch <= 0)
+    return 0;
+
+  if (block->nch != data.meta.nch)
+  {
+    if (block->nch == 0)
+    {
+      block->nch = data.meta.nch;
+    }
+    else if (block->nch != data.meta.nch)
+    {
+      conn->reportError("channel count mismatch");
+      return 0;
+    }
+  }
+
+  const size_t availableSamples = data.samples.size();
+  if (availableSamples == 0)
+    return 0;
+
+  const size_t requestedSamples = static_cast<size_t>(block->length) * static_cast<size_t>(block->nch);
+  if (requestedSamples == 0)
+    return 0;
+
+  const size_t copySamples = std::min(availableSamples, requestedSamples);
+  std::memcpy(block->samples, data.samples.data(), copySamples * sizeof(ReaSample));
+
+  block->time_s = data.meta.time_s;
+  block->samplerate = data.meta.samplerate;
+  block->nch = data.meta.nch;
+  block->length = data.meta.length;
+  const int framesAvailable = data.meta.nch > 0 ? static_cast<int>(availableSamples / data.meta.nch) : 0;
+  const int framesCopied = data.meta.nch > 0 ? static_cast<int>(copySamples / data.meta.nch) : 0;
+  const int reportedFrames = data.meta.samples_out > 0 ? std::min(data.meta.samples_out, framesCopied) : framesCopied;
+  block->samples_out = reportedFrames;
+  block->midi_events = nullptr;
+  block->approximate_playback_latency = data.meta.approximate_playback_latency;
+  block->roundtrip_latency = data.meta.roundtrip_latency;
+  block->absolute_time_s = data.meta.absolute_time_s;
+  block->force_bpm = data.meta.force_bpm;
+
+  (void)framesAvailable;
+
   return block->samples_out;
 }

--- a/sdk/reaper_stream/reaper_stream.h
+++ b/sdk/reaper_stream/reaper_stream.h
@@ -1,14 +1,16 @@
 #ifndef REAPER_STREAM_H
 #define REAPER_STREAM_H
 
-#include "../reaper_plugin.h"
+#include "pcm_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Open a WebSocket or SRT stream. The URL scheme (ws://, wss://, srt://)
-// selects the transport. Returns a non-zero handle on success.
+// Open a streaming connection. The URL scheme selects the transport.
+// Currently supported schemes: ws:// (and wss:// when TLS support is
+// enabled at build time).
+// Returns a non-zero handle on success.
 int stream_open(const char *url);
 
 // Send an audio block over the stream. Returns non-zero on success.


### PR DESCRIPTION
## Summary
- add ixwebsocket via FetchContent and expose a reaper_stream static library
- replace the in-memory loopback with a real WebSocket client that frames PCM_source_transfer_t data and processes async callbacks
- document the new workflow, supply standalone PCM type definitions, and update the example plug-in to exercise send/receive behaviour

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68c9e64e40d4832c8c7cdd12cc3d2e91