### PR TITLE
Add scene quantization support and arrangement commits

### DIFF
--- a/adapters/minhost/main.cpp
+++ b/adapters/minhost/main.cpp
@@ -407,7 +407,7 @@ bool PrepareSession(const SessionLoadOptions &options, SessionContext &context,
         continue;
       }
       const orpheus_clip_desc clip_desc{clip_ptr->name().c_str(), clip_ptr->start(),
-                                        clip_ptr->length()};
+                                        clip_ptr->length(), 0u};
       orpheus_clip_handle clip_handle = nullptr;
       status = context.abi.clipgrid_api->add_clip(context.guard.handle, track_handle,
                                                   &clip_desc, &clip_handle);

--- a/adapters/reaper/reaper_entry.cpp
+++ b/adapters/reaper/reaper_entry.cpp
@@ -105,7 +105,8 @@ orpheus_status PopulateSession(const SessionGraph &graph,
     for (const auto &clip_ptr : track_ptr->clips()) {
       const orpheus_clip_desc clip_desc{clip_ptr->name().c_str(),
                                         clip_ptr->start(),
-                                        clip_ptr->length()};
+                                        clip_ptr->length(),
+                                        0u};
       orpheus_clip_handle clip_handle{};
       status = clipgrid_abi->add_clip(handle, track_handle, &clip_desc,
                                       &clip_handle);

--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -388,7 +388,7 @@ public:
             trackState.handle = trackHandle;
             for (const auto& clipPtr : trackPtr->clips())
             {
-                const orpheus_clip_desc clipDesc{ clipPtr->name().c_str(), clipPtr->start(), clipPtr->length() };
+                const orpheus_clip_desc clipDesc{ clipPtr->name().c_str(), clipPtr->start(), clipPtr->length(), 0u };
                 orpheus_clip_handle clipHandle{};
                 status = clipgridApi->add_clip(guard.handle, trackHandle, &clipDesc, &clipHandle);
                 if (status != ORPHEUS_STATUS_OK)

--- a/include/orpheus/abi.h
+++ b/include/orpheus/abi.h
@@ -34,10 +34,12 @@ typedef struct orpheus_transport_state {
 struct orpheus_session_handle_t;
 struct orpheus_track_handle_t;
 struct orpheus_clip_handle_t;
+struct orpheus_scene_handle_t;
 
 typedef struct orpheus_session_handle_t *orpheus_session_handle;
 typedef struct orpheus_track_handle_t *orpheus_track_handle;
 typedef struct orpheus_clip_handle_t *orpheus_clip_handle;
+typedef struct orpheus_scene_handle_t *orpheus_scene_handle;
 
 typedef struct orpheus_track_desc {
   const char *name;
@@ -47,7 +49,29 @@ typedef struct orpheus_clip_desc {
   const char *name;
   double start_beats;
   double length_beats;
+  uint32_t scene_index;
 } orpheus_clip_desc;
+
+typedef struct orpheus_quantization_window {
+  double grid_beats;
+  double tolerance_beats;
+} orpheus_quantization_window;
+
+typedef struct orpheus_scene_trigger_desc {
+  uint32_t scene_index;
+  double position_beats;
+  orpheus_quantization_window quant;
+} orpheus_scene_trigger_desc;
+
+typedef struct orpheus_scene_end_desc {
+  uint32_t scene_index;
+  double position_beats;
+  orpheus_quantization_window quant;
+} orpheus_scene_end_desc;
+
+typedef struct orpheus_arrangement_commit_desc {
+  double fallback_scene_length_beats;
+} orpheus_arrangement_commit_desc;
 
 typedef struct orpheus_render_click_spec {
   double tempo_bpm;
@@ -87,7 +111,17 @@ typedef struct orpheus_clipgrid_api_v1 {
   orpheus_status (*set_clip_length)(orpheus_session_handle session,
                                     orpheus_clip_handle clip,
                                     double length_beats);
+  orpheus_status (*set_clip_scene)(orpheus_session_handle session,
+                                   orpheus_clip_handle clip,
+                                   uint32_t scene_index);
   orpheus_status (*commit)(orpheus_session_handle session);
+  orpheus_status (*trigger_scene)(orpheus_session_handle session,
+                                  const orpheus_scene_trigger_desc *desc);
+  orpheus_status (*end_scene)(orpheus_session_handle session,
+                              const orpheus_scene_end_desc *desc);
+  orpheus_status (*commit_arrangement)(
+      orpheus_session_handle session,
+      const orpheus_arrangement_commit_desc *desc);
 } orpheus_clipgrid_api_v1;
 
 typedef struct orpheus_render_api_v1 {

--- a/include/orpheus/abi_version.h
+++ b/include/orpheus/abi_version.h
@@ -20,4 +20,5 @@
 
 #define ORPHEUS_SESSION_CAP_V1_CORE (1ull << 0)
 #define ORPHEUS_CLIPGRID_CAP_V1_CORE (1ull << 0)
+#define ORPHEUS_CLIPGRID_CAP_V1_SCENES (1ull << 1)
 #define ORPHEUS_RENDER_CAP_V1_CORE (1ull << 0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(orpheus_tests
   render_tracks.cpp
   session_graph_ownership.cpp
   session_graph_invariants.cpp
+  session_graph_scenes.cpp
   session_roundtrip.cpp
 )
 

--- a/tests/abi_smoke.cpp
+++ b/tests/abi_smoke.cpp
@@ -52,6 +52,11 @@ TEST(AbiTablesTest, CapBitsAdvertised) {
       orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &clip_major, &clip_minor);
   ASSERT_NE(clipgrid, nullptr);
   EXPECT_NE(clipgrid->caps & ORPHEUS_CLIPGRID_CAP_V1_CORE, 0ull);
+  EXPECT_NE(clipgrid->caps & ORPHEUS_CLIPGRID_CAP_V1_SCENES, 0ull);
+  EXPECT_NE(clipgrid->set_clip_scene, nullptr);
+  EXPECT_NE(clipgrid->trigger_scene, nullptr);
+  EXPECT_NE(clipgrid->end_scene, nullptr);
+  EXPECT_NE(clipgrid->commit_arrangement, nullptr);
 
   uint32_t render_major = 0;
   uint32_t render_minor = 0;

--- a/tests/render_tracks.cpp
+++ b/tests/render_tracks.cpp
@@ -232,7 +232,8 @@ TEST(RenderTracks, GeneratesSineStemsWithDitheredQuantization) {
     for (const auto &clip_spec : track_def.clips) {
       const orpheus_clip_desc clip_desc{track_def.name.c_str(),
                                         clip_spec.start_beats,
-                                        clip_spec.length_beats};
+                                        clip_spec.length_beats,
+                                        0u};
       orpheus_clip_handle clip_handle{};
       ASSERT_EQ(clipgrid_api->add_clip(session_handle, track_handle,
                                        &clip_desc, &clip_handle),

--- a/tests/session_graph_scenes.cpp
+++ b/tests/session_graph_scenes.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+#include "session/session_graph.h"
+
+#include <gtest/gtest.h>
+
+namespace orpheus::core::tests {
+namespace {
+
+QuantizationWindow MakeQuant(double grid, double tolerance) {
+  QuantizationWindow window;
+  window.grid_beats = grid;
+  window.tolerance_beats = tolerance;
+  return window;
+}
+
+}  // namespace
+
+TEST(SessionGraphScenes, TriggerQuantizesWithinTolerance) {
+  SessionGraph session;
+  Track *track = session.add_track("Track");
+  ASSERT_NE(track, nullptr);
+
+  Clip *clip = session.add_clip(*track, "Clip", 0.0, 2.0);
+  ASSERT_NE(clip, nullptr);
+  session.set_clip_scene(*clip, 1u);
+
+  session.trigger_scene(1u, 3.05, MakeQuant(1.0, 0.1));
+  session.end_scene(1u, 5.95, MakeQuant(1.0, 0.1));
+  session.commit_arrangement();
+
+  const auto &committed = session.committed_clips();
+  ASSERT_EQ(committed.size(), 1u);
+  EXPECT_EQ(committed[0].scene_index, 1u);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_start_beats, 3.0);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_length_beats, 2.0);
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 3.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), 5.0);
+}
+
+TEST(SessionGraphScenes, TriggerOutsideToleranceMovesForward) {
+  SessionGraph session;
+  Track *track = session.add_track("Track");
+  ASSERT_NE(track, nullptr);
+
+  Clip *clip = session.add_clip(*track, "Clip", 0.0, 4.0);
+  ASSERT_NE(clip, nullptr);
+  session.set_clip_scene(*clip, 2u);
+
+  session.trigger_scene(2u, 3.21, MakeQuant(1.0, 0.05));
+  session.commit_arrangement(1.0);
+
+  const auto &committed = session.committed_clips();
+  ASSERT_EQ(committed.size(), 1u);
+  EXPECT_EQ(committed[0].scene_index, 2u);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_start_beats, 4.0);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_length_beats, 1.0);
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 4.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), 5.0);
+}
+
+TEST(SessionGraphScenes, ArrangementCommitOrdersScenesAndTracks) {
+  SessionGraph session;
+  Track *a = session.add_track("A");
+  Track *b = session.add_track("B");
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  Clip *a1 = session.add_clip(*a, "A1", 0.0, 1.5);
+  Clip *b1 = session.add_clip(*b, "B1", 0.0, 1.0);
+  Clip *a2 = session.add_clip(*a, "A2", 0.0, 1.0);
+  Clip *b2 = session.add_clip(*b, "B2", 0.0, 0.5);
+
+  ASSERT_NE(a1, nullptr);
+  ASSERT_NE(b1, nullptr);
+  ASSERT_NE(a2, nullptr);
+  ASSERT_NE(b2, nullptr);
+
+  session.set_clip_scene(*a1, 10u);
+  session.set_clip_scene(*b1, 10u);
+  session.set_clip_scene(*a2, 20u);
+  session.set_clip_scene(*b2, 20u);
+
+  session.trigger_scene(10u, 0.01, MakeQuant(2.0, 0.1));
+  session.end_scene(10u, 1.95, MakeQuant(2.0, 0.1));
+
+  session.trigger_scene(20u, 2.05, MakeQuant(2.0, 0.1));
+  session.end_scene(20u, 3.95, MakeQuant(2.0, 0.1));
+
+  session.commit_arrangement();
+
+  const auto &committed = session.committed_clips();
+  ASSERT_EQ(committed.size(), 4u);
+
+  EXPECT_EQ(committed[0].scene_index, 10u);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_start_beats, 0.0);
+  EXPECT_DOUBLE_EQ(committed[0].arranged_length_beats, 1.5);
+
+  EXPECT_EQ(committed[1].scene_index, 10u);
+  EXPECT_DOUBLE_EQ(committed[1].arranged_start_beats, 0.0);
+  EXPECT_DOUBLE_EQ(committed[1].arranged_length_beats, 1.0);
+
+  EXPECT_EQ(committed[2].scene_index, 20u);
+  EXPECT_DOUBLE_EQ(committed[2].arranged_start_beats, 2.0);
+  EXPECT_DOUBLE_EQ(committed[2].arranged_length_beats, 1.0);
+
+  EXPECT_EQ(committed[3].scene_index, 20u);
+  EXPECT_DOUBLE_EQ(committed[3].arranged_start_beats, 2.0);
+  EXPECT_DOUBLE_EQ(committed[3].arranged_length_beats, 0.5);
+
+  EXPECT_DOUBLE_EQ(session.session_start_beats(), 0.0);
+  EXPECT_DOUBLE_EQ(session.session_end_beats(), 3.0);
+}
+
+}  // namespace orpheus::core::tests

--- a/tests/session_roundtrip.cpp
+++ b/tests/session_roundtrip.cpp
@@ -79,7 +79,7 @@ TEST(SessionApiTest, ClipgridOperationsSucceed) {
   EXPECT_EQ(clip_major, ORPHEUS_ABI_V1_MAJOR);
   EXPECT_EQ(clip_minor, ORPHEUS_ABI_V1_MINOR);
 
-  const orpheus_clip_desc clip_desc{"intro", 0.0, 4.0};
+  const orpheus_clip_desc clip_desc{"intro", 0.0, 4.0, 0u};
   orpheus_clip_handle clip{};
   ASSERT_EQ(clipgrid->add_clip(session.get(), track, &clip_desc, &clip),
             ORPHEUS_STATUS_OK);


### PR DESCRIPTION
## Summary
- extend the clipgrid ABI with scene descriptors, quantization windows, and arrangement commit entry points
- teach the session graph to track per-clip scenes, honor quantization windows, and materialize committed arrangements
- cover the new scene scheduling flow with dedicated unit tests and update existing call sites

## Testing
- `cmake --build build --target orpheus_tests`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d7638b8004832c9f2bef6e665e0dd8