### PR TITLE
core: enforce session invariants and deterministic IO

### DIFF
--- a/adapters/minhost/main.cpp
+++ b/adapters/minhost/main.cpp
@@ -248,11 +248,14 @@ int main(int argc, char **argv) {
             << session_graph.tracks().size() << " track(s) and " << clip_count
             << " clip(s)" << std::endl;
 
+  constexpr std::uint32_t kClickSampleRate = 44100;
+  constexpr std::uint32_t kClickBitDepth = 16;
+
   if (options.render_path) {
     orpheus_render_click_spec spec{};
     spec.tempo_bpm = tempo;
     spec.bars = options.bars;
-    spec.sample_rate = 44100;
+    spec.sample_rate = kClickSampleRate;
     spec.channels = 2;
     spec.gain = 0.3;
     spec.click_frequency_hz = 1000.0;
@@ -267,7 +270,7 @@ int main(int argc, char **argv) {
   } else {
     RunTransportSimulation(state.tempo_bpm, std::chrono::seconds(5));
     const std::string suggested = session_json::MakeRenderClickFilename(
-        session_graph.name(), tempo, options.bars);
+        session_graph.name(), "click", kClickSampleRate, kClickBitDepth);
     std::cout << "Suggested render path: " << suggested << std::endl;
   }
 

--- a/src/core/session/json_io.h
+++ b/src/core/session/json_io.h
@@ -18,7 +18,8 @@ ORPHEUS_API void SaveSessionToFile(const SessionGraph &session,
                                    const std::string &path);
 
 ORPHEUS_API std::string MakeRenderClickFilename(const std::string &session_name,
-                                                double tempo_bpm,
-                                                std::uint32_t bars);
+                                                const std::string &stem_name,
+                                                std::uint32_t sample_rate_hz,
+                                                std::uint32_t bit_depth_bits);
 
 }  // namespace orpheus::core::session_json

--- a/src/core/session/session_graph.h
+++ b/src/core/session/session_graph.h
@@ -122,6 +122,7 @@ class ORPHEUS_API SessionGraph {
  private:
   Track *find_track(const Track *track);
   Clip *find_clip(const Clip *clip);
+  void mark_clip_grid_dirty() { clip_grid_dirty_ = true; }
 
   double tempo_bpm_{120.0};
   double transport_position_beats_{0.0};
@@ -130,6 +131,7 @@ class ORPHEUS_API SessionGraph {
   double session_start_beats_{0.0};
   double session_end_beats_{0.0};
   std::vector<std::unique_ptr<Track>> tracks_;
+  bool clip_grid_dirty_{false};
 };
 
 }  // namespace orpheus::core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(orpheus_tests
   abi_smoke.cpp
   session_graph_ownership.cpp
+  session_graph_invariants.cpp
   session_roundtrip.cpp
 )
 

--- a/tests/session_graph_invariants.cpp
+++ b/tests/session_graph_invariants.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+#include "session/session_graph.h"
+
+#include <gtest/gtest.h>
+
+namespace orpheus::core::tests {
+namespace {
+
+double ClipEnd(const Clip &clip) { return clip.start() + clip.length(); }
+
+}  // namespace
+
+TEST(SessionGraphInvariants, CommitSortsTracksAndClipsAndUpdatesRange) {
+  SessionGraph session;
+  Track *second = session.add_track("Beta");
+  Track *first = session.add_track("Alpha");
+
+  ASSERT_NE(second, nullptr);
+  ASSERT_NE(first, nullptr);
+
+  Clip *late = session.add_clip(*second, "zzz", 8.0, 2.0);
+  Clip *early = session.add_clip(*second, "aaa", 2.0, 1.0);
+  Clip *tied = session.add_clip(*second, "mmm", 2.0, 0.5);
+  ASSERT_NE(late, nullptr);
+  ASSERT_NE(early, nullptr);
+  ASSERT_NE(tied, nullptr);
+
+  session.commit_clip_grid();
+
+  const auto &tracks = session.tracks();
+  ASSERT_EQ(tracks.size(), 2u);
+  EXPECT_EQ(tracks[0]->name(), "Alpha");
+  EXPECT_EQ(tracks[1]->name(), "Beta");
+
+  const auto &clips = tracks[1]->clips();
+  ASSERT_EQ(clips.size(), 3u);
+  EXPECT_EQ(clips[0]->name(), "aaa");
+  EXPECT_EQ(clips[1]->name(), "mmm");
+  EXPECT_EQ(clips[2]->name(), "zzz");
+
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 2.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), ClipEnd(*late));
+}
+
+TEST(SessionGraphInvariants, CommitResetsRangeWhenEmpty) {
+  SessionGraph session;
+  Track *track = session.add_track("Track");
+  ASSERT_NE(track, nullptr);
+
+  Clip *clip = session.add_clip(*track, "short", 1.0, 1.5);
+  ASSERT_NE(clip, nullptr);
+
+  session.commit_clip_grid();
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 1.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), ClipEnd(*clip));
+
+  EXPECT_TRUE(session.remove_clip(clip));
+  session.commit_clip_grid();
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 0.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), 0.0);
+}
+
+TEST(SessionGraphInvariants, ClipLengthIsClampedToMinimum) {
+  SessionGraph session;
+  Track *track = session.add_track("Track");
+  ASSERT_NE(track, nullptr);
+
+  Clip *clip = session.add_clip(*track, "Clip", 0.0, 0.0);
+  ASSERT_NE(clip, nullptr);
+  EXPECT_GT(clip->length(), 0.0);
+
+  session.set_clip_length(*clip, -10.0);
+  EXPECT_GT(clip->length(), 0.0);
+}
+
+}  // namespace orpheus::core::tests

--- a/tools/fixtures/loop_grid.json
+++ b/tools/fixtures/loop_grid.json
@@ -2,8 +2,23 @@
   "name": "Loop Grid",
   "tempo_bpm": 128,
   "start_beats": 0,
-  "end_beats": 64,
+  "end_beats": 36,
   "tracks": [
+    {
+      "name": "FX",
+      "clips": [
+        {
+          "name": "impact",
+          "start_beats": 0,
+          "length_beats": 4
+        },
+        {
+          "name": "sweep",
+          "start_beats": 28,
+          "length_beats": 8
+        }
+      ]
+    },
     {
       "name": "Synth",
       "clips": [
@@ -21,21 +36,6 @@
           "name": "riff_c",
           "start_beats": 16,
           "length_beats": 16
-        }
-      ]
-    },
-    {
-      "name": "FX",
-      "clips": [
-        {
-          "name": "impact",
-          "start_beats": 0,
-          "length_beats": 4
-        },
-        {
-          "name": "sweep",
-          "start_beats": 28,
-          "length_beats": 8
         }
       ]
     }

--- a/tools/fixtures/two_tracks.json
+++ b/tools/fixtures/two_tracks.json
@@ -5,6 +5,16 @@
   "end_beats": 32,
   "tracks": [
     {
+      "name": "Bass",
+      "clips": [
+        {
+          "name": "verse",
+          "start_beats": 8,
+          "length_beats": 16
+        }
+      ]
+    },
+    {
       "name": "Drums",
       "clips": [
         {
@@ -16,16 +26,6 @@
           "name": "fill",
           "start_beats": 24,
           "length_beats": 8
-        }
-      ]
-    },
-    {
-      "name": "Bass",
-      "clips": [
-        {
-          "name": "verse",
-          "start_beats": 8,
-          "length_beats": 16
         }
       ]
     }


### PR DESCRIPTION
## Summary
- clamp clip lengths, track session range, and sort tracks/clips when committing the session graph
- ensure session JSON round-trips byte-for-byte via updated golden fixtures and new invariants tests
- switch render click filenames to {project}_{stem}_{sr}k_{bd}b and update consumers/tests

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d74c6d4c68832c98562dbea4d9a9b8