### PR TITLE
Clarify lint pipeline documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,8 @@ When working on Orpheus SDK code, understand:
 
 - **Language:** C++20
 - **Scope:** Portable across Windows/macOS/Linux (ARM64 and x86_64)
-- **Build System:** CMake + ctest; CI uses clang-format, clang-tidy, AddressSanitizer
+- **Build System:** CMake + ctest; CI enforces clang-format, runs sanitizer builds,
+  and ships a `.clang-tidy` configuration for optional local analysis
 - **Core Features:** 
   - SessionGraph (tracks, clips, tempo, transport)
   - Deterministic render path (offline or real-time)
@@ -180,7 +181,8 @@ ctest --test-dir build --output-on-failure
 ```
 
 **Requirements:**
-- Enforce `.clang-format` + `.clang-tidy` (CI fails if violated)
+- Match the repository `.clang-format`; clang-tidy findings are encouraged but not
+  currently CI-blocking (run `clang-tidy -p build` locally if needed)
 - Keep adapters ≤300 LOC when possible
 - Preserve float determinism across OSes (use `std::bit_cast`, avoid undefined behavior)
 - No allocations in audio callback threads (use lock-free structures, pre-allocate)

--- a/README.md
+++ b/README.md
@@ -162,12 +162,17 @@ graph instead of writing audio.
 
 - **Sanitizers** – AddressSanitizer and UBSan are enabled automatically for
   Debug builds on non-MSVC toolchains.
-- **Static analysis** – `.clang-format`, `.clang-tidy`, and workspace linting
-  scripts (see `package.json`) enforce consistent style across C++ and
-  TypeScript.
+- **Formatting & linting** – GitHub Actions runs `clang-format` against the C++
+  sources and executes the workspace linting scripts for TypeScript (see
+  `package.json`). A project-wide `.clang-tidy` configuration is available for
+  local static analysis, but it is not currently a required CI gate.
 - **Continuous Integration** – GitHub Actions builds and tests the C++ targets
-  and runs formatting/linting checks for the monorepo on Linux, macOS, and
-  Windows.
+  on Linux, macOS, and Windows, verifies sanitizer builds, and checks for
+  accidentally committed binary artifacts.
+
+To experiment with `clang-tidy` locally, configure a build with
+`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and invoke `clang-tidy -p build` (or the
+LLVM `run-clang-tidy.py` helper) on the files you want to inspect.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- update README tooling section to reflect current CI formatting checks and optional clang-tidy usage
- align AGENTS guidance with the active clang-format enforcement and optional clang-tidy workflow
- document a quick command for contributors who want to experiment with clang-tidy locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9ba239108832c96cf28c38d9924d9