### PR TITLE
host(demo): add JUCE-based Orpheus demo host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(ORP_WITH_TESTS "Build Orpheus tests" ON)
 option(ORPHEUS_ENABLE_ADAPTERS "Build Orpheus host adapters" ON)
 option(ORPHEUS_ENABLE_ADAPTER_MINHOST "Build the minimal host adapter" ON)
 option(ORPHEUS_ENABLE_ADAPTER_REAPER "Build the REAPER adapter" OFF)
+option(ORPHEUS_ENABLE_APP_JUCE_HOST "Build the Orpheus JUCE demo host" OFF)
 option(ENABLE_LTO "Enable interprocedural optimization" OFF)
 option(ORP_BUILD_SHARED_CORE "Build Orpheus ABI libraries as shared" OFF)
 option(ORP_BUILD_ABI_DYNAMIC "Build shared core libs for abi_link test" ON)
@@ -91,6 +92,10 @@ endif()
 
 if(ORPHEUS_ENABLE_ADAPTER_MINHOST)
   add_subdirectory(adapters/minhost)
+endif()
+
+if(ORPHEUS_ENABLE_APP_JUCE_HOST)
+  add_subdirectory(apps/juce-demo-host)
 endif()
 
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ ctest --test-dir build --output-on-failure
 
 By default the build produces the Orpheus core libraries, the reference
 `orpheus_minhost` adapter, and the GoogleTest suite. Host-specific adapters
-are opt-in.
+and demo applications are opt-in.
+
+### Standalone Demo Host
+
+To compile the JUCE-based demonstration host, enable the dedicated CMake flag:
+
+```sh
+cmake -S . -B build -DORPHEUS_ENABLE_APP_JUCE_HOST=ON
+cmake --build build --target orpheus_demo_host_app
+```
+
+`OrpheusDemoHost` dynamically loads the Orpheus ABI shared libraries at
+runtime. The menu flow mirrors the demo brief: **File → Open Session…** loads a
+session JSON, **Session → Trigger ClipGrid Scene** negotiates the clip grid,
+and **Session → Render WAV Stems…** writes the rendered stems to disk. The app
+shows the active session summary and requires no DAW or plug-in.
+The executable is produced as `OrpheusDemoHost` (with the usual platform
+extension) inside your build directory.
 
 ### Rendering a Click Track
 
@@ -53,6 +70,7 @@ hosts and build flags.
 
 ```
 ├── adapters/        # Host integrations (minhost CLI, optional REAPER shim)
+├── apps/            # Standalone demo hosts (JUCE demo)
 ├── cmake/           # Helper modules (warnings + third-party deps)
 ├── include/         # Public headers for the Orpheus core library
 ├── src/             # Core library implementation

--- a/apps/juce-demo-host/CMakeLists.txt
+++ b/apps/juce-demo-host/CMakeLists.txt
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+cmake_minimum_required(VERSION 3.22)
+
+project(orpheus_demo_host LANGUAGES CXX)
+
+include(FetchContent)
+
+if(NOT TARGET juce::juce_gui_basics)
+  FetchContent_Declare(
+    juce
+    GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+    GIT_TAG 7.0.9
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_MakeAvailable(juce)
+endif()
+
+juce_add_gui_app(orpheus_demo_host_app
+  PRODUCT_NAME "Orpheus Demo Host"
+  VERSION 0.1.0
+  COMPANY_NAME "Orpheus"
+  BUNDLE_ID "com.orpheus.demo.host"
+  NEEDS_CURL FALSE
+  NEEDS_WEB_BROWSER FALSE
+)
+
+set(ORPHEUS_DEMO_HOST_SOURCES
+  Source/Main.cpp
+  ${CMAKE_SOURCE_DIR}/src/core/session/session_graph.cpp
+  ${CMAKE_SOURCE_DIR}/src/core/session/json_io.cpp
+)
+
+target_sources(orpheus_demo_host_app PRIVATE ${ORPHEUS_DEMO_HOST_SOURCES})
+
+target_compile_features(orpheus_demo_host_app PRIVATE cxx_std_20)
+
+target_include_directories(orpheus_demo_host_app
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core/session
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_compile_definitions(orpheus_demo_host_app
+  PRIVATE
+    JUCE_MODAL_LOOPS_PERMITTED=1
+    JUCE_DISABLE_JUCE_VERSION_PRINTING=1
+)
+
+target_link_libraries(orpheus_demo_host_app
+  PRIVATE
+    juce::juce_gui_extra
+    juce::juce_audio_utils
+)
+
+set_target_properties(orpheus_demo_host_app PROPERTIES
+  OUTPUT_NAME "OrpheusDemoHost"
+)

--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -1,0 +1,768 @@
+// SPDX-License-Identifier: MIT
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <juce_audio_utils/juce_audio_utils.h>
+
+#include "orpheus/abi.h"
+#include "json_io.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if JUCE_WINDOWS
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace fs = std::filesystem;
+using orpheus::core::SessionGraph;
+namespace session_json = orpheus::core::session_json;
+
+namespace {
+
+juce::String StatusToString(orpheus_status status)
+{
+    switch (status)
+    {
+        case ORPHEUS_STATUS_OK: return "ok";
+        case ORPHEUS_STATUS_INVALID_ARGUMENT: return "invalid argument";
+        case ORPHEUS_STATUS_NOT_FOUND: return "not found";
+        case ORPHEUS_STATUS_OUT_OF_MEMORY: return "out of memory";
+        case ORPHEUS_STATUS_INTERNAL_ERROR: return "internal error";
+        case ORPHEUS_STATUS_NOT_IMPLEMENTED: return "not implemented";
+        case ORPHEUS_STATUS_IO_ERROR: return "io error";
+    }
+    return "unknown";
+}
+
+fs::path ExecutableDirectory()
+{
+    const auto execFile = juce::File::getSpecialLocation(juce::File::currentExecutableFile);
+    return execFile.getParentDirectory().getFullPathName().toStdString();
+}
+
+#if JUCE_WINDOWS
+using ModuleHandle = HMODULE;
+ModuleHandle LoadModule(const fs::path& path, juce::String& error)
+{
+    juce::String pathString(path.string());
+    ModuleHandle handle = ::LoadLibraryW((LPCWSTR)pathString.toWideCharPointer());
+    if (handle == nullptr)
+    {
+        const juce::String message = DescribeLoaderError();
+        error = juce::String("LoadLibrary failed for ") + pathString +
+                (message.isNotEmpty() ? juce::String(": ") + message : juce::String());
+    }
+    return handle;
+}
+void UnloadModule(ModuleHandle handle)
+{
+    if (handle != nullptr)
+        ::FreeLibrary(handle);
+}
+void* LoadSymbol(ModuleHandle handle, const char* name)
+{
+    return reinterpret_cast<void*>(::GetProcAddress(handle, name));
+}
+#else
+using ModuleHandle = void*;
+ModuleHandle LoadModule(const fs::path& path, juce::String& error)
+{
+    ModuleHandle handle = ::dlopen(path.c_str(), RTLD_NOW);
+    if (handle == nullptr)
+        error = juce::String("dlopen failed: ") + juce::String(::dlerror());
+    return handle;
+}
+void UnloadModule(ModuleHandle handle)
+{
+    if (handle != nullptr)
+        ::dlclose(handle);
+}
+void* LoadSymbol(ModuleHandle handle, const char* name)
+{
+    ::dlerror();
+    return ::dlsym(handle, name);
+}
+#endif
+
+juce::String PlatformLibraryName(const juce::String& stem)
+{
+#if JUCE_WINDOWS
+    return stem + ".dll";
+#elif JUCE_MAC
+    return "lib" + stem + ".dylib";
+#else
+    return "lib" + stem + ".so";
+#endif
+}
+
+struct ModuleEntry
+{
+    juce::String stem;
+    const char* entryPoint;
+};
+
+constexpr ModuleEntry kModules[] = {
+    { "orpheus_session", "orpheus_session_abi_v1" },
+    { "orpheus_clipgrid", "orpheus_clipgrid_abi_v1" },
+    { "orpheus_render", "orpheus_render_abi_v1" },
+};
+
+juce::String DescribeLoaderError()
+{
+#if JUCE_WINDOWS
+    const DWORD err = ::GetLastError();
+    if (err == 0)
+        return {};
+    LPWSTR buffer = nullptr;
+    const DWORD length = ::FormatMessageW(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
+    juce::String message;
+    if (length != 0 && buffer != nullptr)
+    {
+        message = juce::String(buffer).trim();
+        ::LocalFree(buffer);
+    }
+    else
+    {
+        message = juce::String((int)err);
+    }
+    return message;
+#else
+    if (const char* msg = ::dlerror())
+        return juce::String(msg);
+    return {};
+#endif
+}
+
+} // namespace
+
+class OrpheusModuleLoader
+{
+public:
+    struct Tables
+    {
+        const orpheus_session_api_v1* session{};
+        const orpheus_clipgrid_api_v1* clipgrid{};
+        const orpheus_render_api_v1* render{};
+    };
+
+    ~OrpheusModuleLoader() { unload(); }
+
+    bool ensureLoaded(juce::String& error)
+    {
+        if (tables_.session != nullptr && tables_.clipgrid != nullptr && tables_.render != nullptr)
+            return true;
+
+        if (const char* overrideDir = std::getenv("ORPHEUS_DEMO_HOST_LIBDIR"))
+        {
+            if (overrideDir[0] != '\0')
+            {
+                const fs::path overridePath(overrideDir);
+                if (loadFrom(overridePath, error))
+                    return true;
+                error = juce::String("Failed to load Orpheus modules from override directory: ") +
+                        overridePath.string() + "\n" + error;
+                return false;
+            }
+        }
+
+        const fs::path execDir = ExecutableDirectory();
+        juce::String directError;
+        if (loadFrom(execDir, directError))
+            return true;
+
+        const fs::path parentDir = execDir.parent_path();
+        if (!parentDir.empty())
+        {
+            const fs::path libDir = parentDir / "lib";
+            if (libDir != execDir)
+            {
+                juce::String fallbackError;
+                if (loadFrom(libDir, fallbackError))
+                    return true;
+                error = juce::String("Failed to load Orpheus modules from ") + execDir.string() +
+                        "\n" + directError + "\nFallback to " + libDir.string() + " failed:\n" +
+                        fallbackError;
+                return false;
+            }
+        }
+
+        error = juce::String("Failed to load Orpheus modules from ") + execDir.string() +
+                "\n" + directError;
+        return false;
+    }
+
+    bool loadFrom(const fs::path& directory, juce::String& error)
+    {
+        unload();
+
+        for (const auto& module : kModules)
+        {
+            ModuleHandle handle{};
+            const auto fileName = PlatformLibraryName(module.stem);
+            const auto modulePath = directory / fileName.toStdString();
+            juce::String moduleError;
+            handle = LoadModule(modulePath, moduleError);
+            if (handle == nullptr)
+            {
+                error = juce::String("Unable to load ") + modulePath.string();
+                if (moduleError.isNotEmpty())
+                    error += ": " + moduleError;
+                unload();
+                return false;
+            }
+
+            modules_.push_back(handle);
+
+            auto* symbol = LoadSymbol(handle, module.entryPoint);
+            if (symbol == nullptr)
+            {
+                const juce::String symbolError = DescribeLoaderError();
+                error = juce::String("Missing entry point ") + module.entryPoint +
+                        (symbolError.isNotEmpty() ? juce::String(": ") + symbolError : juce::String());
+                unload();
+                return false;
+            }
+
+            if (module.stem == "orpheus_session")
+            {
+                auto fn = reinterpret_cast<const orpheus_session_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
+                uint32_t major{};
+                uint32_t minor{};
+                tables_.session = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+                if (tables_.session == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                {
+                    error = "Session ABI negotiation failed";
+                    unload();
+                    return false;
+                }
+            }
+            else if (module.stem == "orpheus_clipgrid")
+            {
+                auto fn = reinterpret_cast<const orpheus_clipgrid_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
+                uint32_t major{};
+                uint32_t minor{};
+                tables_.clipgrid = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+                if (tables_.clipgrid == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                {
+                    error = "ClipGrid ABI negotiation failed";
+                    unload();
+                    return false;
+                }
+            }
+            else if (module.stem == "orpheus_render")
+            {
+                auto fn = reinterpret_cast<const orpheus_render_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
+                uint32_t major{};
+                uint32_t minor{};
+                tables_.render = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+                if (tables_.render == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                {
+                    error = "Render ABI negotiation failed";
+                    unload();
+                    return false;
+                }
+            }
+        }
+
+        return tables_.session != nullptr && tables_.clipgrid != nullptr && tables_.render != nullptr;
+    }
+
+    void unload()
+    {
+        tables_ = {};
+        for (auto handle : modules_)
+            UnloadModule(handle);
+        modules_.clear();
+    }
+
+    [[nodiscard]] const Tables& tables() const noexcept { return tables_; }
+
+private:
+    Tables tables_{};
+    std::vector<ModuleHandle> modules_{};
+};
+
+class OrpheusSessionController
+{
+public:
+    struct Snapshot
+    {
+        juce::String sessionName;
+        juce::String sourcePath;
+        std::size_t trackCount{};
+        std::size_t clipCount{};
+        double tempoBpm{};
+        double rangeStart{};
+        double rangeEnd{};
+        bool clipgridCommitted{};
+        juce::String lastRenderDirectory;
+    };
+
+    explicit OrpheusSessionController(OrpheusModuleLoader& loader) : loader_(loader) {}
+    ~OrpheusSessionController() { reset(); }
+
+    bool openSession(const juce::File& file, juce::String& error)
+    {
+        if (!loader_.ensureLoaded(error))
+            return false;
+
+        SessionGraph parsed;
+        try
+        {
+            parsed = session_json::LoadSessionFromFile(file.getFullPathName().toStdString());
+        }
+        catch (const std::exception& ex)
+        {
+            error = juce::String("Session load failed: ") + ex.what();
+            return false;
+        }
+
+        const auto* sessionApi = loader_.tables().session;
+        const auto* clipgridApi = loader_.tables().clipgrid;
+        if (sessionApi == nullptr || clipgridApi == nullptr)
+        {
+            error = "ABI tables unavailable";
+            return false;
+        }
+
+        struct HandleGuard
+        {
+            const orpheus_session_api_v1* api{};
+            orpheus_session_handle handle{};
+            ~HandleGuard()
+            {
+                if (api != nullptr && handle != nullptr)
+                    api->destroy(handle);
+            }
+        } guard{ sessionApi, nullptr };
+
+        auto status = sessionApi->create(&guard.handle);
+        if (status != ORPHEUS_STATUS_OK)
+        {
+            error = juce::String("Session create failed: ") + StatusToString(status);
+            return false;
+        }
+
+        auto* sessionImpl = reinterpret_cast<SessionGraph*>(guard.handle);
+        sessionImpl->set_name(parsed.name());
+        sessionImpl->set_render_sample_rate(parsed.render_sample_rate());
+        sessionImpl->set_render_bit_depth(parsed.render_bit_depth());
+        sessionImpl->set_render_dither(parsed.render_dither());
+        sessionImpl->set_session_range(parsed.session_start_beats(), parsed.session_end_beats());
+
+        status = sessionApi->set_tempo(guard.handle, parsed.tempo());
+        if (status != ORPHEUS_STATUS_OK)
+        {
+            error = juce::String("Tempo apply failed: ") + StatusToString(status);
+            return false;
+        }
+
+        std::vector<TrackState> newTracks;
+        std::size_t newClipCount = 0;
+        newTracks.reserve(parsed.tracks().size());
+
+        for (const auto& trackPtr : parsed.tracks())
+        {
+            orpheus_track_handle trackHandle{};
+            const orpheus_track_desc trackDesc{ trackPtr->name().c_str() };
+            status = sessionApi->add_track(guard.handle, &trackDesc, &trackHandle);
+            if (status != ORPHEUS_STATUS_OK)
+            {
+                error = juce::String("Track add failed: ") + StatusToString(status);
+                return false;
+            }
+
+            TrackState trackState;
+            trackState.handle = trackHandle;
+            for (const auto& clipPtr : trackPtr->clips())
+            {
+                const orpheus_clip_desc clipDesc{ clipPtr->name().c_str(), clipPtr->start(), clipPtr->length() };
+                orpheus_clip_handle clipHandle{};
+                status = clipgridApi->add_clip(guard.handle, trackHandle, &clipDesc, &clipHandle);
+                if (status != ORPHEUS_STATUS_OK)
+                {
+                    error = juce::String("Clip add failed: ") + StatusToString(status);
+                    return false;
+                }
+                trackState.clips.push_back(clipHandle);
+                ++newClipCount;
+            }
+            newTracks.push_back(std::move(trackState));
+        }
+
+        reset();
+
+        graph_ = std::move(parsed);
+        sessionHandle_ = guard.handle;
+        guard.handle = nullptr;
+        tracks_ = std::move(newTracks);
+        clipCount_ = newClipCount;
+        sourcePath_ = file.getFullPathName();
+        clipgridCommitted_ = false;
+        lastRenderDirectory_.clear();
+
+        return true;
+    }
+
+    bool triggerClipgrid(juce::String& error)
+    {
+        if (sessionHandle_ == nullptr)
+        {
+            error = "Load a session first";
+            return false;
+        }
+        if (clipgridCommitted_)
+            return true;
+
+        const auto* clipgridApi = loader_.tables().clipgrid;
+        if (clipgridApi == nullptr)
+        {
+            error = "ClipGrid ABI unavailable";
+            return false;
+        }
+
+        const auto status = clipgridApi->commit(sessionHandle_);
+        if (status != ORPHEUS_STATUS_OK)
+        {
+            error = juce::String("ClipGrid commit failed: ") + StatusToString(status);
+            return false;
+        }
+
+        clipgridCommitted_ = true;
+        return true;
+    }
+
+    bool renderToDirectory(const juce::File& directory, juce::String& error)
+    {
+        if (sessionHandle_ == nullptr)
+        {
+            error = "Load a session first";
+            return false;
+        }
+        if (!clipgridCommitted_)
+        {
+            error = "Trigger the ClipGrid scene before rendering";
+            return false;
+        }
+
+        const auto* renderApi = loader_.tables().render;
+        if (renderApi == nullptr)
+        {
+            error = "Render ABI unavailable";
+            return false;
+        }
+
+        if (!directory.exists())
+            directory.createDirectory();
+
+        const std::string directoryPath = directory.getFullPathName().toStdString();
+        const auto status = renderApi->render_tracks(sessionHandle_, directoryPath.c_str());
+        if (status != ORPHEUS_STATUS_OK)
+        {
+            error = juce::String("Render failed: ") + StatusToString(status);
+            return false;
+        }
+
+        lastRenderDirectory_ = directory.getFullPathName();
+        return true;
+    }
+
+    [[nodiscard]] bool hasSession() const noexcept { return sessionHandle_ != nullptr; }
+    [[nodiscard]] bool clipgridCommitted() const noexcept { return clipgridCommitted_; }
+
+    Snapshot snapshot() const
+    {
+        Snapshot snap{};
+        snap.sessionName = graph_.name();
+        snap.sourcePath = sourcePath_;
+        snap.trackCount = graph_.tracks().size();
+        snap.clipCount = clipCount_;
+        snap.tempoBpm = graph_.tempo();
+        snap.rangeStart = graph_.session_start_beats();
+        snap.rangeEnd = graph_.session_end_beats();
+        snap.clipgridCommitted = clipgridCommitted_;
+        snap.lastRenderDirectory = lastRenderDirectory_;
+        return snap;
+    }
+
+private:
+    struct TrackState
+    {
+        orpheus_track_handle handle{};
+        std::vector<orpheus_clip_handle> clips;
+    };
+
+    void reset()
+    {
+        if (sessionHandle_ != nullptr)
+        {
+            if (const auto* sessionApi = loader_.tables().session)
+                sessionApi->destroy(sessionHandle_);
+        }
+        sessionHandle_ = nullptr;
+        tracks_.clear();
+        clipCount_ = 0;
+        graph_ = SessionGraph{};
+        sourcePath_.clear();
+        clipgridCommitted_ = false;
+        lastRenderDirectory_.clear();
+    }
+
+    OrpheusModuleLoader& loader_;
+    SessionGraph graph_{};
+    std::vector<TrackState> tracks_{};
+    std::size_t clipCount_{};
+    orpheus_session_handle sessionHandle_{};
+    juce::String sourcePath_;
+    bool clipgridCommitted_{};
+    juce::String lastRenderDirectory_;
+};
+
+class MainComponent : public juce::Component
+{
+public:
+    MainComponent()
+    {
+        addAndMakeVisible(header_);
+        header_.setText("Orpheus Demo Host", juce::dontSendNotification);
+        header_.setFont({ 24.0f, juce::Font::bold });
+
+        addAndMakeVisible(disclaimer_);
+        disclaimer_.setJustificationType(juce::Justification::centredLeft);
+        disclaimer_.setColour(juce::Label::textColourId, juce::Colours::orange);
+        disclaimer_.setText("Evaluation build – renders synthetic stems only.", juce::dontSendNotification);
+
+        addAndMakeVisible(statusBox_);
+        statusBox_.setReadOnly(true);
+        statusBox_.setMultiLine(true);
+        statusBox_.setColour(juce::TextEditor::backgroundColourId, juce::Colours::black);
+        statusBox_.setColour(juce::TextEditor::textColourId, juce::Colours::lightgreen);
+        statusBox_.setFont({ 14.0f });
+        statusBox_.setText(initialInstructions(), juce::dontSendNotification);
+
+        audioDeviceManager_.initialise(0, 2, nullptr, true);
+    }
+
+    void updateSnapshot(const OrpheusSessionController::Snapshot& snapshot)
+    {
+        std::ostringstream stream;
+        stream << "Session: " << snapshot.sessionName << '\n';
+        stream << "Source: " << snapshot.sourcePath << '\n';
+        stream << "Tempo: " << std::fixed << std::setprecision(2) << snapshot.tempoBpm << " BPM\n";
+        stream << "Tracks: " << snapshot.trackCount << "\n";
+        stream << "Clips: " << snapshot.clipCount << "\n";
+        stream << "Range: " << snapshot.rangeStart << " → " << snapshot.rangeEnd << " beats\n";
+        stream << "ClipGrid committed: " << (snapshot.clipgridCommitted ? "yes" : "no") << "\n";
+        if (snapshot.lastRenderDirectory.isNotEmpty())
+            stream << "Last render: " << snapshot.lastRenderDirectory << '\n';
+        statusBox_.setText(stream.str());
+    }
+
+    void resized() override
+    {
+        auto area = getLocalBounds().reduced(16);
+        header_.setBounds(area.removeFromTop(40));
+        disclaimer_.setBounds(area.removeFromTop(24));
+        statusBox_.setBounds(area);
+    }
+
+private:
+    static juce::String initialInstructions()
+    {
+        juce::String text;
+        text << "Open an Orpheus session JSON via File → Open Session.\n";
+        text << "Then use Session → Trigger ClipGrid Scene before rendering.\n";
+        text << "Session → Render WAV writes synthetic stems into a directory.\n";
+        text << "No DAW or plug-ins are required for this demonstration.";
+        return text;
+    }
+
+    juce::Label header_;
+    juce::Label disclaimer_;
+    juce::TextEditor statusBox_;
+    juce::AudioDeviceManager audioDeviceManager_;
+};
+
+class MainWindow : public juce::DocumentWindow, public juce::MenuBarModel
+{
+public:
+    MainWindow() : juce::DocumentWindow("Orpheus Demo Host", juce::Colours::darkgrey, DocumentWindow::allButtons)
+    {
+        setUsingNativeTitleBar(true);
+        setResizable(true, false);
+        setContentOwned(new MainComponent(), true);
+        setMenuBar(this);
+        centreWithSize(640, 420);
+        setVisible(true);
+    }
+
+    ~MainWindow() override
+    {
+        setMenuBar(nullptr);
+    }
+
+    void closeButtonPressed() override
+    {
+        juce::JUCEApplication::getInstance()->systemRequestedQuit();
+    }
+
+    juce::StringArray getMenuBarNames() override
+    {
+        return { "File", "Session", "Help" };
+    }
+
+    juce::PopupMenu getMenuForIndex(int topLevelMenuIndex, const juce::String& menuName) override
+    {
+        juce::PopupMenu menu;
+        if (menuName == "File")
+        {
+            menu.addItem(CommandIDs::openSession, "Open Session...");
+            menu.addSeparator();
+            menu.addItem(CommandIDs::quit, "Quit");
+        }
+        else if (menuName == "Session")
+        {
+            menu.addItem(CommandIDs::triggerClipgrid, "Trigger ClipGrid Scene", controller_.hasSession(), controller_.hasSession() && !controller_.clipgridCommitted());
+            menu.addItem(CommandIDs::renderSession, "Render WAV Stems…", controller_.clipgridCommitted());
+        }
+        else if (menuName == "Help")
+        {
+            menu.addItem(CommandIDs::about, "About Orpheus Demo Host");
+        }
+        return menu;
+    }
+
+    void menuItemSelected(int menuItemID, int /*topLevelMenuIndex*/) override
+    {
+        switch (menuItemID)
+        {
+            case CommandIDs::openSession:
+                handleOpenSession();
+                break;
+            case CommandIDs::triggerClipgrid:
+                handleTriggerClipgrid();
+                break;
+            case CommandIDs::renderSession:
+                handleRender();
+                break;
+            case CommandIDs::quit:
+                closeButtonPressed();
+                break;
+            case CommandIDs::about:
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon,
+                                                        "About Orpheus Demo Host",
+                                                        "A minimal, unbranded host demonstrating the Orpheus SDK."\
+                                                        "\n\nOpen a session, trigger the ClipGrid, then render synthetic stems to disk.");
+                break;
+            default:
+                break;
+        }
+    }
+
+private:
+    enum CommandIDs
+    {
+        openSession = 1,
+        triggerClipgrid,
+        renderSession,
+        quit,
+        about
+    };
+
+    MainComponent& mainComponent()
+    {
+        return *static_cast<MainComponent*>(getContentComponent());
+    }
+
+    void handleOpenSession()
+    {
+        juce::FileChooser chooser("Open Orpheus Session", juce::File(), "*.json;*.orp;*.*");
+        if (!chooser.browseForFileToOpen())
+            return;
+
+        juce::String error;
+        if (!controller_.openSession(chooser.getResult(), error))
+        {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Session Load", error);
+            return;
+        }
+
+        mainComponent().updateSnapshot(controller_.snapshot());
+        menuItemsChanged();
+    }
+
+    void handleTriggerClipgrid()
+    {
+        juce::String error;
+        if (!controller_.triggerClipgrid(error))
+        {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "ClipGrid", error);
+            return;
+        }
+
+        mainComponent().updateSnapshot(controller_.snapshot());
+        menuItemsChanged();
+    }
+
+    void handleRender()
+    {
+        juce::FileChooser chooser("Render stems to directory", juce::File(), "*");
+        if (!chooser.browseForDirectory())
+            return;
+
+        juce::String error;
+        if (!controller_.renderToDirectory(chooser.getResult(), error))
+        {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Render", error);
+            return;
+        }
+
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "Render Complete",
+                                               "Synthetic stems were written to:\n" + chooser.getResult().getFullPathName());
+        mainComponent().updateSnapshot(controller_.snapshot());
+        menuItemsChanged();
+    }
+
+    OrpheusModuleLoader loader_{};
+    OrpheusSessionController controller_{ loader_ };
+};
+
+class DemoHostApplication : public juce::JUCEApplication
+{
+public:
+    const juce::String getApplicationName() override { return "Orpheus Demo Host"; }
+    const juce::String getApplicationVersion() override { return "0.1.0"; }
+    bool moreThanOneInstanceAllowed() override { return true; }
+
+    void initialise(const juce::String&) override
+    {
+        mainWindow_ = std::make_unique<MainWindow>();
+    }
+
+    void shutdown() override
+    {
+        mainWindow_.reset();
+    }
+
+    void systemRequestedQuit() override
+    {
+        quit();
+    }
+
+private:
+    std::unique_ptr<MainWindow> mainWindow_;
+};
+
+START_JUCE_APPLICATION(DemoHostApplication)


### PR DESCRIPTION
## Summary
- add a CMake option for building the JUCE demo host and wire it into the top-level build
- create the OrpheusDemoHost JUCE application that loads the Orpheus ABI tables at runtime and drives the open/trigger/render flow
- document how to build and run the standalone demo host in the README

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_e_68d75d7307e0832cba35e7f9a89d35a3