### PR TITLE
Refine exported graph APIs for warning-free headers

### DIFF
--- a/adapters/minhost/main.cpp
+++ b/adapters/minhost/main.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
@@ -510,9 +511,9 @@ void PrintSessionSummary(const SessionContext &context) {
   }
 }
 
-void PrintAbiJson(const AbiContext &abi, int indent) {
+void PrintAbiJson(const AbiContext &abi, std::size_t indent) {
   const std::string base(indent, ' ');
-  const std::string inner(indent + 2, ' ');
+  const std::string inner(indent + std::size_t{2}, ' ');
   const bool session_ok = abi.session_api != nullptr &&
                           abi.session_major == ORPHEUS_ABI_MAJOR &&
                           abi.session_minor == ORPHEUS_ABI_MINOR;

--- a/include/orpheus/adm/entity_graph.h
+++ b/include/orpheus/adm/entity_graph.h
@@ -42,42 +42,46 @@ enum class ThinningPolicy {
   kEnabled,
 };
 
-class ORPHEUS_API Bed {
+class Bed {
  public:
-  explicit Bed(EntityEnvelope envelope);
+  ORPHEUS_API explicit Bed(EntityEnvelope envelope);
+  ORPHEUS_API ~Bed();
 
-  const EntityEnvelope &envelope() const;
-  void add_channel(BedChannel channel);
-  const std::vector<BedChannel> &channels() const;
+  [[nodiscard]] ORPHEUS_API const EntityEnvelope &envelope() const;
+  ORPHEUS_API void add_channel(BedChannel channel);
+  [[nodiscard]] ORPHEUS_API const std::vector<BedChannel> &channels() const;
 
  private:
   EntityEnvelope envelope_;
   std::vector<BedChannel> channels_;
 };
 
-class ORPHEUS_API Object {
+class Object {
  public:
-  explicit Object(EntityEnvelope envelope);
+  ORPHEUS_API explicit Object(EntityEnvelope envelope);
+  ORPHEUS_API ~Object();
 
-  const EntityEnvelope &envelope() const;
-  void add_point(ObjectPoint point);
-  std::vector<ObjectPoint> trajectory(ThinningPolicy policy) const;
+  [[nodiscard]] ORPHEUS_API const EntityEnvelope &envelope() const;
+  ORPHEUS_API void add_point(ObjectPoint point);
+  [[nodiscard]] ORPHEUS_API std::vector<ObjectPoint> trajectory(
+      ThinningPolicy policy) const;
 
  private:
   EntityEnvelope envelope_;
   std::vector<ObjectPoint> points_;
 };
 
-class ORPHEUS_API Content {
+class Content {
  public:
-  explicit Content(EntityEnvelope envelope);
+  ORPHEUS_API explicit Content(EntityEnvelope envelope);
+  ORPHEUS_API ~Content();
 
-  const EntityEnvelope &envelope() const;
-  void attach_bed(std::size_t bed_index);
-  void attach_object(std::size_t object_index);
+  [[nodiscard]] ORPHEUS_API const EntityEnvelope &envelope() const;
+  ORPHEUS_API void attach_bed(std::size_t bed_index);
+  ORPHEUS_API void attach_object(std::size_t object_index);
 
-  const std::vector<std::size_t> &beds() const;
-  const std::vector<std::size_t> &objects() const;
+  [[nodiscard]] ORPHEUS_API const std::vector<std::size_t> &beds() const;
+  [[nodiscard]] ORPHEUS_API const std::vector<std::size_t> &objects() const;
 
  private:
   EntityEnvelope envelope_;
@@ -85,52 +89,60 @@ class ORPHEUS_API Content {
   std::vector<std::size_t> objects_;
 };
 
-class ORPHEUS_API Programme {
+class Programme {
  public:
-  explicit Programme(EntityEnvelope envelope);
+  ORPHEUS_API explicit Programme(EntityEnvelope envelope);
+  ORPHEUS_API ~Programme();
 
-  const EntityEnvelope &envelope() const;
-  void attach_content(std::size_t content_index);
-  const std::vector<std::size_t> &contents() const;
+  [[nodiscard]] ORPHEUS_API const EntityEnvelope &envelope() const;
+  ORPHEUS_API void attach_content(std::size_t content_index);
+  [[nodiscard]] ORPHEUS_API const std::vector<std::size_t> &contents() const;
 
  private:
   EntityEnvelope envelope_;
   std::vector<std::size_t> contents_;
 };
 
-class ORPHEUS_API EntityGraph {
+class EntityGraph {
  public:
-  Programme &add_programme(EntityEnvelope envelope);
-  Content &add_content(EntityEnvelope envelope);
-  Bed &add_bed(EntityEnvelope envelope);
-  Object &add_object(EntityEnvelope envelope);
+  ORPHEUS_API EntityGraph();
+  ORPHEUS_API ~EntityGraph();
 
-  void link_programme_to_content(const Programme &programme,
-                                 const Content &content);
-  void link_content_to_bed(const Content &content, const Bed &bed);
-  void link_content_to_object(const Content &content, const Object &object);
+  [[nodiscard]] ORPHEUS_API Programme &add_programme(EntityEnvelope envelope);
+  [[nodiscard]] ORPHEUS_API Content &add_content(EntityEnvelope envelope);
+  [[nodiscard]] ORPHEUS_API Bed &add_bed(EntityEnvelope envelope);
+  [[nodiscard]] ORPHEUS_API Object &add_object(EntityEnvelope envelope);
 
-  const Programme &programme_at(std::size_t index) const;
-  Programme &programme_at(std::size_t index);
-  const Content &content_at(std::size_t index) const;
-  Content &content_at(std::size_t index);
-  const Bed &bed_at(std::size_t index) const;
-  Bed &bed_at(std::size_t index);
-  const Object &object_at(std::size_t index) const;
-  Object &object_at(std::size_t index);
+  ORPHEUS_API void link_programme_to_content(const Programme &programme,
+                                             const Content &content);
+  ORPHEUS_API void link_content_to_bed(const Content &content,
+                                       const Bed &bed);
+  ORPHEUS_API void link_content_to_object(const Content &content,
+                                          const Object &object);
 
-  std::size_t programme_count() const;
-  std::size_t content_count() const;
-  std::size_t bed_count() const;
-  std::size_t object_count() const;
+  [[nodiscard]] ORPHEUS_API const Programme &programme_at(
+      std::size_t index) const;
+  [[nodiscard]] ORPHEUS_API Programme &programme_at(std::size_t index);
+  [[nodiscard]] ORPHEUS_API const Content &content_at(std::size_t index) const;
+  [[nodiscard]] ORPHEUS_API Content &content_at(std::size_t index);
+  [[nodiscard]] ORPHEUS_API const Bed &bed_at(std::size_t index) const;
+  [[nodiscard]] ORPHEUS_API Bed &bed_at(std::size_t index);
+  [[nodiscard]] ORPHEUS_API const Object &object_at(std::size_t index) const;
+  [[nodiscard]] ORPHEUS_API Object &object_at(std::size_t index);
 
-  std::string DebugDumpJson(ThinningPolicy policy) const;
+  [[nodiscard]] ORPHEUS_API std::size_t programme_count() const;
+  [[nodiscard]] ORPHEUS_API std::size_t content_count() const;
+  [[nodiscard]] ORPHEUS_API std::size_t bed_count() const;
+  [[nodiscard]] ORPHEUS_API std::size_t object_count() const;
+
+  [[nodiscard]] ORPHEUS_API std::string DebugDumpJson(
+      ThinningPolicy policy) const;
 
  private:
-  std::size_t programme_index(const Programme &programme) const;
-  std::size_t content_index(const Content &content) const;
-  std::size_t bed_index(const Bed &bed) const;
-  std::size_t object_index(const Object &object) const;
+  [[nodiscard]] std::size_t programme_index(const Programme &programme) const;
+  [[nodiscard]] std::size_t content_index(const Content &content) const;
+  [[nodiscard]] std::size_t bed_index(const Bed &bed) const;
+  [[nodiscard]] std::size_t object_index(const Object &object) const;
 
   std::deque<Programme> programmes_;
   std::deque<Content> contents_;
@@ -138,9 +150,10 @@ class ORPHEUS_API EntityGraph {
   std::deque<Object> objects_;
 };
 
-ORPHEUS_API std::string_view ToString(EntityKind kind);
-ORPHEUS_API std::string DebugDumpEnvelope(const EntityEnvelope &envelope);
-ORPHEUS_API std::vector<ObjectPoint> ThinTrajectory(
+[[nodiscard]] ORPHEUS_API std::string_view ToString(EntityKind kind);
+[[nodiscard]] ORPHEUS_API std::string DebugDumpEnvelope(
+    const EntityEnvelope &envelope);
+[[nodiscard]] ORPHEUS_API std::vector<ObjectPoint> ThinTrajectory(
     const std::vector<ObjectPoint> &points);
 
 }  // namespace orpheus::core::adm

--- a/include/orpheus/json.hpp
+++ b/include/orpheus/json.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <optional>
@@ -29,39 +30,39 @@ class ORPHEUS_API JsonParser {
  public:
   explicit JsonParser(std::string_view input);
 
-  JsonValue Parse();
+  [[nodiscard]] JsonValue Parse();
 
  private:
-  bool AtEnd() const;
-  char Peek() const;
+  [[nodiscard]] bool AtEnd() const;
+  [[nodiscard]] char Peek() const;
   char Consume();
   void SkipWhitespace();
 
   JsonValue ParseValue();
   JsonValue ParseObject();
   JsonValue ParseArray();
-  std::string ParseString();
-  bool ParseBoolean();
+  [[nodiscard]] std::string ParseString();
+  [[nodiscard]] bool ParseBoolean();
   void ParseNull();
-  double ParseNumber();
+  [[nodiscard]] double ParseNumber();
 
   std::string_view input_;
   std::size_t index_ = 0;
 };
 
-ORPHEUS_API const JsonValue &ExpectObject(const JsonValue &value,
-                                          const char *context);
-ORPHEUS_API const JsonValue &ExpectArray(const JsonValue &value,
-                                         const char *context);
-ORPHEUS_API const JsonValue *RequireField(const JsonValue &object,
-                                          const std::string &key);
-ORPHEUS_API double RequireNumber(const JsonValue &value,
-                                 const std::string &key);
-ORPHEUS_API std::string RequireString(const JsonValue &value,
-                                      const std::string &key);
+[[nodiscard]] ORPHEUS_API const JsonValue &ExpectObject(const JsonValue &value,
+                                                       const char *context);
+[[nodiscard]] ORPHEUS_API const JsonValue &ExpectArray(const JsonValue &value,
+                                                      const char *context);
+[[nodiscard]] ORPHEUS_API const JsonValue *RequireField(
+    const JsonValue &object, const std::string &key);
+[[nodiscard]] ORPHEUS_API double RequireNumber(const JsonValue &value,
+                                               const std::string &key);
+[[nodiscard]] ORPHEUS_API std::string RequireString(const JsonValue &value,
+                                                    const std::string &key);
 
 ORPHEUS_API std::string FormatDouble(double value);
-ORPHEUS_API void WriteIndent(std::ostringstream &stream, int indent);
+ORPHEUS_API void WriteIndent(std::ostringstream &stream, std::size_t indent);
 ORPHEUS_API std::string EscapeString(const std::string &value);
 
 }  // namespace orpheus::json

--- a/src/core/adm/entity_graph.cpp
+++ b/src/core/adm/entity_graph.cpp
@@ -84,6 +84,8 @@ void AppendEnvelopeJson(std::ostringstream &oss, const EntityEnvelope &envelope)
 
 Bed::Bed(EntityEnvelope envelope) : envelope_(std::move(envelope)) {}
 
+Bed::~Bed() = default;
+
 const EntityEnvelope &Bed::envelope() const { return envelope_; }
 
 void Bed::add_channel(BedChannel channel) {
@@ -93,6 +95,8 @@ void Bed::add_channel(BedChannel channel) {
 const std::vector<BedChannel> &Bed::channels() const { return channels_; }
 
 Object::Object(EntityEnvelope envelope) : envelope_(std::move(envelope)) {}
+
+Object::~Object() = default;
 
 const EntityEnvelope &Object::envelope() const { return envelope_; }
 
@@ -106,6 +110,8 @@ std::vector<ObjectPoint> Object::trajectory(ThinningPolicy policy) const {
 }
 
 Content::Content(EntityEnvelope envelope) : envelope_(std::move(envelope)) {}
+
+Content::~Content() = default;
 
 const EntityEnvelope &Content::envelope() const { return envelope_; }
 
@@ -128,6 +134,12 @@ const std::vector<std::size_t> &Content::objects() const { return objects_; }
 
 Programme::Programme(EntityEnvelope envelope)
     : envelope_(std::move(envelope)) {}
+
+Programme::~Programme() = default;
+
+EntityGraph::EntityGraph() = default;
+
+EntityGraph::~EntityGraph() = default;
 
 const EntityEnvelope &Programme::envelope() const { return envelope_; }
 

--- a/src/core/common/json_parser.cpp
+++ b/src/core/common/json_parser.cpp
@@ -336,7 +336,7 @@ std::string FormatDouble(double value) {
   return text;
 }
 
-void WriteIndent(std::ostringstream &stream, int indent) {
+void WriteIndent(std::ostringstream &stream, std::size_t indent) {
   stream << std::string(indent, ' ');
 }
 

--- a/src/core/otio/reconform_plan.cpp
+++ b/src/core/otio/reconform_plan.cpp
@@ -2,6 +2,7 @@
 #include "reconform_plan.h"
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <limits>
@@ -36,7 +37,7 @@ ReconformTimeRange ParseTimeRange(const JsonValue &value,
                                            context + ".duration_seconds")};
 }
 
-void WriteTimeRange(std::ostringstream &stream, int indent,
+void WriteTimeRange(std::ostringstream &stream, std::size_t indent,
                     const std::string &name, const ReconformTimeRange &range) {
   WriteIndent(stream, indent);
   stream << '"' << name << '"' << ": {\n";

--- a/src/core/session/session_graph.cpp
+++ b/src/core/session/session_graph.cpp
@@ -21,6 +21,8 @@ Clip::Clip(std::string name, double start_beats, double length_beats,
       length_beats_(std::max(length_beats, kMinimumLengthBeats)),
       scene_index_(scene_index) {}
 
+Clip::~Clip() = default;
+
 void Clip::set_start(double start_beats) { start_beats_ = start_beats; }
 
 void Clip::set_length(double length_beats) {
@@ -32,6 +34,8 @@ void Clip::set_scene_index(std::uint32_t scene_index) {
 }
 
 Track::Track(std::string name) : name_(std::move(name)) {}
+
+Track::~Track() = default;
 
 Clip *Track::add_clip(std::string name, double start_beats, double length_beats,
                       std::uint32_t scene_index) {
@@ -106,6 +110,8 @@ void Track::validate_clip_layout() const {
 
 MarkerSet::MarkerSet(std::string name) : name_(std::move(name)) {}
 
+MarkerSet::~MarkerSet() = default;
+
 MarkerSet::Marker *MarkerSet::add_marker(std::string name,
                                          double position_beats) {
   auto &marker = markers_.emplace_back();
@@ -140,7 +146,13 @@ MarkerSet::Marker *MarkerSet::find_marker(const Marker *marker) {
 PlaylistLane::PlaylistLane(std::string name, bool is_active)
     : name_(std::move(name)), is_active_(is_active) {}
 
+PlaylistLane::~PlaylistLane() = default;
+
+void PlaylistLane::set_active(bool active) { is_active_ = active; }
+
 SessionGraph::SessionGraph() : name_("Session") {}
+
+SessionGraph::~SessionGraph() = default;
 
 void SessionGraph::set_name(std::string name) { name_ = std::move(name); }
 

--- a/src/core/session/session_graph.h
+++ b/src/core/session/session_graph.h
@@ -13,14 +13,15 @@
 
 namespace orpheus::core {
 
-class ORPHEUS_API Clip {
+class Clip {
  public:
-  Clip(std::string name, double start_beats, double length_beats,
-       std::uint32_t scene_index = 0u);
+  ORPHEUS_API Clip(std::string name, double start_beats, double length_beats,
+                   std::uint32_t scene_index = 0u);
+  ORPHEUS_API ~Clip();
 
-  void set_start(double start_beats);
-  void set_length(double length_beats);
-  void set_scene_index(std::uint32_t scene_index);
+  ORPHEUS_API void set_start(double start_beats);
+  ORPHEUS_API void set_length(double length_beats);
+  ORPHEUS_API void set_scene_index(std::uint32_t scene_index);
 
   [[nodiscard]] double start() const { return start_beats_; }
   [[nodiscard]] double length() const { return length_beats_; }
@@ -34,21 +35,23 @@ class ORPHEUS_API Clip {
   std::uint32_t scene_index_;
 };
 
-class ORPHEUS_API Track {
+class Track {
  public:
-  explicit Track(std::string name);
+  ORPHEUS_API explicit Track(std::string name);
+  ORPHEUS_API ~Track();
 
   Track(const Track &) = delete;
   Track &operator=(const Track &) = delete;
-  Track(Track &&) noexcept = default;
-  Track &operator=(Track &&) noexcept = default;
+  ORPHEUS_API Track(Track &&) noexcept = default;
+  ORPHEUS_API Track &operator=(Track &&) noexcept = default;
 
   [[nodiscard]] const std::string &name() const { return name_; }
 
-  Clip *add_clip(std::string name, double start_beats, double length_beats,
-                 std::uint32_t scene_index = 0u);
-  bool remove_clip(const Clip *clip);
-  Clip *find_clip(const Clip *clip);
+  [[nodiscard]] ORPHEUS_API Clip *add_clip(std::string name, double start_beats,
+                                           double length_beats,
+                                           std::uint32_t scene_index = 0u);
+  [[nodiscard]] ORPHEUS_API bool remove_clip(const Clip *clip);
+  [[nodiscard]] ORPHEUS_API Clip *find_clip(const Clip *clip);
 
   [[nodiscard]] const std::vector<std::unique_ptr<Clip>> &clips() const {
     return clips_;
@@ -64,7 +67,7 @@ class ORPHEUS_API Track {
     return clips_.end();
   }
 
-  void sort_clips();
+  ORPHEUS_API void sort_clips();
 
  private:
   void validate_clip_layout() const;
@@ -75,20 +78,22 @@ class ORPHEUS_API Track {
   friend class SessionGraph;
 };
 
-class ORPHEUS_API MarkerSet {
+class MarkerSet {
  public:
   struct Marker {
     std::string name;
     double position_beats{0.0};
   };
 
-  explicit MarkerSet(std::string name);
+  ORPHEUS_API explicit MarkerSet(std::string name);
+  ORPHEUS_API ~MarkerSet();
 
   [[nodiscard]] const std::string &name() const { return name_; }
 
-  Marker *add_marker(std::string name, double position_beats);
-  bool remove_marker(const Marker *marker);
-  Marker *find_marker(const Marker *marker);
+  [[nodiscard]] ORPHEUS_API Marker *add_marker(std::string name,
+                                              double position_beats);
+  [[nodiscard]] ORPHEUS_API bool remove_marker(const Marker *marker);
+  [[nodiscard]] ORPHEUS_API Marker *find_marker(const Marker *marker);
 
   [[nodiscard]] const std::vector<Marker> &markers() const {
     return markers_;
@@ -107,14 +112,15 @@ class ORPHEUS_API MarkerSet {
   std::vector<Marker> markers_;
 };
 
-class ORPHEUS_API PlaylistLane {
+class PlaylistLane {
  public:
-  explicit PlaylistLane(std::string name, bool is_active = false);
+  ORPHEUS_API explicit PlaylistLane(std::string name, bool is_active = false);
+  ORPHEUS_API ~PlaylistLane();
 
   [[nodiscard]] const std::string &name() const { return name_; }
   [[nodiscard]] bool is_active() const { return is_active_; }
 
-  void set_active(bool active) { is_active_ = active; }
+  ORPHEUS_API void set_active(bool active);
 
  private:
   std::string name_;
@@ -139,30 +145,32 @@ struct ORPHEUS_API CommittedClip {
   double arranged_length_beats{0.0};
 };
 
-class ORPHEUS_API SessionGraph {
+class SessionGraph {
  public:
-  SessionGraph();
+  ORPHEUS_API SessionGraph();
+  ORPHEUS_API ~SessionGraph();
 
   SessionGraph(const SessionGraph &) = delete;
   SessionGraph &operator=(const SessionGraph &) = delete;
-  SessionGraph(SessionGraph &&) noexcept = default;
-  SessionGraph &operator=(SessionGraph &&) noexcept = default;
+  ORPHEUS_API SessionGraph(SessionGraph &&) noexcept = default;
+  ORPHEUS_API SessionGraph &operator=(SessionGraph &&) noexcept = default;
 
-  void set_name(std::string name);
+  ORPHEUS_API void set_name(std::string name);
   [[nodiscard]] const std::string &name() const { return name_; }
 
-  Track *add_track(std::string name);
-  bool remove_track(const Track *track);
+  [[nodiscard]] ORPHEUS_API Track *add_track(std::string name);
+  [[nodiscard]] ORPHEUS_API bool remove_track(const Track *track);
 
-  MarkerSet *add_marker_set(std::string name);
-  PlaylistLane *add_playlist_lane(std::string name, bool is_active = false);
+  [[nodiscard]] ORPHEUS_API MarkerSet *add_marker_set(std::string name);
+  [[nodiscard]] ORPHEUS_API PlaylistLane *add_playlist_lane(
+      std::string name, bool is_active = false);
 
-  void set_tempo(double bpm);
+  ORPHEUS_API void set_tempo(double bpm);
   [[nodiscard]] double tempo() const { return tempo_bpm_; }
 
-  void set_render_sample_rate(std::uint32_t sample_rate_hz);
-  void set_render_bit_depth(std::uint16_t bit_depth_bits);
-  void set_render_dither(bool enabled);
+  ORPHEUS_API void set_render_sample_rate(std::uint32_t sample_rate_hz);
+  ORPHEUS_API void set_render_bit_depth(std::uint16_t bit_depth_bits);
+  ORPHEUS_API void set_render_dither(bool enabled);
 
   [[nodiscard]] std::uint32_t render_sample_rate() const {
     return render_sample_rate_hz_;
@@ -172,9 +180,9 @@ class ORPHEUS_API SessionGraph {
   }
   [[nodiscard]] bool render_dither() const { return render_dither_enabled_; }
 
-  [[nodiscard]] TransportState transport_state() const;
+  [[nodiscard]] ORPHEUS_API TransportState transport_state() const;
 
-  void set_session_range(double start_beats, double end_beats);
+  ORPHEUS_API void set_session_range(double start_beats, double end_beats);
   [[nodiscard]] double session_start_beats() const {
     return session_start_beats_;
   }
@@ -182,19 +190,23 @@ class ORPHEUS_API SessionGraph {
     return session_end_beats_;
   }
 
-  Clip *add_clip(Track &track, std::string name, double start_beats,
-                double length_beats, std::uint32_t scene_index = 0u);
-  bool remove_clip(const Clip *clip);
-  void set_clip_start(Clip &clip, double start_beats);
-  void set_clip_length(Clip &clip, double length_beats);
-  void set_clip_scene(Clip &clip, std::uint32_t scene_index);
-  void commit_clip_grid();
+  [[nodiscard]] ORPHEUS_API Clip *add_clip(Track &track, std::string name,
+                                          double start_beats,
+                                          double length_beats,
+                                          std::uint32_t scene_index = 0u);
+  [[nodiscard]] ORPHEUS_API bool remove_clip(const Clip *clip);
+  ORPHEUS_API void set_clip_start(Clip &clip, double start_beats);
+  ORPHEUS_API void set_clip_length(Clip &clip, double length_beats);
+  ORPHEUS_API void set_clip_scene(Clip &clip, std::uint32_t scene_index);
+  ORPHEUS_API void commit_clip_grid();
 
-  void trigger_scene(std::uint32_t scene_index, double position_beats,
-                     const QuantizationWindow &quantization);
-  void end_scene(std::uint32_t scene_index, double position_beats,
-                 const QuantizationWindow &quantization);
-  void commit_arrangement(double fallback_scene_length_beats = 0.0);
+  ORPHEUS_API void trigger_scene(std::uint32_t scene_index,
+                                 double position_beats,
+                                 const QuantizationWindow &quantization);
+  ORPHEUS_API void end_scene(std::uint32_t scene_index, double position_beats,
+                             const QuantizationWindow &quantization);
+  ORPHEUS_API void commit_arrangement(
+      double fallback_scene_length_beats = 0.0);
 
   [[nodiscard]] const std::vector<CommittedClip> &committed_clips() const {
     return committed_clips_;


### PR DESCRIPTION
## Summary
- export API methods instead of STL-owning classes within the ADM entity graph headers and define explicit destructors where needed
- restructure session graph API exports and annotate frequently used accessors with [[nodiscard]] to support warning-free builds
- tighten JSON helpers by switching WriteIndent to size_t, adding [[nodiscard]] annotations, and adjusting call sites

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5ca1b7ee4832cbaeb114f0a52eb8b