### PR TITLE
core(common): unify error enums + logger callback + disabled telemetry hook

### DIFF
--- a/adapters/reaper/reaper_entry.cpp
+++ b/adapters/reaper/reaper_entry.cpp
@@ -3,6 +3,7 @@
 
 #include "json_io.h"
 #include "orpheus/abi.h"
+#include "orpheus/errors.h"
 #include "orpheus/adapters/reaper/entry.h"
 
 #include <algorithm>
@@ -61,23 +62,7 @@ const orpheus_render_api_v1 *RenderAbi() {
 }
 
 std::string StatusToString(orpheus_status status) {
-  switch (status) {
-    case ORPHEUS_STATUS_OK:
-      return "ok";
-    case ORPHEUS_STATUS_INVALID_ARGUMENT:
-      return "invalid argument";
-    case ORPHEUS_STATUS_NOT_FOUND:
-      return "not found";
-    case ORPHEUS_STATUS_OUT_OF_MEMORY:
-      return "out of memory";
-    case ORPHEUS_STATUS_INTERNAL_ERROR:
-      return "internal error";
-    case ORPHEUS_STATUS_NOT_IMPLEMENTED:
-      return "not implemented";
-    case ORPHEUS_STATUS_IO_ERROR:
-      return "io error";
-  }
-  return "unknown";
+  return std::string{orpheus_status_to_string(status)};
 }
 
 void RefreshPanelLocked() { gPanelText = orpheus::reaper::BuildPanelText(gSnapshot); }

--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -4,6 +4,7 @@
 #include <juce_audio_utils/juce_audio_utils.h>
 
 #include "orpheus/abi.h"
+#include "orpheus/errors.h"
 #include "json_io.h"
 
 #include <cstdlib>
@@ -29,17 +30,7 @@ namespace {
 
 juce::String StatusToString(orpheus_status status)
 {
-    switch (status)
-    {
-        case ORPHEUS_STATUS_OK: return "ok";
-        case ORPHEUS_STATUS_INVALID_ARGUMENT: return "invalid argument";
-        case ORPHEUS_STATUS_NOT_FOUND: return "not found";
-        case ORPHEUS_STATUS_OUT_OF_MEMORY: return "out of memory";
-        case ORPHEUS_STATUS_INTERNAL_ERROR: return "internal error";
-        case ORPHEUS_STATUS_NOT_IMPLEMENTED: return "not implemented";
-        case ORPHEUS_STATUS_IO_ERROR: return "io error";
-    }
-    return "unknown";
+    return juce::String(orpheus_status_to_string(status));
 }
 
 fs::path ExecutableDirectory()

--- a/include/orpheus/abi.h
+++ b/include/orpheus/abi.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "orpheus/abi_version.h"
+#include "orpheus/errors.h"
 #include "orpheus/export.h"
 
 #include <stdint.h>
@@ -14,16 +15,6 @@ typedef struct orpheus_abi_version {
   uint32_t major;
   uint32_t minor;
 } orpheus_abi_version;
-
-typedef enum orpheus_status {
-  ORPHEUS_STATUS_OK = 0,
-  ORPHEUS_STATUS_INVALID_ARGUMENT = 1,
-  ORPHEUS_STATUS_NOT_FOUND = 2,
-  ORPHEUS_STATUS_OUT_OF_MEMORY = 3,
-  ORPHEUS_STATUS_INTERNAL_ERROR = 4,
-  ORPHEUS_STATUS_NOT_IMPLEMENTED = 5,
-  ORPHEUS_STATUS_IO_ERROR = 6
-} orpheus_status;
 
 typedef struct orpheus_transport_state {
   double tempo_bpm;

--- a/include/orpheus/errors.h
+++ b/include/orpheus/errors.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "orpheus/export.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum orpheus_status {
+  ORPHEUS_STATUS_OK = 0,
+  ORPHEUS_STATUS_INVALID_ARGUMENT = 1,
+  ORPHEUS_STATUS_NOT_FOUND = 2,
+  ORPHEUS_STATUS_OUT_OF_MEMORY = 3,
+  ORPHEUS_STATUS_INTERNAL_ERROR = 4,
+  ORPHEUS_STATUS_NOT_IMPLEMENTED = 5,
+  ORPHEUS_STATUS_IO_ERROR = 6
+} orpheus_status;
+
+typedef enum orpheus_log_level {
+  ORPHEUS_LOG_LEVEL_DEBUG = 0,
+  ORPHEUS_LOG_LEVEL_INFO = 1,
+  ORPHEUS_LOG_LEVEL_WARN = 2,
+  ORPHEUS_LOG_LEVEL_ERROR = 3
+} orpheus_log_level;
+
+typedef void (*orpheus_log_callback)(orpheus_log_level level,
+                                      const char *message,
+                                      void *user_data);
+
+ORPHEUS_API const char *orpheus_status_to_string(orpheus_status status);
+ORPHEUS_API void orpheus_set_logger(orpheus_log_callback callback,
+                                    void *user_data);
+
+typedef void (*orpheus_telemetry_callback)(const char *event_name,
+                                            const char *json_payload,
+                                            void *user_data);
+
+ORPHEUS_API void orpheus_set_telemetry_callback(
+    orpheus_telemetry_callback callback, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#include <string_view>
+
+namespace orpheus {
+
+ORPHEUS_API void Log(orpheus_log_level level, std::string_view message);
+ORPHEUS_API void EmitTelemetry(std::string_view event_name,
+                               std::string_view json_payload);
+
+}  // namespace orpheus
+
+#endif  // __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ if(ORP_BUILD_SHARED_CORE)
 endif()
 
 add_library(orpheus_core_runtime OBJECT
+  core/common/errors.cpp
   core/session/session_graph.cpp
   core/session/json_io.cpp
 )

--- a/src/core/abi/abi_internal.h
+++ b/src/core/abi/abi_internal.h
@@ -34,16 +34,22 @@ orpheus_status GuardAbiCall(Fn &&fn) {
   try {
     return fn();
   } catch (const std::invalid_argument &) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_WARN, "abi: invalid argument");
     return ORPHEUS_STATUS_INVALID_ARGUMENT;
   } catch (const IoException &) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_ERROR, "abi: io error");
     return ORPHEUS_STATUS_IO_ERROR;
   } catch (const std::filesystem::filesystem_error &) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_ERROR, "abi: io error");
     return ORPHEUS_STATUS_IO_ERROR;
   } catch (const std::ios_base::failure &) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_ERROR, "abi: io error");
     return ORPHEUS_STATUS_IO_ERROR;
   } catch (const std::bad_alloc &) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_ERROR, "abi: out of memory");
     return ORPHEUS_STATUS_OUT_OF_MEMORY;
   } catch (...) {
+    orpheus::Log(ORPHEUS_LOG_LEVEL_ERROR, "abi: internal error");
     return ORPHEUS_STATUS_INTERNAL_ERROR;
   }
 }

--- a/src/core/common/errors.cpp
+++ b/src/core/common/errors.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+#include "orpheus/errors.h"
+
+#include <atomic>
+#include <string>
+#include <string_view>
+
+namespace {
+
+template <typename Callback>
+struct CallbackState {
+  std::atomic<Callback> callback{nullptr};
+  std::atomic<void *> user_data{nullptr};
+};
+
+CallbackState<orpheus_log_callback> &LoggerState() {
+  static CallbackState<orpheus_log_callback> state;
+  return state;
+}
+
+CallbackState<orpheus_telemetry_callback> &TelemetryState() {
+  static CallbackState<orpheus_telemetry_callback> state;
+  return state;
+}
+
+}  // namespace
+
+extern "C" {
+
+const char *orpheus_status_to_string(orpheus_status status) {
+  switch (status) {
+    case ORPHEUS_STATUS_OK:
+      return "ok";
+    case ORPHEUS_STATUS_INVALID_ARGUMENT:
+      return "invalid argument";
+    case ORPHEUS_STATUS_NOT_FOUND:
+      return "not found";
+    case ORPHEUS_STATUS_OUT_OF_MEMORY:
+      return "out of memory";
+    case ORPHEUS_STATUS_INTERNAL_ERROR:
+      return "internal error";
+    case ORPHEUS_STATUS_NOT_IMPLEMENTED:
+      return "not implemented";
+    case ORPHEUS_STATUS_IO_ERROR:
+      return "io error";
+  }
+  return "unknown status";
+}
+
+void orpheus_set_logger(orpheus_log_callback callback, void *user_data) {
+  auto &state = LoggerState();
+  state.user_data.store(callback ? user_data : nullptr,
+                        std::memory_order_relaxed);
+  state.callback.store(callback, std::memory_order_release);
+}
+
+void orpheus_set_telemetry_callback(orpheus_telemetry_callback callback,
+                                    void *user_data) {
+  auto &state = TelemetryState();
+  state.user_data.store(callback ? user_data : nullptr,
+                        std::memory_order_relaxed);
+  state.callback.store(callback, std::memory_order_release);
+}
+
+}  // extern "C"
+
+namespace orpheus {
+
+void Log(orpheus_log_level level, std::string_view message) {
+  auto &state = LoggerState();
+  const auto callback = state.callback.load(std::memory_order_acquire);
+  if (callback == nullptr) {
+    return;
+  }
+  const auto user_data = state.user_data.load(std::memory_order_acquire);
+  std::string buffer(message);
+  callback(level, buffer.c_str(), user_data);
+}
+
+void EmitTelemetry(std::string_view event_name,
+                   std::string_view json_payload) {
+  auto &state = TelemetryState();
+  const auto callback = state.callback.load(std::memory_order_acquire);
+  if (callback == nullptr) {
+    return;
+  }
+  const auto user_data = state.user_data.load(std::memory_order_acquire);
+  const std::string event_copy(event_name);
+  const std::string payload_copy(json_payload);
+  callback(event_copy.c_str(), payload_copy.c_str(), user_data);
+}
+
+}  // namespace orpheus

--- a/tools/perf/perf_render_click.cpp
+++ b/tools/perf/perf_render_click.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "orpheus/abi.h"
+#include "orpheus/errors.h"
 
 #include <chrono>
 #include <filesystem>
@@ -10,26 +11,6 @@
 #include <vector>
 
 namespace fs = std::filesystem;
-
-std::string StatusToString(orpheus_status status) {
-  switch (status) {
-    case ORPHEUS_STATUS_OK:
-      return "ok";
-    case ORPHEUS_STATUS_INVALID_ARGUMENT:
-      return "invalid argument";
-    case ORPHEUS_STATUS_NOT_FOUND:
-      return "not found";
-    case ORPHEUS_STATUS_OUT_OF_MEMORY:
-      return "out of memory";
-    case ORPHEUS_STATUS_INTERNAL_ERROR:
-      return "internal error";
-    case ORPHEUS_STATUS_NOT_IMPLEMENTED:
-      return "not implemented";
-    case ORPHEUS_STATUS_IO_ERROR:
-      return "io error";
-  }
-  return "unknown";
-}
 
 int main() {
   uint32_t got_major = 0;
@@ -65,8 +46,8 @@ int main() {
     const auto status = render->render_click(&spec, output.string().c_str());
     const auto end = std::chrono::steady_clock::now();
     if (status != ORPHEUS_STATUS_OK) {
-      std::cerr << "render_click failed: " << StatusToString(status)
-                << std::endl;
+      std::cerr << "render_click failed: "
+                << orpheus_status_to_string(status) << std::endl;
       return 1;
     }
 


### PR DESCRIPTION
## Summary
- add a shared public errors header that hosts the status enum, stringizer, logging API, and telemetry hook
- implement the logger/telemetry plumbing in the core runtime and surface common logging from the ABI guard
- refactor host tools and adapters to rely on the shared status stringizer and build the new common source

## Testing
- cmake -S . -B build
- cmake --build build *(fails: missing lreaper_orpheus library in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d76f78ee58832cb13befe9d58c4f69