### PR TITLE
Add stream cleanup helpers and tighten STT registration

### DIFF
--- a/sdk/example_stream/basic_stream.cpp
+++ b/sdk/example_stream/basic_stream.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <thread>
+#include <string>
 
 #define REAPERAPI_IMPLEMENT
 #define REAPERAPI_MINIMAL
@@ -51,7 +52,16 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE in
 
       if (!stream_send(handle, &block))
       {
-        ShowConsoleMsg("basic_stream: failed to send audio block.\n");
+        char error[256];
+        size_t written = stream_last_error(handle, error, sizeof(error));
+        std::string msg = "basic_stream: failed to send audio block";
+        if (written > 0 && error[0])
+        {
+          msg += ": ";
+          msg += error;
+        }
+        msg += "\n";
+        ShowConsoleMsg(msg.c_str());
       }
       else
       {
@@ -80,8 +90,22 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE in
         }
         else
         {
-          ShowConsoleMsg("basic_stream: no audio received before timeout.\n");
+          char error[256];
+          size_t written = stream_last_error(handle, error, sizeof(error));
+          std::string msg = "basic_stream: no audio received before timeout";
+          if (written > 0 && error[0])
+          {
+            msg += ": ";
+            msg += error;
+          }
+          msg += "\n";
+          ShowConsoleMsg(msg.c_str());
         }
+      }
+
+      if (!stream_close(handle))
+      {
+        ShowConsoleMsg("basic_stream: failed to close stream handle.\n");
       }
     }
     else

--- a/sdk/reaper_stream/reaper_stream.h
+++ b/sdk/reaper_stream/reaper_stream.h
@@ -2,6 +2,7 @@
 #define REAPER_STREAM_H
 
 #include "pcm_types.h"
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +21,17 @@ int stream_send(int handle, const PCM_source_transfer_t *block);
 // large enough to hold the requested number of samples. Returns the number of
 // sample pairs received.
 int stream_receive(int handle, PCM_source_transfer_t *block);
+
+// Close an open stream handle. Returns non-zero when the handle was valid and
+// has been released.
+int stream_close(int handle);
+
+// Copy the last error message associated with a handle into the supplied
+// buffer. The returned value is the length of the full error string (without
+// the terminating null). When the buffer is null or too small, the message is
+// truncated but the full length is still reported. Returns 0 when no error is
+// latched or the handle is invalid.
+size_t stream_last_error(int handle, char *buffer, size_t buffer_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- extend the reaper_stream API with explicit close/error helpers and update the documentation and example plug-in
- refactor the speech-to-text extension to register its exported APIs via a single rollback-safe helper

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68c9d8c9b5c0832c9671d8e7d0d167aa