### PR TITLE
docs: expand README to cover platform and workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,72 @@
 <!-- SPDX-License-Identifier: MIT -->
 # Orpheus SDK
 
-The Orpheus SDK packages a host-neutral core for working with sessions,
-clip grids, and renders. Optional adapters provide thin integration layers
-for specific hosts, including a minimal standalone utility and a REAPER
-extension. The codebase is designed to be friendly to continuous
-integration, modern CMake workflows, and cross-platform development.
+The Orpheus Software Development Kit (SDK) supplies a host-neutral core for
+negotiating sessions, clip grids, and renders. Thin adapter layers expose the
+core to host applications, including a minimal standalone utility and a REAPER
+extension, while remaining portable across Windows, macOS, and Linux.
 
-## Quickstart
+## Table of Contents
+
+- [Overview](#overview)
+- [Key Features](#key-features)
+- [Supported Platforms](#supported-platforms)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Quickstart](#quickstart)
+  - [Optional Targets](#optional-targets)
+- [Demo Workflows](#demo-workflows)
+  - [Standalone Demo Host](#standalone-demo-host)
+  - [Render a Click Track](#render-a-click-track)
+- [Tooling & Quality](#tooling--quality)
+- [Repository Layout](#repository-layout)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Overview
+
+Orpheus offers a modern C++ foundation for hosts that need to negotiate and
+render session data without relying on a particular digital audio workstation
+(DAW). The core is intentionally host-neutral and built to be:
+
+- **Modular** – adapters opt into only the integrations they require.
+- **Portable** – CMake-based workflows keep Windows, macOS, and Linux builds in
+  sync.
+- **Automation-friendly** – the project embraces continuous integration and
+  static analysis to maintain code health.
+
+## Key Features
+
+- Host-agnostic session negotiation and render APIs.
+- Reference adapters, including a minimal command-line host and an optional
+  REAPER extension.
+- JUCE-based demo application for interactive exploration of the SDK.
+- Click-track rendering utilities with overridable render specifications.
+- GoogleTest-based smoke tests covering core functionality.
+
+## Supported Platforms
+
+The SDK is regularly built and tested on:
+
+- Windows (MSVC toolchains for x64)
+- macOS (Clang toolchains for x86_64 and arm64)
+- Linux (GCC and Clang)
+
+Other platforms may work but are not part of the automated coverage.
+
+## Getting Started
+
+### Prerequisites
+
+- CMake 3.20 or newer.
+- A C++20-capable compiler (MSVC 2019+, Clang 13+, or GCC 11+).
+- Ninja or Make (optional, but recommended for faster incremental builds).
+- Git, for fetching submodules and adapters as needed.
+
+### Quickstart
+
+Configure, build, and run the test suite in Debug mode:
 
 ```sh
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
@@ -15,28 +74,43 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-By default the build produces the Orpheus core libraries, the reference
-`orpheus_minhost` adapter, and the GoogleTest suite. Host-specific adapters
-and demo applications are opt-in.
+By default these commands produce the Orpheus core libraries, the
+`orpheus_minhost` adapter, and the GoogleTest suite.
+
+### Optional Targets
+
+Additional components are disabled unless explicitly requested during
+configuration:
+
+- **JUCE demo application** – enable the standalone demonstration host:
+
+  ```sh
+  cmake -S . -B build -DORPHEUS_ENABLE_APP_JUCE_HOST=ON
+  cmake --build build --target orpheus_demo_host_app
+  ```
+
+- **Host integrations** – each adapter advertises a CMake option documented in
+  [`docs/ADAPTERS.md`](docs/ADAPTERS.md). Toggle only the integrations your
+  environment supports.
+
+## Demo Workflows
 
 ### Standalone Demo Host
 
-To compile the JUCE-based demonstration host, enable the dedicated CMake flag:
-
-```sh
-cmake -S . -B build -DORPHEUS_ENABLE_APP_JUCE_HOST=ON
-cmake --build build --target orpheus_demo_host_app
-```
-
 `OrpheusDemoHost` dynamically loads the Orpheus ABI shared libraries at
-runtime. The menu flow mirrors the demo brief: **File → Open Session…** loads a
-session JSON, **Session → Trigger ClipGrid Scene** negotiates the clip grid,
-and **Session → Render WAV Stems…** writes the rendered stems to disk. The app
-shows the active session summary and requires no DAW or plug-in.
-The executable is produced as `OrpheusDemoHost` (with the usual platform
-extension) inside your build directory.
+runtime. The menu flow mirrors the demo brief:
 
-### Rendering a Click Track
+1. **File → Open Session…** – load a session JSON file.
+2. **Session → Trigger ClipGrid Scene** – negotiate the clip grid.
+3. **Session → Render WAV Stems…** – write rendered stems to disk.
+
+The application summarizes the active session and runs without a DAW or plugin
+host. The resulting executable (`OrpheusDemoHost` with the usual platform
+extension) is emitted inside your build directory.
+
+### Render a Click Track
+
+Generate a two-bar click track with an overridden tempo:
 
 ```sh
 ./build/orpheus_minhost \
@@ -46,27 +120,19 @@ extension) inside your build directory.
   --bpm 100
 ```
 
-This command loads the provided session JSON, overrides the tempo to 100 BPM,
-and renders a two-bar click track to `click.wav`. If you omit `--render`, the
-minhost instead runs a short transport simulation using the session tempo (or
-your override) and prints the suggested render path.
+If you omit `--render`, the minhost performs a brief transport simulation and
+prints the suggested render path instead of writing audio.
 
-### Adapter Overview
+## Tooling & Quality
 
-Adapters are thin shims over the Orpheus SDK core. See
-[`docs/ADAPTERS.md`](docs/ADAPTERS.md) for the complete matrix of supported
-hosts and build flags.
-
-## Tooling
-
-* **Sanitizers** – AddressSanitizer and UBSan are enabled automatically for
+- **Sanitizers** – AddressSanitizer and UBSan are enabled automatically for
   Debug builds on non-MSVC toolchains.
-* **Static analysis** – Repository-wide `.clang-format` and `.clang-tidy`
-  configurations enforce a consistent C++ style and checks.
-* **Continuous Integration** – GitHub Actions builds and tests the project on
+- **Static analysis** – Repository-wide `.clang-format` and `.clang-tidy`
+  configurations enforce a consistent style and catch common issues.
+- **Continuous Integration** – GitHub Actions builds and tests the project on
   Linux, macOS, and Windows for every push and pull request.
 
-## Project Layout
+## Repository Layout
 
 ```
 ├── adapters/        # Host integrations (minhost CLI, optional REAPER shim)
@@ -77,4 +143,23 @@ hosts and build flags.
 ├── tests/           # GoogleTest-based smoke tests
 └── backup/          # Quarantined legacy SDK content (read-only)
 ```
+
+## Documentation
+
+- [`docs/ADAPTERS.md`](docs/ADAPTERS.md) – adapter catalog, build flags, and
+  host-specific notes.
+- [`ROADMAP.md`](ROADMAP.md) – planned milestones and long-term initiatives.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) – design considerations for the modular
+  core (if available in your checkout).
+
+## Contributing
+
+Issues and pull requests are welcome. Please open a discussion or issue before
+contributing substantial changes so that design goals remain aligned. Follow
+the existing code style (`.clang-format`, `.clang-tidy`) and ensure `ctest`
+passes locally before submitting.
+
+## License
+
+This project is released under the [MIT License](LICENSE).
 


### PR DESCRIPTION
## Summary
- expand the README with a table of contents and high-level product overview
- document prerequisites, supported platforms, and optional build targets
- capture demo workflows, tooling, documentation pointers, and contribution notes

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8ce0172c8832ca696b48479472535