### PR TITLE
Centralize compiler warnings configuration

### DIFF
--- a/apps/juce-demo-host/CMakeLists.txt
+++ b/apps/juce-demo-host/CMakeLists.txt
@@ -55,3 +55,6 @@ target_link_libraries(orpheus_demo_host_app
 set_target_properties(orpheus_demo_host_app PROPERTIES
   OUTPUT_NAME "OrpheusDemoHost"
 )
+
+include(${CMAKE_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
+orpheus_enable_warnings(orpheus_demo_host_app)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,8 +1,15 @@
 # SPDX-License-Identifier: MIT
+
 function(orpheus_enable_warnings target)
   if(MSVC)
-    target_compile_options(${target} PRIVATE /W4 /permissive-)
+    target_compile_options(${target} PRIVATE
+      /W4 /WX /permissive- /Zc:preprocessor /Zc:__cplusplus /EHsc
+      /wd5105
+      /external:W0 /external:anglebrackets /experimental:external
+    )
   else()
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(${target} PRIVATE
+      -Wall -Wextra -Werror -Wconversion -Wsign-conversion
+    )
   endif()
 endfunction()

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -9,6 +9,9 @@ add_executable(orpheus_find_package_smoke main.cpp)
 
 target_link_libraries(orpheus_find_package_smoke PRIVATE Orpheus::core)
 
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/CompilerWarnings.cmake)
+orpheus_enable_warnings(orpheus_find_package_smoke)
+
 if(APPLE)
   add_compile_options(-stdlib=libc++)
   add_link_options(-stdlib=libc++)

--- a/tools/conformance/CMakeLists.txt
+++ b/tools/conformance/CMakeLists.txt
@@ -20,6 +20,9 @@ target_compile_definitions(orpheus_conformance_json
     ORPHEUS_FIXTURES_DIR="${CMAKE_SOURCE_DIR}/tools/fixtures"
 )
 
+include(${CMAKE_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
+orpheus_enable_warnings(orpheus_conformance_json)
+
 include(GoogleTest)
 set(TEST_NAME conformance_json)
 add_test(NAME ${TEST_NAME} COMMAND orpheus_conformance_json)


### PR DESCRIPTION
## Summary
- add a reusable CMake helper that enforces strict warnings while silencing diagnostics from external headers
- apply the warning policy to remaining executables that previously missed it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d2648194832c816c727f513fb0de