### PR TITLE
Add forward declaration for DescribeLoaderError in JUCE demo host

### DIFF
--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -32,6 +32,8 @@ namespace reconform = orpheus::core::otio;
 
 namespace {
 
+juce::String DescribeLoaderError();
+
 juce::String StatusToString(orpheus_status status)
 {
     return juce::String(orpheus_status_to_string(status));


### PR DESCRIPTION
## Summary
- add a forward declaration for DescribeLoaderError so the Windows LoadModule definition can see the prototype

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd470142b0832ca382231252596c7f