### PR TITLE
Add NOMINMAX guard and lint for windows includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 1 }
+      - name: Lint Windows includes
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import sys
+
+          ROOT = pathlib.Path('.')
+          violations = []
+          for path in ROOT.rglob('*'):
+            if not path.is_file():
+              continue
+            try:
+              relative = path.relative_to(ROOT)
+            except ValueError:
+              continue
+            parts = set(relative.parts)
+            if 'backup' in parts:
+              continue
+            if path.suffix.lower() not in {
+                '.c', '.cc', '.cxx', '.cpp', '.h', '.hh', '.hpp', '.hxx', '.inl'
+            }:
+              continue
+            try:
+              text = path.read_text(encoding='utf-8')
+            except UnicodeDecodeError:
+              continue
+            lines = text.splitlines()
+            for index, line in enumerate(lines):
+              if '#include <windows.h>' not in line:
+                continue
+              prior = lines[:index]
+              if not any('#define NOMINMAX' in candidate for candidate in prior):
+                violations.append(f"{path}:{index + 1}")
+
+          if violations:
+            print('Found #include <windows.h> without prior #define NOMINMAX:')
+            for violation in violations:
+              print(f"  {violation}")
+            sys.exit(1)
+          PY
       - name: Configure
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} $([[ "${{ matrix.build_type }}" == "Debug" ]] && echo "-DORP_ENABLE_SANITIZERS=ON")

--- a/apps/juce-demo-host/Source/Main.cpp
+++ b/apps/juce-demo-host/Source/Main.cpp
@@ -20,6 +20,8 @@
 #include <vector>
 
 #if JUCE_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <dlfcn.h>

--- a/tests/abi_link/main.cpp
+++ b/tests/abi_link/main.cpp
@@ -12,6 +12,7 @@
 
 #if defined(_WIN32)
   #define WIN32_LEAN_AND_MEAN
+  #define NOMINMAX
   #include <windows.h>
 #elif defined(__APPLE__)
   #include <dlfcn.h>


### PR DESCRIPTION
## Summary
- define NOMINMAX before including <windows.h> in the ABI link test and JUCE demo host
- add a CI lint step that fails if any translation unit includes <windows.h> without the NOMINMAX guard

## Testing
- python3 - <<'PY' ... (lint script)


------
https://chatgpt.com/codex/tasks/task_e_68e5cff0be60832c87977122621f970e