### PR TITLE
Unify ABI negotiation across Orpheus subsystems

### DIFF
--- a/adapters/minhost/main.cpp
+++ b/adapters/minhost/main.cpp
@@ -195,31 +195,31 @@ void PrintNegotiationSummary(const AbiContext &abi) {
               << minor << (ok ? " ✅" : " ❌") << std::endl;
   };
   print_entry("session", abi.session_major, abi.session_minor,
-              abi.session_api != nullptr && abi.session_major == ORPHEUS_ABI_V1_MAJOR &&
-                  abi.session_minor == ORPHEUS_ABI_V1_MINOR);
+              abi.session_api != nullptr && abi.session_major == ORPHEUS_ABI_MAJOR &&
+                  abi.session_minor == ORPHEUS_ABI_MINOR);
   print_entry("clipgrid", abi.clip_major, abi.clip_minor,
-              abi.clipgrid_api != nullptr && abi.clip_major == ORPHEUS_ABI_V1_MAJOR &&
-                  abi.clip_minor == ORPHEUS_ABI_V1_MINOR);
+              abi.clipgrid_api != nullptr && abi.clip_major == ORPHEUS_ABI_MAJOR &&
+                  abi.clip_minor == ORPHEUS_ABI_MINOR);
   print_entry("render", abi.render_major, abi.render_minor,
-              abi.render_api != nullptr && abi.render_major == ORPHEUS_ABI_V1_MAJOR &&
-                  abi.render_minor == ORPHEUS_ABI_V1_MINOR);
+              abi.render_api != nullptr && abi.render_major == ORPHEUS_ABI_MAJOR &&
+                  abi.render_minor == ORPHEUS_ABI_MINOR);
 }
 
 bool NegotiateApis(AbiContext &abi, ErrorInfo &error) {
-  abi.session_api = orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &abi.session_major,
+  abi.session_api = orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &abi.session_major,
                                            &abi.session_minor);
-  abi.clipgrid_api = orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &abi.clip_major,
+  abi.clipgrid_api = orpheus_clipgrid_abi_v1(ORPHEUS_ABI_MAJOR, &abi.clip_major,
                                              &abi.clip_minor);
-  abi.render_api = orpheus_render_abi_v1(ORPHEUS_ABI_V1_MAJOR, &abi.render_major,
+  abi.render_api = orpheus_render_abi_v1(ORPHEUS_ABI_MAJOR, &abi.render_major,
                                          &abi.render_minor);
   PrintNegotiationSummary(abi);
   if (!abi.session_api || !abi.clipgrid_api || !abi.render_api ||
-      abi.session_major != ORPHEUS_ABI_V1_MAJOR ||
-      abi.clip_major != ORPHEUS_ABI_V1_MAJOR ||
-      abi.render_major != ORPHEUS_ABI_V1_MAJOR ||
-      abi.session_minor != ORPHEUS_ABI_V1_MINOR ||
-      abi.clip_minor != ORPHEUS_ABI_V1_MINOR ||
-      abi.render_minor != ORPHEUS_ABI_V1_MINOR) {
+      abi.session_major != ORPHEUS_ABI_MAJOR ||
+      abi.clip_major != ORPHEUS_ABI_MAJOR ||
+      abi.render_major != ORPHEUS_ABI_MAJOR ||
+      abi.session_minor != ORPHEUS_ABI_MINOR ||
+      abi.clip_minor != ORPHEUS_ABI_MINOR ||
+      abi.render_minor != ORPHEUS_ABI_MINOR) {
     error.code = "abi.negotiation";
     error.message = "ABI negotiation failed";
     return false;

--- a/adapters/reaper/reaper_entry.cpp
+++ b/adapters/reaper/reaper_entry.cpp
@@ -29,9 +29,9 @@ const orpheus_session_api_v1 *SessionAbi() {
   uint32_t major = 0;
   uint32_t minor = 0;
   const auto *api =
-      orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-  if (api == nullptr || major != ORPHEUS_ABI_V1_MAJOR ||
-      minor != ORPHEUS_ABI_V1_MINOR) {
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &major, &minor);
+  if (api == nullptr || major != ORPHEUS_ABI_MAJOR ||
+      minor != ORPHEUS_ABI_MINOR) {
     return nullptr;
   }
   return api;
@@ -41,9 +41,9 @@ const orpheus_clipgrid_api_v1 *ClipgridAbi() {
   uint32_t major = 0;
   uint32_t minor = 0;
   const auto *api =
-      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-  if (api == nullptr || major != ORPHEUS_ABI_V1_MAJOR ||
-      minor != ORPHEUS_ABI_V1_MINOR) {
+      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_MAJOR, &major, &minor);
+  if (api == nullptr || major != ORPHEUS_ABI_MAJOR ||
+      minor != ORPHEUS_ABI_MINOR) {
     return nullptr;
   }
   return api;
@@ -53,9 +53,9 @@ const orpheus_render_api_v1 *RenderAbi() {
   uint32_t major = 0;
   uint32_t minor = 0;
   const auto *api =
-      orpheus_render_abi_v1(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-  if (api == nullptr || major != ORPHEUS_ABI_V1_MAJOR ||
-      minor != ORPHEUS_ABI_V1_MINOR) {
+      orpheus_render_abi_v1(ORPHEUS_ABI_MAJOR, &major, &minor);
+  if (api == nullptr || major != ORPHEUS_ABI_MAJOR ||
+      minor != ORPHEUS_ABI_MINOR) {
     return nullptr;
   }
   return api;

--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -237,8 +237,8 @@ public:
                 auto fn = reinterpret_cast<const orpheus_session_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
                 uint32_t major{};
                 uint32_t minor{};
-                tables_.session = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-                if (tables_.session == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                tables_.session = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
+                if (tables_.session == nullptr || major != ORPHEUS_ABI_MAJOR)
                 {
                     error = "Session ABI negotiation failed";
                     unload();
@@ -250,8 +250,8 @@ public:
                 auto fn = reinterpret_cast<const orpheus_clipgrid_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
                 uint32_t major{};
                 uint32_t minor{};
-                tables_.clipgrid = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-                if (tables_.clipgrid == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                tables_.clipgrid = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
+                if (tables_.clipgrid == nullptr || major != ORPHEUS_ABI_MAJOR)
                 {
                     error = "ClipGrid ABI negotiation failed";
                     unload();
@@ -263,8 +263,8 @@ public:
                 auto fn = reinterpret_cast<const orpheus_render_api_v1*(*) (uint32_t, uint32_t*, uint32_t*)>(symbol);
                 uint32_t major{};
                 uint32_t minor{};
-                tables_.render = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-                if (tables_.render == nullptr || major != ORPHEUS_ABI_V1_MAJOR)
+                tables_.render = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
+                if (tables_.render == nullptr || major != ORPHEUS_ABI_MAJOR)
                 {
                     error = "Render ABI negotiation failed";
                     unload();

--- a/include/orpheus/abi.h
+++ b/include/orpheus/abi.h
@@ -141,12 +141,9 @@ namespace orpheus {
 
 using AbiVersion = orpheus_abi_version;
 
-inline constexpr AbiVersion kSessionAbi{ORPHEUS_ABI_V1_MAJOR,
-                                        ORPHEUS_ABI_V1_MINOR};
-inline constexpr AbiVersion kClipgridAbi{ORPHEUS_ABI_V1_MAJOR,
-                                         ORPHEUS_ABI_V1_MINOR};
-inline constexpr AbiVersion kRenderAbi{ORPHEUS_ABI_V1_MAJOR,
-                                       ORPHEUS_ABI_V1_MINOR};
+inline constexpr AbiVersion kSessionAbi{ORPHEUS_ABI_MAJOR, ORPHEUS_ABI_MINOR};
+inline constexpr AbiVersion kClipgridAbi{ORPHEUS_ABI_MAJOR, ORPHEUS_ABI_MINOR};
+inline constexpr AbiVersion kRenderAbi{ORPHEUS_ABI_MAJOR, ORPHEUS_ABI_MINOR};
 
 inline std::string ToString(const AbiVersion &version) {
   return std::to_string(version.major) + "." + std::to_string(version.minor);

--- a/include/orpheus/abi_version.h
+++ b/include/orpheus/abi_version.h
@@ -3,18 +3,12 @@
 
 #include <stdint.h>
 
-#define ORPHEUS_ABI_V1_MAJOR 1u
-#define ORPHEUS_ABI_V1_MINOR 0u
+#define ORPHEUS_ABI_MAJOR 1
+#define ORPHEUS_ABI_MINOR 0
+#define ORPHEUS_ABI_EXPECT(x) ((x) == ORPHEUS_ABI_MAJOR)
 
-#if defined(__cplusplus)
-#define ORPHEUS_ABI_EXPECT(major_literal)                                            \
-  static_assert((major_literal) == ORPHEUS_ABI_V1_MAJOR,                            \
-                "Orpheus ABI major mismatch; rebuild against the expected version")
-#else
-#define ORPHEUS_ABI_EXPECT(major_literal)                                            \
-  _Static_assert((major_literal) == ORPHEUS_ABI_V1_MAJOR,                           \
-                 "Orpheus ABI major mismatch; rebuild against the expected version")
-#endif
+#define ORPHEUS_ABI_V1_MAJOR ORPHEUS_ABI_MAJOR
+#define ORPHEUS_ABI_V1_MINOR ORPHEUS_ABI_MINOR
 
 #define ORPHEUS_ABI_CAP_NONE 0ull
 

--- a/src/core/abi/clipgrid_api.cpp
+++ b/src/core/abi/clipgrid_api.cpp
@@ -160,12 +160,14 @@ const orpheus_clipgrid_api_v1 kClipgridApiV1{
 extern "C" ORPHEUS_API const orpheus_clipgrid_api_v1 *
 orpheus_clipgrid_abi_v1(uint32_t want_major, uint32_t *got_major,
                         uint32_t *got_minor) {
-  (void)want_major;
   if (got_major != nullptr) {
-    *got_major = ORPHEUS_ABI_V1_MAJOR;
+    *got_major = ORPHEUS_ABI_MAJOR;
   }
   if (got_minor != nullptr) {
-    *got_minor = ORPHEUS_ABI_V1_MINOR;
+    *got_minor = ORPHEUS_ABI_MINOR;
+  }
+  if (want_major != ORPHEUS_ABI_MAJOR) {
+    return nullptr;
   }
   return &kClipgridApiV1;
 }

--- a/src/core/abi/render_api.cpp
+++ b/src/core/abi/render_api.cpp
@@ -347,12 +347,14 @@ const orpheus_render_api_v1 kRenderApiV1{ORPHEUS_RENDER_CAP_V1_CORE, &RenderClic
 extern "C" ORPHEUS_API const orpheus_render_api_v1 *
 orpheus_render_abi_v1(uint32_t want_major, uint32_t *got_major,
                       uint32_t *got_minor) {
-  (void)want_major;
   if (got_major != nullptr) {
-    *got_major = ORPHEUS_ABI_V1_MAJOR;
+    *got_major = ORPHEUS_ABI_MAJOR;
   }
   if (got_minor != nullptr) {
-    *got_minor = ORPHEUS_ABI_V1_MINOR;
+    *got_minor = ORPHEUS_ABI_MINOR;
+  }
+  if (want_major != ORPHEUS_ABI_MAJOR) {
+    return nullptr;
   }
   return &kRenderApiV1;
 }

--- a/src/core/abi/session_api.cpp
+++ b/src/core/abi/session_api.cpp
@@ -90,12 +90,14 @@ const orpheus_session_api_v1 kSessionApiV1{
 extern "C" ORPHEUS_API const orpheus_session_api_v1 *
 orpheus_session_abi_v1(uint32_t want_major, uint32_t *got_major,
                        uint32_t *got_minor) {
-  (void)want_major;
   if (got_major != nullptr) {
-    *got_major = ORPHEUS_ABI_V1_MAJOR;
+    *got_major = ORPHEUS_ABI_MAJOR;
   }
   if (got_minor != nullptr) {
-    *got_minor = ORPHEUS_ABI_V1_MINOR;
+    *got_minor = ORPHEUS_ABI_MINOR;
+  }
+  if (want_major != ORPHEUS_ABI_MAJOR) {
+    return nullptr;
   }
   return &kSessionApiV1;
 }

--- a/tests/abi_link/main.cpp
+++ b/tests/abi_link/main.cpp
@@ -164,7 +164,7 @@ int main() {
             uint32_t, uint32_t *, uint32_t *)>(symbol);
         uint32_t major = 0;
         uint32_t minor = 0;
-        const auto *abi = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+        const auto *abi = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
         if (abi == nullptr) {
           throw std::runtime_error("Session ABI negotiation returned null");
         }
@@ -176,7 +176,7 @@ int main() {
             uint32_t, uint32_t *, uint32_t *)>(symbol);
         uint32_t major = 0;
         uint32_t minor = 0;
-        const auto *abi = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+        const auto *abi = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
         if (abi == nullptr) {
           throw std::runtime_error("Clipgrid ABI negotiation returned null");
         }
@@ -188,7 +188,7 @@ int main() {
             uint32_t, uint32_t *, uint32_t *)>(symbol);
         uint32_t major = 0;
         uint32_t minor = 0;
-        const auto *abi = fn(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
+        const auto *abi = fn(ORPHEUS_ABI_MAJOR, &major, &minor);
         if (abi == nullptr) {
           throw std::runtime_error("Render ABI negotiation returned null");
         }

--- a/tests/abi_smoke.cpp
+++ b/tests/abi_smoke.cpp
@@ -5,32 +5,44 @@
 
 namespace orpheus::tests {
 
-TEST(AbiNegotiationTest, DowngradesToSupportedMajor) {
+TEST(AbiNegotiationTest, ReturnsTableForMatchingMajor) {
   uint32_t got_major = 0;
   uint32_t got_minor = 0;
-  const auto *session = orpheus_session_abi_v1(2, &got_major, &got_minor);
+  const auto *session =
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &got_major, &got_minor);
   ASSERT_NE(session, nullptr);
-  EXPECT_EQ(got_major, ORPHEUS_ABI_V1_MAJOR);
-  EXPECT_EQ(got_minor, ORPHEUS_ABI_V1_MINOR);
+  EXPECT_EQ(got_major, ORPHEUS_ABI_MAJOR);
+  EXPECT_EQ(got_minor, ORPHEUS_ABI_MINOR);
 }
 
-TEST(AbiNegotiationTest, UpgradesOlderMajorRequests) {
+TEST(AbiNegotiationTest, ReturnsNullForFutureMajorRequests) {
   uint32_t got_major = 0;
   uint32_t got_minor = 0;
-  const auto *session = orpheus_session_abi_v1(0, &got_major, &got_minor);
-  ASSERT_NE(session, nullptr);
-  EXPECT_EQ(got_major, ORPHEUS_ABI_V1_MAJOR);
-  EXPECT_EQ(got_minor, ORPHEUS_ABI_V1_MINOR);
+  const auto *session =
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR + 1, &got_major, &got_minor);
+  EXPECT_EQ(session, nullptr);
+  EXPECT_EQ(got_major, ORPHEUS_ABI_MAJOR);
+  EXPECT_EQ(got_minor, ORPHEUS_ABI_MINOR);
+}
+
+TEST(AbiNegotiationTest, ReturnsNullForOlderMajorRequests) {
+  uint32_t got_major = 0;
+  uint32_t got_minor = 0;
+  const auto *session =
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR - 1, &got_major, &got_minor);
+  EXPECT_EQ(session, nullptr);
+  EXPECT_EQ(got_major, ORPHEUS_ABI_MAJOR);
+  EXPECT_EQ(got_minor, ORPHEUS_ABI_MINOR);
 }
 
 TEST(AbiTablesTest, SessionTableProvidesCreateDestroy) {
   uint32_t got_major = 0;
   uint32_t got_minor = 0;
   const auto *session =
-      orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &got_major, &got_minor);
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &got_major, &got_minor);
   ASSERT_NE(session, nullptr);
-  EXPECT_EQ(got_major, ORPHEUS_ABI_V1_MAJOR);
-  EXPECT_EQ(got_minor, ORPHEUS_ABI_V1_MINOR);
+  EXPECT_EQ(got_major, ORPHEUS_ABI_MAJOR);
+  EXPECT_EQ(got_minor, ORPHEUS_ABI_MINOR);
 
   orpheus_session_handle handle{};
   ASSERT_EQ(session->create(&handle), ORPHEUS_STATUS_OK);
@@ -41,7 +53,7 @@ TEST(AbiTablesTest, SessionTableProvidesCreateDestroy) {
 TEST(AbiTablesTest, CapBitsAdvertised) {
   uint32_t session_major = 0;
   uint32_t session_minor = 0;
-  const auto *session = orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR,
+  const auto *session = orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR,
                                                &session_major, &session_minor);
   ASSERT_NE(session, nullptr);
   EXPECT_NE(session->caps & ORPHEUS_SESSION_CAP_V1_CORE, 0ull);
@@ -49,7 +61,7 @@ TEST(AbiTablesTest, CapBitsAdvertised) {
   uint32_t clip_major = 0;
   uint32_t clip_minor = 0;
   const auto *clipgrid =
-      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &clip_major, &clip_minor);
+      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_MAJOR, &clip_major, &clip_minor);
   ASSERT_NE(clipgrid, nullptr);
   EXPECT_NE(clipgrid->caps & ORPHEUS_CLIPGRID_CAP_V1_CORE, 0ull);
   EXPECT_NE(clipgrid->caps & ORPHEUS_CLIPGRID_CAP_V1_SCENES, 0ull);
@@ -61,7 +73,7 @@ TEST(AbiTablesTest, CapBitsAdvertised) {
   uint32_t render_major = 0;
   uint32_t render_minor = 0;
   const auto *render =
-      orpheus_render_abi_v1(ORPHEUS_ABI_V1_MAJOR, &render_major, &render_minor);
+      orpheus_render_abi_v1(ORPHEUS_ABI_MAJOR, &render_major, &render_minor);
   ASSERT_NE(render, nullptr);
   EXPECT_NE(render->caps & ORPHEUS_RENDER_CAP_V1_CORE, 0ull);
 }

--- a/tests/cmake/find_package/main.cpp
+++ b/tests/cmake/find_package/main.cpp
@@ -5,7 +5,7 @@ int main() {
   uint32_t major = 0;
   uint32_t minor = 0;
   const auto *session =
-      orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &major, &minor);
-  return session == nullptr || major != ORPHEUS_ABI_V1_MAJOR ||
-         minor != ORPHEUS_ABI_V1_MINOR;
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &major, &minor);
+  return session == nullptr || major != ORPHEUS_ABI_MAJOR ||
+         minor != ORPHEUS_ABI_MINOR;
 }

--- a/tests/render_tracks.cpp
+++ b/tests/render_tracks.cpp
@@ -164,27 +164,27 @@ TEST(RenderTracks, GeneratesSineStemsWithDitheredQuantization) {
   uint32_t session_major = 0;
   uint32_t session_minor = 0;
   const auto *session_api =
-      orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &session_major,
+      orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &session_major,
                              &session_minor);
   ASSERT_NE(session_api, nullptr);
-  ASSERT_EQ(session_major, ORPHEUS_ABI_V1_MAJOR);
-  ASSERT_EQ(session_minor, ORPHEUS_ABI_V1_MINOR);
+  ASSERT_EQ(session_major, ORPHEUS_ABI_MAJOR);
+  ASSERT_EQ(session_minor, ORPHEUS_ABI_MINOR);
 
   uint32_t clip_major = 0;
   uint32_t clip_minor = 0;
   const auto *clipgrid_api =
-      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &clip_major, &clip_minor);
+      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_MAJOR, &clip_major, &clip_minor);
   ASSERT_NE(clipgrid_api, nullptr);
-  ASSERT_EQ(clip_major, ORPHEUS_ABI_V1_MAJOR);
-  ASSERT_EQ(clip_minor, ORPHEUS_ABI_V1_MINOR);
+  ASSERT_EQ(clip_major, ORPHEUS_ABI_MAJOR);
+  ASSERT_EQ(clip_minor, ORPHEUS_ABI_MINOR);
 
   uint32_t render_major = 0;
   uint32_t render_minor = 0;
   const auto *render_api =
-      orpheus_render_abi_v1(ORPHEUS_ABI_V1_MAJOR, &render_major, &render_minor);
+      orpheus_render_abi_v1(ORPHEUS_ABI_MAJOR, &render_major, &render_minor);
   ASSERT_NE(render_api, nullptr);
-  ASSERT_EQ(render_major, ORPHEUS_ABI_V1_MAJOR);
-  ASSERT_EQ(render_minor, ORPHEUS_ABI_V1_MINOR);
+  ASSERT_EQ(render_major, ORPHEUS_ABI_MAJOR);
+  ASSERT_EQ(render_minor, ORPHEUS_ABI_MINOR);
 
   orpheus_session_handle session_handle{};
   ASSERT_EQ(session_api->create(&session_handle), ORPHEUS_STATUS_OK);

--- a/tests/session_roundtrip.cpp
+++ b/tests/session_roundtrip.cpp
@@ -13,13 +13,13 @@ class SessionHandle {
     uint32_t got_major = 0;
     uint32_t got_minor = 0;
     const auto *abi =
-        orpheus_session_abi_v1(ORPHEUS_ABI_V1_MAJOR, &got_major, &got_minor);
+        orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &got_major, &got_minor);
     EXPECT_NE(abi, nullptr);
     if (abi == nullptr) {
       return;
     }
-    EXPECT_EQ(got_major, ORPHEUS_ABI_V1_MAJOR);
-    EXPECT_EQ(got_minor, ORPHEUS_ABI_V1_MINOR);
+    EXPECT_EQ(got_major, ORPHEUS_ABI_MAJOR);
+    EXPECT_EQ(got_minor, ORPHEUS_ABI_MINOR);
     EXPECT_EQ(abi->create(&handle_), ORPHEUS_STATUS_OK);
     abi_ = abi;
   }
@@ -74,10 +74,10 @@ TEST(SessionApiTest, ClipgridOperationsSucceed) {
   uint32_t clip_major = 0;
   uint32_t clip_minor = 0;
   const auto *clipgrid =
-      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_V1_MAJOR, &clip_major, &clip_minor);
+      orpheus_clipgrid_abi_v1(ORPHEUS_ABI_MAJOR, &clip_major, &clip_minor);
   ASSERT_NE(clipgrid, nullptr);
-  EXPECT_EQ(clip_major, ORPHEUS_ABI_V1_MAJOR);
-  EXPECT_EQ(clip_minor, ORPHEUS_ABI_V1_MINOR);
+  EXPECT_EQ(clip_major, ORPHEUS_ABI_MAJOR);
+  EXPECT_EQ(clip_minor, ORPHEUS_ABI_MINOR);
 
   const orpheus_clip_desc clip_desc{"intro", 0.0, 4.0, 0u};
   orpheus_clip_handle clip{};

--- a/tools/perf/perf_render_click.cpp
+++ b/tools/perf/perf_render_click.cpp
@@ -16,9 +16,9 @@ int main() {
   uint32_t got_major = 0;
   uint32_t got_minor = 0;
   const auto *render =
-      orpheus_render_abi_v1(ORPHEUS_ABI_V1_MAJOR, &got_major, &got_minor);
-  if (render == nullptr || got_major != ORPHEUS_ABI_V1_MAJOR ||
-      got_minor != ORPHEUS_ABI_V1_MINOR) {
+      orpheus_render_abi_v1(ORPHEUS_ABI_MAJOR, &got_major, &got_minor);
+  if (render == nullptr || got_major != ORPHEUS_ABI_MAJOR ||
+      got_minor != ORPHEUS_ABI_MINOR) {
     std::cerr << "render ABI unavailable" << std::endl;
     return 1;
   }


### PR DESCRIPTION
## Summary
- add a central `abi_version.h` with shared ABI version macros and capability constants
- update the session, clipgrid, and render factories to reject unsupported major versions and report the negotiated version
- refresh adapters, utilities, and tests to consume the new macros and cover negotiation success/failure and capability flags

## Testing
- `cmake --build build --target orpheus_tests`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68e4e24779b4832caf5302e50a8cf9e1