### PR TITLE
Refactor minhost JSON parsing to shared utilities

### DIFF
--- a/include/orpheus/json.hpp
+++ b/include/orpheus/json.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "orpheus/export.h"
+
+namespace orpheus::json {
+
+struct JsonValue {
+  enum class Type { kNull, kObject, kArray, kString, kNumber, kBoolean };
+
+  Type type = Type::kNull;
+  double number{};
+  bool boolean{};
+  std::string string;
+  std::map<std::string, JsonValue> object;
+  std::vector<JsonValue> array;
+};
+
+class ORPHEUS_API JsonParser {
+ public:
+  explicit JsonParser(std::string_view input);
+
+  JsonValue Parse();
+
+ private:
+  bool AtEnd() const;
+  char Peek() const;
+  char Consume();
+  void SkipWhitespace();
+
+  JsonValue ParseValue();
+  JsonValue ParseObject();
+  JsonValue ParseArray();
+  std::string ParseString();
+  bool ParseBoolean();
+  void ParseNull();
+  double ParseNumber();
+
+  std::string_view input_;
+  std::size_t index_ = 0;
+};
+
+ORPHEUS_API const JsonValue &ExpectObject(const JsonValue &value,
+                                          const char *context);
+ORPHEUS_API const JsonValue &ExpectArray(const JsonValue &value,
+                                         const char *context);
+ORPHEUS_API const JsonValue *RequireField(const JsonValue &object,
+                                          const std::string &key);
+ORPHEUS_API double RequireNumber(const JsonValue &value,
+                                 const std::string &key);
+ORPHEUS_API std::string RequireString(const JsonValue &value,
+                                      const std::string &key);
+
+ORPHEUS_API std::string FormatDouble(double value);
+ORPHEUS_API void WriteIndent(std::ostringstream &stream, int indent);
+ORPHEUS_API std::string EscapeString(const std::string &value);
+
+}  // namespace orpheus::json

--- a/src/core/common/json_parser.cpp
+++ b/src/core/common/json_parser.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "json_parser.h"
+#include "orpheus/json.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -9,7 +9,7 @@
 #include <limits>
 #include <stdexcept>
 
-namespace orpheus::core::json {
+namespace orpheus::json {
 
 JsonParser::JsonParser(std::string_view input) : input_(input) {}
 
@@ -368,4 +368,4 @@ std::string EscapeString(const std::string &value) {
   return result;
 }
 
-}  // namespace orpheus::core::json
+}  // namespace orpheus::json

--- a/src/core/common/json_parser.h
+++ b/src/core/common/json_parser.h
@@ -1,67 +1,19 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <cstdint>
-#include <map>
-#include <optional>
-#include <ostream>
-#include <sstream>
-#include <string>
-#include <string_view>
-#include <vector>
-
-#include "orpheus/export.h"
+#include "orpheus/json.hpp"
 
 namespace orpheus::core::json {
 
-struct JsonValue {
-  enum class Type { kNull, kObject, kArray, kString, kNumber, kBoolean };
-
-  Type type = Type::kNull;
-  double number{};
-  bool boolean{};
-  std::string string;
-  std::map<std::string, JsonValue> object;
-  std::vector<JsonValue> array;
-};
-
-class ORPHEUS_API JsonParser {
- public:
-  explicit JsonParser(std::string_view input);
-
-  JsonValue Parse();
-
- private:
-  bool AtEnd() const;
-  char Peek() const;
-  char Consume();
-  void SkipWhitespace();
-
-  JsonValue ParseValue();
-  JsonValue ParseObject();
-  JsonValue ParseArray();
-  std::string ParseString();
-  bool ParseBoolean();
-  void ParseNull();
-  double ParseNumber();
-
-  std::string_view input_;
-  std::size_t index_ = 0;
-};
-
-ORPHEUS_API const JsonValue &ExpectObject(const JsonValue &value,
-                                          const char *context);
-ORPHEUS_API const JsonValue &ExpectArray(const JsonValue &value,
-                                         const char *context);
-ORPHEUS_API const JsonValue *RequireField(const JsonValue &object,
-                                          const std::string &key);
-ORPHEUS_API double RequireNumber(const JsonValue &value,
-                                 const std::string &key);
-ORPHEUS_API std::string RequireString(const JsonValue &value,
-                                      const std::string &key);
-
-ORPHEUS_API std::string FormatDouble(double value);
-ORPHEUS_API void WriteIndent(std::ostringstream &stream, int indent);
-ORPHEUS_API std::string EscapeString(const std::string &value);
+using ::orpheus::json::EscapeString;
+using ::orpheus::json::ExpectArray;
+using ::orpheus::json::ExpectObject;
+using ::orpheus::json::FormatDouble;
+using ::orpheus::json::JsonParser;
+using ::orpheus::json::JsonValue;
+using ::orpheus::json::RequireField;
+using ::orpheus::json::RequireNumber;
+using ::orpheus::json::RequireString;
+using ::orpheus::json::WriteIndent;
 
 }  // namespace orpheus::core::json

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(ORPHEUS_TEST_SOURCES
   abi_smoke.cpp
   adm_entity_graph.cpp
   render_tracks.cpp
+  json_minhost_bridge_tests.cpp
   session_graph_ownership.cpp
   session_graph_invariants.cpp
   session_graph_scenes.cpp
@@ -34,6 +35,7 @@ target_include_directories(orpheus_tests
   PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/core/session
     ${CMAKE_SOURCE_DIR}/adapters/reaper/include
 )
 

--- a/tests/json_minhost_bridge_tests.cpp
+++ b/tests/json_minhost_bridge_tests.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include <gtest/gtest.h>
+
+#define ORPHEUS_MINHOST_NO_ENTRYPOINT
+#include "../adapters/minhost/main.cpp"
+#undef ORPHEUS_MINHOST_NO_ENTRYPOINT
+
+namespace {
+
+std::filesystem::path MakeUniqueSpecPath() {
+  static std::atomic<int> counter{0};
+  const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+  const int id = counter.fetch_add(1);
+  std::string filename = "orpheus-minhost-json-" + std::to_string(now) + "-" +
+                         std::to_string(id) + ".json";
+  return std::filesystem::temp_directory_path() / std::move(filename);
+}
+
+class TempJsonFile {
+ public:
+  explicit TempJsonFile(std::string_view contents)
+      : path_(MakeUniqueSpecPath()) {
+    std::ofstream stream(path_);
+    stream << contents;
+    stream.close();
+  }
+
+  ~TempJsonFile() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+
+  const std::filesystem::path &path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+}  // namespace
+
+TEST(JsonMinhostBridgeTests, ParsesTypicalSpec) {
+  const std::string contents = R"JSON({
+    "tempo_bpm": 123.5,
+    "bars": 8,
+    "sample_rate": 48000,
+    "channels": 2,
+    "gain": -3.0,
+    "click_frequency_hz": 950.0,
+    "click_duration_seconds": 0.25,
+    "output_path": "click.wav"
+  })JSON";
+
+  TempJsonFile file(contents);
+  minhost::ClickSpecOverrides overrides;
+  minhost::ErrorInfo error;
+  ASSERT_TRUE(minhost::ParseClickSpecOverrides(file.path(), overrides, error));
+  EXPECT_TRUE(error.code.empty());
+  EXPECT_TRUE(error.message.empty());
+  EXPECT_TRUE(error.details.empty());
+
+  ASSERT_TRUE(overrides.tempo_bpm.has_value());
+  EXPECT_DOUBLE_EQ(*overrides.tempo_bpm, 123.5);
+  ASSERT_TRUE(overrides.bars.has_value());
+  EXPECT_EQ(*overrides.bars, 8u);
+  ASSERT_TRUE(overrides.sample_rate.has_value());
+  EXPECT_EQ(*overrides.sample_rate, 48000u);
+  ASSERT_TRUE(overrides.channels.has_value());
+  EXPECT_EQ(*overrides.channels, 2u);
+  ASSERT_TRUE(overrides.gain.has_value());
+  EXPECT_DOUBLE_EQ(*overrides.gain, -3.0);
+  ASSERT_TRUE(overrides.click_frequency_hz.has_value());
+  EXPECT_DOUBLE_EQ(*overrides.click_frequency_hz, 950.0);
+  ASSERT_TRUE(overrides.click_duration_seconds.has_value());
+  EXPECT_DOUBLE_EQ(*overrides.click_duration_seconds, 0.25);
+  ASSERT_TRUE(overrides.output_path.has_value());
+  EXPECT_EQ(*overrides.output_path, "click.wav");
+}
+
+TEST(JsonMinhostBridgeTests, ParsesMinimalSpec) {
+  TempJsonFile file("{}\n");
+  minhost::ClickSpecOverrides overrides;
+  minhost::ErrorInfo error;
+  EXPECT_TRUE(minhost::ParseClickSpecOverrides(file.path(), overrides, error));
+  EXPECT_TRUE(error.message.empty());
+  EXPECT_FALSE(overrides.tempo_bpm.has_value());
+  EXPECT_FALSE(overrides.bars.has_value());
+  EXPECT_FALSE(overrides.sample_rate.has_value());
+  EXPECT_FALSE(overrides.channels.has_value());
+  EXPECT_FALSE(overrides.gain.has_value());
+  EXPECT_FALSE(overrides.click_frequency_hz.has_value());
+  EXPECT_FALSE(overrides.click_duration_seconds.has_value());
+  EXPECT_FALSE(overrides.output_path.has_value());
+}
+
+TEST(JsonMinhostBridgeTests, ReportsInvalidSpecDetails) {
+  const std::string contents = R"JSON({
+    "bars": -1
+  })JSON";
+
+  TempJsonFile file(contents);
+  minhost::ClickSpecOverrides overrides;
+  minhost::ErrorInfo error;
+  EXPECT_FALSE(minhost::ParseClickSpecOverrides(file.path(), overrides, error));
+  EXPECT_EQ(error.code, "spec.parse");
+  EXPECT_EQ(error.message, "Failed to parse click spec");
+  ASSERT_EQ(error.details.size(), 1u);
+  EXPECT_EQ(error.details.front(), "bars must be non-negative");
+  EXPECT_FALSE(overrides.bars.has_value());
+}


### PR DESCRIPTION
## Summary
- add a public `orpheus/json.hpp` wrapper around the core JSON parser
- update the minhost adapter to consume the shared JSON utilities and expose its entry point behind a guard
- add regression tests covering typical, minimal, and invalid click spec payloads through the minhost parser

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dbd1486298832cabe758060cb238db