### PR TITLE
Fix MusicXML pitch step closing tag

### DIFF
--- a/sdk/example_musicxml/musicxml_util.cpp
+++ b/sdk/example_musicxml/musicxml_util.cpp
@@ -51,7 +51,7 @@ static bool DoExportTrackMIDIToMusicXML(MediaTrack* tr, const char* fn)
                         const char* step = steps[pitch % 12];
                         int octave = pitch / 12 - 1;
                         std::fprintf(f, "      <note>\n");
-                        std::fprintf(f, "        <pitch><step>%c</step", step[0]);
+                        std::fprintf(f, "        <pitch><step>%c</step>", step[0]);
                         if (step[1] == '#') std::fprintf(f, "<alter>1</alter>");
                         std::fprintf(f, "<octave>%d</octave></pitch>\n", octave);
                         std::fprintf(f, "        <duration>1</duration>\n");


### PR DESCRIPTION
## Summary
- close the <step> tag properly when exporting MusicXML note pitches
- keep the conditional <alter> emission and ensure octave output remains valid

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68ca235e4ac0832ca258422e5afb7c8f