### PR TITLE
Fix drop-frame frame rate conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,22 @@ if(BUILD_TESTING AND ORPHEUS_ENABLE_TESTS)
 
   or_safe_add_test(track_playlist_test COMMAND track_playlist_test)
 
+  or_safe_add_executable(timecode_test
+    sdk/timecode.cpp
+    sdk/timecode_test.cpp)
+  target_link_libraries(timecode_test
+    PRIVATE
+      gmock_main
+      Threads::Threads
+  )
+  target_include_directories(timecode_test PRIVATE
+    ${googletest_SOURCE_DIR}/googletest/include
+    ${googletest_SOURCE_DIR}/googlemock/include
+  )
+  target_compile_features(timecode_test PRIVATE cxx_std_17)
+
+  or_safe_add_test(timecode_test COMMAND timecode_test)
+
   or_safe_add_executable(reaper_atmos_test reaper-plugins/reaper_atmos/reaper_atmos_test.cpp)
   target_link_libraries(reaper_atmos_test
     PRIVATE

--- a/sdk/timecode.cpp
+++ b/sdk/timecode.cpp
@@ -61,7 +61,7 @@ PTPv2Time ToPTP(const Frame &src) {
     out.seconds = static_cast<uint64_t>(src.hours) * 3600ULL +
                   static_cast<uint64_t>(src.minutes) * 60ULL +
                   static_cast<uint64_t>(src.seconds);
-    const double fps = static_cast<int>(src.rate);
+    const double fps = FramesPerSecond(src.rate);
     out.nanoseconds = static_cast<uint32_t>((src.frames / fps) * 1e9);
     return out;
 }
@@ -79,14 +79,14 @@ uint32_t ToST2110RTP(const PTPv2Time &src, uint32_t sampleRate) {
 }
 
 double ToSeconds(const Frame &tc) {
-    const double fps = static_cast<int>(tc.rate);
+    const double fps = FramesPerSecond(tc.rate);
     return tc.hours * 3600.0 + tc.minutes * 60.0 + tc.seconds + tc.frames / fps;
 }
 
 Frame FromSeconds(double seconds, FrameRate rate) {
     Frame out;
     out.rate = rate;
-    const double fps = static_cast<int>(rate);
+    const double fps = FramesPerSecond(rate);
     out.hours = static_cast<int>(seconds / 3600.0);
     seconds -= out.hours * 3600.0;
     out.minutes = static_cast<int>(seconds / 60.0);

--- a/sdk/timecode.h
+++ b/sdk/timecode.h
@@ -14,6 +14,23 @@ enum class FrameRate {
     FPS30_DROP = 29
 };
 
+inline constexpr double kFrameRate30Drop = 30000.0 / 1001.0;
+
+// Retrieve the true frames-per-second value for a frame rate.
+constexpr double FramesPerSecond(FrameRate rate) {
+    switch (rate) {
+        case FrameRate::FPS24:
+            return 24.0;
+        case FrameRate::FPS25:
+            return 25.0;
+        case FrameRate::FPS30:
+            return 30.0;
+        case FrameRate::FPS30_DROP:
+            return kFrameRate30Drop;
+    }
+    return 30.0;
+}
+
 // SMPTE timecode frame representation.
 struct Frame {
     int hours{0};

--- a/sdk/timecode_test.cpp
+++ b/sdk/timecode_test.cpp
@@ -1,0 +1,45 @@
+#include "timecode.h"
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace reaper {
+namespace timecode {
+
+TEST(TimecodeFrameRate, ProvidesTrueValues) {
+    EXPECT_DOUBLE_EQ(FramesPerSecond(FrameRate::FPS24), 24.0);
+    EXPECT_DOUBLE_EQ(FramesPerSecond(FrameRate::FPS25), 25.0);
+    EXPECT_DOUBLE_EQ(FramesPerSecond(FrameRate::FPS30), 30.0);
+    EXPECT_DOUBLE_EQ(FramesPerSecond(FrameRate::FPS30_DROP), kFrameRate30Drop);
+}
+
+TEST(TimecodeConversion, DropFrameToSecondsUsesTrueRate) {
+    Frame drop_frame{0, 0, 0, 15, FrameRate::FPS30_DROP};
+    const double expected = 15.0 / FramesPerSecond(FrameRate::FPS30_DROP);
+    EXPECT_NEAR(ToSeconds(drop_frame), expected, 1e-9);
+}
+
+TEST(TimecodeConversion, IntegerFrameRatesRemainUnchanged) {
+    Frame tc{0, 0, 0, 15, FrameRate::FPS30};
+    EXPECT_DOUBLE_EQ(ToSeconds(tc), 0.5);
+}
+
+TEST(TimecodeConversion, DropFrameRoundTripSeconds) {
+    const double seconds = 123.456;
+    Frame tc = FromSeconds(seconds, FrameRate::FPS30_DROP);
+    EXPECT_EQ(tc.rate, FrameRate::FPS30_DROP);
+    const double frame_duration = 1.0 / FramesPerSecond(FrameRate::FPS30_DROP);
+    EXPECT_LT(std::fabs(ToSeconds(tc) - seconds), frame_duration);
+}
+
+TEST(TimecodeConversion, DropFrameToPTPUsesTrueRate) {
+    Frame tc{0, 0, 0, 1, FrameRate::FPS30_DROP};
+    const auto ptp = ToPTP(tc);
+    EXPECT_EQ(ptp.seconds, 0u);
+    const uint32_t expected = static_cast<uint32_t>((1.0 / FramesPerSecond(FrameRate::FPS30_DROP)) * 1e9);
+    EXPECT_EQ(ptp.nanoseconds, expected);
+}
+
+}  // namespace timecode
+}  // namespace reaper


### PR DESCRIPTION
## Summary
- add a dedicated 30000/1001 constant for drop-frame timecode and expose a helper that returns each frame rate's true fps
- use the helper in timecode conversions so drop-frame math uses 29.97 fps while leaving integer rates unchanged
- register new unit tests that exercise drop-frame conversions and hook them into CMake

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68ca2366ad34832c82df78446b35d3a0