### PR TITLE
Handle optional conformance command return value

### DIFF
--- a/tools/conformance/json_roundtrip.cpp
+++ b/tools/conformance/json_roundtrip.cpp
@@ -2,6 +2,7 @@
 #include "json_io.h"
 
 #include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -133,6 +134,13 @@ std::string LoadFixtureText(const fs::path &path) {
 }  // namespace
 
 TEST(JsonConformance, RoundTripFixtures) {
+  const char *external_command =
+      std::getenv("ORPHEUS_JSON_ROUNDTRIP_COMMAND");
+  if (external_command != nullptr && external_command[0] != '\0') {
+    const std::string command(external_command);
+    const int result = std::system(command.c_str());
+    (void)result;
+  }
   const std::vector<std::string> fixtures = {
       "solo_click.json", "two_tracks.json", "loop_grid.json"};
   for (const auto &fixture : fixtures) {


### PR DESCRIPTION
## Summary
- include `<cstdlib>` so the conformance test can call `std::system`
- run the optional `ORPHEUS_JSON_ROUNDTRIP_COMMAND` hook with a captured result to suppress unused-result warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c1f39cb4832cb497a1cb1aa1edbd