### PR TITLE
Fix zstd magic error reporting

### DIFF
--- a/apps/wordbird-web/src/runtime/packs.ts
+++ b/apps/wordbird-web/src/runtime/packs.ts
@@ -17,10 +17,8 @@ async function sha256(buffer: ArrayBuffer): Promise<string> {
 }
 
 function readMagic(bytes: Uint8Array): string {
-  return bytes
-    .slice(0, 4)
-    .map((value) => value.toString(16).padStart(2, '0'))
-    .join(' ');
+  const header = Array.from(bytes.slice(0, 4));
+  return header.map((value) => value.toString(16).padStart(2, '0')).join(' ');
 }
 
 function ensureZstdMagic(bytes: Uint8Array): void {
@@ -32,6 +30,13 @@ function ensureZstdMagic(bytes: Uint8Array): void {
     }
   }
 }
+
+/*
+Manual test snippet:
+const bad = new Uint8Array([0x00, 0x10, 0x20, 0x30, 0x40]);
+ensureZstdMagic(bad);
+// throws "Error: pack payload invalid (no zstd magic; got 00 10 20 30)"
+*/
 
 export interface BootstrapOutcome {
   catalogUrl: string;


### PR DESCRIPTION
## Summary
- convert the zstd header reader to operate on a plain array before formatting bytes
- ensure the thrown error exposes the exact header bytes and document a manual test snippet

## Testing
- node <<'NODE'
function readMagic(bytes) {
  const header = Array.from(bytes.slice(0, 4));
  return header.map((value) => value.toString(16).padStart(2, '0')).join(' ');
}
function ensureZstdMagic(bytes) {
  const MAGIC = [0x28, 0xb5, 0x2f, 0xfd];
  for (let i = 0; i < MAGIC.length; i += 1) {
    if (bytes[i] !== MAGIC[i]) {
      const magic = readMagic(bytes);
      throw new Error(`pack payload invalid (no zstd magic; got ${magic})`);
    }
  }
}
const bad = new Uint8Array([0x00, 0x10, 0x20, 0x30, 0x40]);
try {
  ensureZstdMagic(bad);
} catch (error) {
  console.log(error.message);
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d7292cd43c832cace684dd215d9235