### PR TITLE
Ensure ABI factories export unmangled symbols

### DIFF
--- a/src/core/abi/clipgrid_api.cpp
+++ b/src/core/abi/clipgrid_api.cpp
@@ -157,11 +157,9 @@ const orpheus_clipgrid_api_v1 kClipgridApiV1{
 
 }  // namespace
 
-extern "C" {
-
-const orpheus_clipgrid_api_v1 *orpheus_clipgrid_abi_v1(uint32_t want_major,
-                                                       uint32_t *got_major,
-                                                       uint32_t *got_minor) {
+extern "C" ORPHEUS_API const orpheus_clipgrid_api_v1 *
+orpheus_clipgrid_abi_v1(uint32_t want_major, uint32_t *got_major,
+                        uint32_t *got_minor) {
   (void)want_major;
   if (got_major != nullptr) {
     *got_major = ORPHEUS_ABI_V1_MAJOR;
@@ -171,5 +169,3 @@ const orpheus_clipgrid_api_v1 *orpheus_clipgrid_abi_v1(uint32_t want_major,
   }
   return &kClipgridApiV1;
 }
-
-}  // extern "C"

--- a/src/core/abi/render_api.cpp
+++ b/src/core/abi/render_api.cpp
@@ -344,11 +344,9 @@ const orpheus_render_api_v1 kRenderApiV1{ORPHEUS_RENDER_CAP_V1_CORE, &RenderClic
 
 }  // namespace
 
-extern "C" {
-
-const orpheus_render_api_v1 *orpheus_render_abi_v1(uint32_t want_major,
-                                                   uint32_t *got_major,
-                                                   uint32_t *got_minor) {
+extern "C" ORPHEUS_API const orpheus_render_api_v1 *
+orpheus_render_abi_v1(uint32_t want_major, uint32_t *got_major,
+                      uint32_t *got_minor) {
   (void)want_major;
   if (got_major != nullptr) {
     *got_major = ORPHEUS_ABI_V1_MAJOR;
@@ -358,5 +356,3 @@ const orpheus_render_api_v1 *orpheus_render_abi_v1(uint32_t want_major,
   }
   return &kRenderApiV1;
 }
-
-}  // extern "C"

--- a/src/core/abi/session_api.cpp
+++ b/src/core/abi/session_api.cpp
@@ -87,11 +87,9 @@ const orpheus_session_api_v1 kSessionApiV1{
 
 }  // namespace
 
-extern "C" {
-
-const orpheus_session_api_v1 *orpheus_session_abi_v1(uint32_t want_major,
-                                                     uint32_t *got_major,
-                                                     uint32_t *got_minor) {
+extern "C" ORPHEUS_API const orpheus_session_api_v1 *
+orpheus_session_abi_v1(uint32_t want_major, uint32_t *got_major,
+                       uint32_t *got_minor) {
   (void)want_major;
   if (got_major != nullptr) {
     *got_major = ORPHEUS_ABI_V1_MAJOR;
@@ -101,5 +99,3 @@ const orpheus_session_api_v1 *orpheus_session_abi_v1(uint32_t want_major,
   }
   return &kSessionApiV1;
 }
-
-}  // extern "C"


### PR DESCRIPTION
## Summary
- mark each ABI factory definition with extern "C" and ORPHEUS_API so the DLL exports stay unmangled on Windows

## Testing
- ctest -R abi_link -V

------
https://chatgpt.com/codex/tasks/task_e_68e4decf5398832cacfc8596073d1dbb