### PR TITLE
chore: guard puppeteer downloads during validation

### DIFF
--- a/scripts/lib/phase-validation.sh
+++ b/scripts/lib/phase-validation.sh
@@ -8,6 +8,12 @@ fi
 
 : "${REPO_ROOT:?REPO_ROOT must be set before sourcing phase-validation.sh}"
 
+# Ensure Puppeteer never attempts to download Chromium as part of validation
+# workflows. These exports can be overridden by callers, but default to skip
+# downloads for CI and bootstrap scripts that source this helper.
+export PUPPETEER_SKIP_DOWNLOAD=${PUPPETEER_SKIP_DOWNLOAD:-1}
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=${PUPPETEER_SKIP_CHROMIUM_DOWNLOAD:-1}
+
 CHECK_MARK="✓"
 CROSS_MARK="✗"
 ARROW="→"

--- a/scripts/validate-phase0.sh
+++ b/scripts/validate-phase0.sh
@@ -24,6 +24,12 @@ else
 fi
 
 echo "→ Installing dependencies (frozen lockfile)"
+# Prevent Puppeteer from downloading Chromium during validation runs. This mirrors
+# the guard used in bootstrap scripts so CI remains lean while still allowing
+# contributors to opt-in by pre-setting these variables differently.
+export PUPPETEER_SKIP_DOWNLOAD=${PUPPETEER_SKIP_DOWNLOAD:-1}
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=${PUPPETEER_SKIP_CHROMIUM_DOWNLOAD:-1}
+
 set +e
 pnpm install --frozen-lockfile
 rc=$?


### PR DESCRIPTION
## Summary
- export Puppeteer skip flags in validate-phase0 to avoid Chromium downloads during installs
- propagate the same environment defaults through phase-validation helpers so downstream steps inherit them

## Testing
- scripts/validate-phase0.sh

------
https://chatgpt.com/codex/tasks/task_e_68e9bdd8902c832c993f1e77b3acea14