### PR TITLE
Fix pthread detection on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,17 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(WIN32)
+  set(CMAKE_THREAD_PREFER_PTHREAD OFF)
+  set(THREADS_PREFER_PTHREAD_FLAG OFF)
+endif()
+
+find_package(Threads REQUIRED)
+
+if(TARGET Threads::Threads AND NOT WIN32)
+  set(ORPHEUS_THREADS_TARGET Threads::Threads)
+endif()
+
 if(APPLE)
   # Force a single architecture slice and ensure libc++ is used across all builds.
   set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "" FORCE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,10 @@ target_link_libraries(orpheus_tests
     GTest::gtest_main
 )
 
+if(ORPHEUS_THREADS_TARGET)
+  target_link_libraries(orpheus_tests PRIVATE ${ORPHEUS_THREADS_TARGET})
+endif()
+
 target_compile_definitions(orpheus_tests
   PRIVATE
     ORPHEUS_SESSION_FIXTURES_DIR="${CMAKE_SOURCE_DIR}/tests/fixtures/session"


### PR DESCRIPTION
## Summary
- disable pthread preference when configuring threads on Windows and require Threads package
- expose the imported Threads::Threads target for non-Windows builds and link tests against it when available

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_e_68e5d0fa32d8832c9f27c046d8e35e95