### PR TITLE
feat(audio): ORP121 Audio Backend Refactoring - Phases 1-3

### DIFF
--- a/docs/orp/GAIN_STAGING.md
+++ b/docs/orp/GAIN_STAGING.md
@@ -1,0 +1,177 @@
+# Orpheus SDK Gain Staging Model
+
+**ORP121 A-06** | Last Updated: 2026-01-17
+
+## Overview
+
+This document defines the gain staging architecture for the Orpheus audio backend. The design follows broadcast industry standards (ST2110, ITU-R BS.775) and provides ~1528 dB of internal headroom with 32-bit float processing.
+
+## Signal Flow
+
+```
+Source File (0 dBFS normalized)
+       │
+       ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ FORMAT HANDLING (ORP121 A-01)                                    │
+│                                                                  │
+│ Mono:        Duplicate to L/R (phantom center)                   │
+│ Stereo:      Direct L→L, R→R mapping                             │
+│ Multi-ch:    ITU-R BS.775-3 downmix to stereo                    │
+│              L_out = L + 0.707*C + 0.707*Ls                      │
+│              R_out = R + 0.707*C + 0.707*Rs                      │
+└──────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Clip Gain            │  User setting: -inf to +12 dB
+│ (clip.gainLinear)    │  Applied in: TransportController::processAudio()
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Fade Gain            │  Envelope: 0.0 to 1.0
+│ (calculateFadeGain)  │  Types: FadeIn, FadeOut, RestartCrossfade, StopFade
+│                      │  Curves: Linear, EqualPower, SCurve, Logarithmic
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ ROUTING MATRIX INPUT (ST2110-aligned)                            │
+│                                                                  │
+│ Each clip outputs to 2 independent channels (L/R)                │
+│ Channel index: clip * 2 + 0 = L, clip * 2 + 1 = R                │
+│ Total routing channels: MAX_ACTIVE_CLIPS * 2 = 64                │
+└──────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Channel Gain         │  User setting: -inf to +12 dB
+│ (channel.gain)       │  Applied in: RoutingMatrix::processRouting()
+│                      │  Per-channel, smoothed (GainSmoother)
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Pan Law              │  Position: -1.0 to +1.0
+│ (constant power)     │  ORP121 C-04: Constant-power pan law
+│                      │  L/R coefficients: sqrt((1-pan)/2), sqrt((1+pan)/2)
+│                      │  Center: L=R=0.707 (-3 dB each)
+│                      │  Hard L: L=1.0, R=0.0
+│                      │  Hard R: L=0.0, R=1.0
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Stereo Group Buffers │  ORP121 A-02: True stereo imaging
+│ (StereoGroupBuffer)  │  Each group has L/R channel pair
+│                      │  Additive summing (no auto-compensation)
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Group Gain           │  User setting: -inf to +12 dB
+│ (group.gain)         │  Applied per-group before output bus
+│                      │  Per-group, smoothed (GainSmoother)
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Output Bus Routing   │  ORP121 A-03: Configurable output buses
+│ (group.output_bus)   │  Bus 0 = channels 0-1, Bus 1 = 2-3, etc.
+│                      │  Groups sum into their assigned bus
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Master Gain          │  User setting: -inf to +12 dB
+│ (master.gain)        │  Final output level control
+│                      │  Smoothed (GainSmoother)
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Soft Limiter         │  ORP121 C-02: Soft-knee tanh limiter
+│                      │  Threshold: -2 dBFS (0.794 linear)
+│                      │  Knee width: 0.3
+│                      │  Ceiling: -0.001 dBFS (0.9999 linear)
+│                      │  C1 continuous (no audible discontinuity)
+└──────────────────────┘
+       │
+       ▼
+Output (broadcast-safe: -1.0 to +1.0)
+```
+
+## Gain Ranges
+
+| Stage | Min | Max | Unit | Notes |
+|-------|-----|-----|------|-------|
+| Clip Gain | -inf | +12 | dB | Per-clip, precomputed linear |
+| Channel Gain | -inf | +12 | dB | Per-routing-channel |
+| Group Gain | -inf | +12 | dB | Per-group |
+| Master Gain | -inf | +12 | dB | Global |
+| Pan | -1.0 | +1.0 | position | Constant-power law |
+
+## Headroom Analysis
+
+### Internal Processing
+
+32-bit IEEE 754 float provides:
+- Maximum value: ~3.4×10³⁸
+- Minimum positive: ~1.2×10⁻³⁸
+- Dynamic range: ~1528 dB
+
+**Conclusion:** Internal headroom is effectively unlimited. Gain staging is about signal quality, not overflow prevention.
+
+### Clipping Points
+
+Clipping occurs only at:
+
+1. **Soft Limiter** (intentional, C1 continuous)
+   - Threshold: -2 dBFS
+   - Gradual compression above threshold
+   - Hard ceiling: -0.001 dBFS
+
+2. **DAC Output** (hardware)
+   - Must stay within ±1.0
+   - Protected by soft limiter
+
+## Recommended Gain Structure
+
+For broadcast/live use:
+
+| Stage | Recommended | Rationale |
+|-------|-------------|-----------|
+| Source files | -18 dBFS RMS, -6 dBFS peak | EBU R128 alignment |
+| Clip gains | 0 dB (unity) | Preserve source normalization |
+| Channel gains | 0 dB (unity) | Default, adjust as needed |
+| Group gains | -6 to 0 dB | Submix balance |
+| Master gain | -3 to 0 dB | Final trim before limiter |
+
+This structure provides ~12-18 dB of headroom at each summing stage.
+
+## Smoothing
+
+All gain controls use `GainSmoother` for click-free transitions:
+- Default smoothing time: 10ms (configurable)
+- Lock-free atomic target updates
+- Linear ramping to prevent discontinuities
+
+**Exception:** Clip-level fades use dedicated fade curves (not smoothing) to prevent artifacts with rapid clip triggers.
+
+## Thread Safety
+
+| Operation | Thread | Mechanism |
+|-----------|--------|-----------|
+| Gain setting | UI | Atomic write to pending target |
+| Gain smoothing | Audio | Per-sample ramping from GainSmoother |
+| Meter reading | UI | Atomic read from peak/RMS values |
+
+All gain operations are lock-free and broadcast-safe.
+
+## References
+
+- ORP121: Audio Backend Refactoring Master Plan
+- ITU-R BS.775-3: Multi-channel stereophonic sound system
+- ST2110-30: Professional Media Over Managed IP Networks - PCM Digital Audio
+- EBU R128: Loudness normalisation and permitted maximum level

--- a/docs/orp/ORP121 Audio Backend Refactoring Master Plan.md
+++ b/docs/orp/ORP121 Audio Backend Refactoring Master Plan.md
@@ -1,0 +1,1334 @@
+# ORP121: Audio Backend Refactoring Master Plan
+
+**Status:** Planning Complete
+**Priority:** HIGH
+**Date:** 2026-01-18
+**Author:** Audio Architecture Consultant (Claude)
+**Scope:** SDK Core Audio Backend (transport, routing, gain staging, multi-channel)
+**Prerequisites:** ORP114 (gain staging bug fixes) should be completed first
+
+---
+
+## Executive Summary
+
+Comprehensive audit of the Orpheus SDK audio backend identified **23 discrete issues** across 6 categories. This document provides a complete implementation plan to close all gaps and achieve production-ready status for broadcast/theater applications.
+
+**Key Findings:**
+- **4 Critical bugs** requiring immediate fix (GainSmoother range, tanh discontinuity, callback mutex, pan law)
+- **6 Architectural gaps** blocking professional use (stereo routing, multi-channel, output bus wiring)
+- **13 Quality improvements** for long-term maintainability (nomenclature, documentation, testing)
+
+**Estimated Total Effort:** 48-64 engineering hours across 4 phases
+
+---
+
+## Table of Contents
+
+1. [Issue Registry](#1-issue-registry)
+2. [Phase 1: Critical Bug Fixes](#2-phase-1-critical-bug-fixes)
+3. [Phase 2: Stereo Routing Implementation](#3-phase-2-stereo-routing-implementation)
+4. [Phase 3: Multi-Channel Architecture](#4-phase-3-multi-channel-architecture)
+5. [Phase 4: Quality & Nomenclature](#5-phase-4-quality--nomenclature)
+6. [Acceptance Criteria](#6-acceptance-criteria)
+7. [Test Plan](#7-test-plan)
+8. [Risk Assessment](#8-risk-assessment)
+9. [File Index](#9-file-index)
+
+---
+
+## 1. Issue Registry
+
+### 1.1 Critical Issues (P0)
+
+| ID | Issue | Location | Impact | Effort |
+|----|-------|----------|--------|--------|
+| **C-01** | GainSmoother clips at 0 dB | `gain_smoother.cpp:22` | Cannot apply gain boosts (+1 to +12 dB) | 15 min |
+| **C-02** | tanh limiter discontinuity | `routing_matrix.cpp:687-688` | Audible click at 0.9 threshold | 30 min |
+| **C-03** | Callback mutex in audio path | `transport_controller.cpp:916-928` | Priority inversion risk | 2 hrs |
+| **C-04** | Pan law values discarded | `routing_matrix.cpp:567-571` | No stereo positioning | 1 hr |
+
+### 1.2 Architectural Issues (P1)
+
+| ID | Issue | Location | Impact | Effort |
+|----|-------|----------|--------|--------|
+| **A-01** | Mono summing before routing | `transport_controller.cpp:460-468` | Stereo width lost | 4 hrs |
+| **A-02** | Mono group buffers | `routing_matrix.cpp:580-581` | No true stereo image | 4 hrs |
+| **A-03** | Output bus routing ignored | `routing_matrix.cpp:623-626` | Multi-output unusable | 2 hrs |
+| **A-04** | No multi-channel format abstraction | N/A (missing) | No surround/Atmos support | 8 hrs |
+| **A-05** | No upmix/downmix matrices | N/A (missing) | Cannot convert formats | 4 hrs |
+| **A-06** | Double gain application unclear | `transport_controller.cpp` + `routing_matrix.cpp` | Confusing gain staging | 2 hrs |
+
+### 1.3 Quality Issues (P2)
+
+| ID | Issue | Location | Impact | Effort |
+|----|-------|----------|--------|--------|
+| **Q-01** | Mixed case styles | Throughout headers | Inconsistent API | 4 hrs |
+| **Q-02** | Inconsistent terminology | `group` vs `bus`, `handle` vs `id` | Confusing naming | 4 hrs |
+| **Q-03** | Sample rate hardcoded | `routing_matrix.cpp:59,708,751` | 48kHz assumption | 1 hr |
+| **Q-04** | No true-peak metering | `routing_matrix.h:52` | LUFS mode stub only | 4 hrs |
+| **Q-05** | No headroom management | `routing_matrix.cpp:580` | Clip summing can overflow | 2 hrs |
+| **Q-06** | Missing gain staging documentation | N/A | Unclear signal flow | 2 hrs |
+| **Q-07** | No threading stress tests | `tests/transport/` | Race conditions untested | 4 hrs |
+| **Q-08** | No waveform rendering perf tests | `tests/` | UI freeze undetected | 2 hrs |
+| **Q-09** | Silent error handling | `AudioEngine.cpp` | Failures unlogged | 2 hrs |
+| **Q-10** | Cue buss dynamic allocation | `AudioEngine.cpp:537-579` | Memory fragmentation | 2 hrs |
+| **Q-11** | Hard-coded button limits | `AudioEngine.h:308` | 384 max, need 960 | 3 hrs |
+| **Q-12** | No CPU/memory profiling API | N/A | Hard to diagnose | 4 hrs |
+| **Q-13** | Incomplete Doxygen coverage | Various headers | API underdocumented | 4 hrs |
+
+---
+
+## 2. Phase 1: Critical Bug Fixes
+
+**Objective:** Resolve all P0 issues
+**Effort:** 4-6 hours
+**Risk:** Low (isolated changes, high test coverage)
+
+### 2.1 Task C-01: Fix GainSmoother Range
+
+**File:** `src/core/routing/gain_smoother.cpp`
+
+**Current Code (Line 22):**
+```cpp
+target = std::clamp(target, 0.0f, 1.0f);  // BUG: Clips at unity gain
+```
+
+**Fixed Code:**
+```cpp
+// ORP121 C-01: Allow gains up to +12 dB (3.981 linear)
+// Rationale: Professional mixing requires boost capability
+// 32-bit float provides ~1528 dB headroom, clipping at output stage is sufficient
+static constexpr float MAX_LINEAR_GAIN = 3.981071705534972f;  // 10^(12/20) = +12 dB
+target = std::clamp(target, 0.0f, MAX_LINEAR_GAIN);
+```
+
+**Also Update:**
+- `gain_smoother.h` - Add `static constexpr float MAX_GAIN_DB = 12.0f;`
+- `routing_matrix.cpp:127` - Verify gain range matches (-60 to +12 dB)
+
+**Acceptance Criteria:**
+- [ ] `setChannelGain(ch, 6.0f)` results in 2x linear gain (not 1.0)
+- [ ] `setChannelGain(ch, 12.0f)` results in ~4x linear gain
+- [ ] Existing unit tests pass
+- [ ] No audible artifacts in gain transitions
+
+---
+
+### 2.2 Task C-02: Fix tanh Limiter Discontinuity
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code (Lines 687-688):**
+```cpp
+if (std::abs(sample) > 0.9f) {
+  sample = std::tanh(sample * 0.9f) / 0.9f;  // BUG: Discontinuity at 0.9
+}
+```
+
+**Problem Analysis:**
+- At `sample = 0.9`: Output = 0.9 (unchanged, just above threshold)
+- At `sample = 0.9001`: Output = tanh(0.81009) / 0.9 = 0.796 (jump down!)
+- This creates a **discontinuity of ~0.104** causing audible clicks
+
+**Fixed Code:**
+```cpp
+// ORP121 C-02: Continuous soft-knee limiter
+// Uses soft-knee compression starting at -2 dBFS (0.794) with smooth transition
+// Prevents discontinuity while maintaining headroom protection
+static constexpr float THRESHOLD = 0.794f;     // -2 dBFS
+static constexpr float KNEE_WIDTH = 0.3f;      // Soft knee range
+static constexpr float CEILING = 0.9999f;      // Final hard limit
+
+float abs_sample = std::abs(sample);
+if (abs_sample > THRESHOLD) {
+  // Soft-knee: tanh saturation with continuous curve
+  float excess = abs_sample - THRESHOLD;
+  float knee_ratio = excess / KNEE_WIDTH;
+  float compressed = THRESHOLD + std::tanh(knee_ratio) * KNEE_WIDTH;
+  sample = std::copysign(std::min(compressed, CEILING), sample);
+}
+```
+
+**Mathematical Verification:**
+- At threshold (0.794): excess = 0, tanh(0) = 0, output = 0.794 (continuous)
+- At 1.0: excess = 0.206, tanh(0.687) = 0.596, output = 0.794 + 0.179 = 0.973
+- At 2.0: excess = 1.206, tanh(4.02) = 0.999, output = 0.794 + 0.300 = 1.094 -> clamped to 0.9999
+- **Curve is C1 continuous** (no jumps, smooth derivative)
+
+**Acceptance Criteria:**
+- [ ] No audible click when signal crosses 0.9 threshold
+- [ ] Output never exceeds +-1.0
+- [ ] Sine wave at 1.5x amplitude produces smooth saturation curve
+- [ ] THD measurement shows gradual increase (no discontinuity spike)
+
+---
+
+### 2.3 Task C-03: Lock-Free Callback Queue
+
+**File:** `src/core/transport/transport_controller.cpp`
+
+**Current Code (Lines 916-928):**
+```cpp
+void TransportController::postCallback(std::function<void()> callback) {
+  std::lock_guard<std::mutex> lock(m_callbackMutex);  // BUG: Mutex in audio path
+  m_callbackQueue.push(std::move(callback));
+}
+
+void TransportController::processCallbacks() {
+  std::lock_guard<std::mutex> lock(m_callbackMutex);
+  while (!m_callbackQueue.empty()) {
+    auto callback = std::move(m_callbackQueue.front());
+    m_callbackQueue.pop();
+    callback();
+  }
+}
+```
+
+**Problem:**
+- `postCallback()` called from audio thread (processAudio)
+- `processCallbacks()` called from UI thread (timerCallback)
+- Mutex contention can cause priority inversion (audio thread waits for UI thread)
+
+**Fixed Code:**
+```cpp
+// ORP121 C-03: Lock-free SPSC callback queue
+// Audio thread writes, UI thread reads - no contention
+
+// In header (transport_controller.h):
+static constexpr size_t CALLBACK_QUEUE_SIZE = 256;  // Power of 2 for masking
+std::array<std::function<void()>, CALLBACK_QUEUE_SIZE> m_callbackRing;
+std::atomic<size_t> m_callbackWriteIndex{0};
+std::atomic<size_t> m_callbackReadIndex{0};
+
+// In implementation:
+void TransportController::postCallback(std::function<void()> callback) {
+  // Audio thread: Write to ring buffer (lock-free)
+  size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_relaxed);
+  size_t nextIdx = (writeIdx + 1) & (CALLBACK_QUEUE_SIZE - 1);  // Mask for wrap
+
+  // Check if queue full (read index caught up)
+  if (nextIdx == m_callbackReadIndex.load(std::memory_order_acquire)) {
+    // Queue full - drop callback (better than blocking audio thread)
+    // TODO: Increment dropped callback counter for diagnostics
+    return;
+  }
+
+  m_callbackRing[writeIdx] = std::move(callback);
+  m_callbackWriteIndex.store(nextIdx, std::memory_order_release);
+}
+
+void TransportController::processCallbacks() {
+  // UI thread: Read from ring buffer (lock-free)
+  size_t readIdx = m_callbackReadIndex.load(std::memory_order_relaxed);
+  size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_acquire);
+
+  while (readIdx != writeIdx) {
+    auto& callback = m_callbackRing[readIdx];
+    if (callback) {
+      callback();
+      callback = nullptr;  // Clear slot
+    }
+    readIdx = (readIdx + 1) & (CALLBACK_QUEUE_SIZE - 1);
+  }
+
+  m_callbackReadIndex.store(readIdx, std::memory_order_release);
+}
+```
+
+**Memory Ordering Rationale:**
+- `relaxed` for same-thread reads (writeIdx in postCallback, readIdx in processCallbacks)
+- `acquire` for cross-thread reads (writeIdx in processCallbacks, readIdx in postCallback)
+- `release` for writes (ensures callback data visible before index update)
+
+**Acceptance Criteria:**
+- [ ] No mutex in audio path (verify with ThreadSanitizer)
+- [ ] Callbacks still delivered correctly (UI receives clip state changes)
+- [ ] Queue overflow handled gracefully (no crash, diagnostic counter)
+- [ ] Stress test: 10,000 callbacks/second without drops
+
+---
+
+### 2.4 Task C-04: Wire Pan Law Application
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code (Lines 567-571):**
+```cpp
+float pan_left = channel.pan_left->process();
+float pan_right = channel.pan_right->process();
+(void)pan_left;  // Unused for now
+(void)pan_right; // Unused for now
+```
+
+**Problem:** Pan smoothers compute values but results are discarded. All clips play center.
+
+**Fixed Code:**
+```cpp
+// ORP121 C-04: Apply constant-power pan law
+// Pan position: -1.0 (left) to +1.0 (right), 0.0 = center
+// Constant-power: -3 dB at center (sqrt(0.5) ≈ 0.707)
+// This ensures perceived loudness is constant across pan positions
+
+float pan_left = channel.pan_left->process();    // Left channel coefficient
+float pan_right = channel.pan_right->process();  // Right channel coefficient
+
+// Apply pan to mono source -> stereo output
+// For now, source is mono (sample), output is stereo (group_buffer_L/R)
+float sample_L = sample * pan_left;
+float sample_R = sample * pan_right;
+
+// Sum into stereo group buffers (see Task A-02 for buffer changes)
+group_buffer_L[frame] += sample_L;
+group_buffer_R[frame] += sample_R;
+```
+
+**Pan Coefficient Calculation** (update `setChannelPan()`):
+```cpp
+SessionGraphError RoutingMatrix::setChannelPan(uint8_t channel_index, float pan) {
+  // pan: -1.0 (left) to +1.0 (right)
+  pan = std::clamp(pan, -1.0f, 1.0f);
+
+  // Constant-power pan law: L^2 + R^2 = 1
+  // At center (pan=0): L = R = sqrt(0.5) ≈ 0.707 (-3 dB each)
+  // At hard left (pan=-1): L = 1.0, R = 0.0
+  // At hard right (pan=+1): L = 0.0, R = 1.0
+
+  float angle = (pan + 1.0f) * 0.25f * M_PI;  // 0 to pi/2
+  float pan_left = std::cos(angle);
+  float pan_right = std::sin(angle);
+
+  auto& channel = m_channels[channel_index];
+  channel.pan_left->setTarget(pan_left);
+  channel.pan_right->setTarget(pan_right);
+
+  return SessionGraphError::OK;
+}
+```
+
+**Note:** This task requires stereo group buffers (Task A-02). If implementing before A-02, use temporary stereo output.
+
+**Acceptance Criteria:**
+- [ ] Pan = -1.0 outputs only to left channel
+- [ ] Pan = +1.0 outputs only to right channel
+- [ ] Pan = 0.0 outputs equal level to both channels
+- [ ] Panning a clip preserves perceived loudness (constant power)
+- [ ] Pan changes are smoothed (no zipper noise)
+
+---
+
+## 3. Phase 2: Stereo Routing Implementation
+
+**Objective:** Enable true stereo signal flow through the routing matrix
+**Effort:** 12-16 hours
+**Risk:** Medium (structural changes, requires thorough testing)
+**Dependencies:** Phase 1 complete
+
+### 3.1 Task A-01: Preserve Stereo From Source
+
+**File:** `src/core/transport/transport_controller.cpp`
+
+**Current Code (Lines 460-468):**
+```cpp
+// Mix all file channels to mono for routing
+float monoSample = 0.0f;
+for (size_t ch = 0; ch < numFileChannels; ++ch) {
+  monoSample += clipReadBuffer[srcIndex];
+}
+monoSample /= static_cast<float>(numFileChannels);  // Average to mono
+```
+
+**Problem:** Multi-channel files collapsed to mono before any processing.
+
+**Fixed Code:**
+```cpp
+// ORP121 A-01: Preserve source channel separation
+// Files output to L/R clip buffers based on source format:
+// - Mono: Duplicate to both L/R
+// - Stereo: Direct mapping L->L, R->R
+// - Multi-channel: Use standard downmix or direct routing
+
+// New member variables (in transport_controller.h):
+// std::vector<std::array<std::vector<float>, 2>> m_clipChannelBuffersStereo;
+
+// Process stereo-aware output
+float gainedSample_L, gainedSample_R;
+
+if (numFileChannels == 1) {
+  // Mono source: Duplicate to both channels (center phantom image)
+  float mono = clipReadBuffer[frame] * gain;
+  gainedSample_L = mono;
+  gainedSample_R = mono;
+} else if (numFileChannels == 2) {
+  // Stereo source: Preserve L/R separation
+  gainedSample_L = clipReadBuffer[frame * 2 + 0] * gain;
+  gainedSample_R = clipReadBuffer[frame * 2 + 1] * gain;
+} else {
+  // Multi-channel (>2): Apply ITU-R BS.775 downmix to stereo
+  // L_out = L + 0.707*C + 0.707*Ls
+  // R_out = R + 0.707*C + 0.707*Rs
+  // (Simplified for 5.1: L, R, C, LFE, Ls, Rs)
+  gainedSample_L = applyDownmixLeft(clipReadBuffer, frame, numFileChannels) * gain;
+  gainedSample_R = applyDownmixRight(clipReadBuffer, frame, numFileChannels) * gain;
+}
+
+// Write to stereo clip buffers
+m_clipChannelBuffersStereo[i][0][frame] = gainedSample_L;
+m_clipChannelBuffersStereo[i][1][frame] = gainedSample_R;
+```
+
+**Downmix Helper Functions:**
+```cpp
+// ITU-R BS.775-3 standard downmix coefficients
+static constexpr float DOWNMIX_CENTER = 0.7071067811865476f;  // sqrt(0.5)
+static constexpr float DOWNMIX_SURROUND = 0.7071067811865476f;
+
+float TransportController::applyDownmixLeft(const float* src, size_t frame, size_t numCh) {
+  if (numCh < 6) {
+    // Quad or less: simple average
+    float sum = 0.0f;
+    for (size_t ch = 0; ch < numCh; ch += 2) sum += src[frame * numCh + ch];
+    return sum / ((numCh + 1) / 2);
+  }
+  // 5.1/7.1 layout: L=0, R=1, C=2, LFE=3, Ls=4, Rs=5
+  float L = src[frame * numCh + 0];
+  float C = src[frame * numCh + 2];
+  float Ls = src[frame * numCh + 4];
+  return L + DOWNMIX_CENTER * C + DOWNMIX_SURROUND * Ls;
+}
+
+float TransportController::applyDownmixRight(const float* src, size_t frame, size_t numCh) {
+  if (numCh < 6) {
+    float sum = 0.0f;
+    for (size_t ch = 1; ch < numCh; ch += 2) sum += src[frame * numCh + ch];
+    return sum / (numCh / 2);
+  }
+  float R = src[frame * numCh + 1];
+  float C = src[frame * numCh + 2];
+  float Rs = src[frame * numCh + 5];
+  return R + DOWNMIX_CENTER * C + DOWNMIX_SURROUND * Rs;
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Mono file plays as centered phantom image
+- [ ] Stereo file preserves L/R separation
+- [ ] 5.1 file downmixes correctly to stereo
+- [ ] No change in gain with format conversion
+
+---
+
+### 3.2 Task A-02: Stereo Group Buffers
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code:**
+```cpp
+// Mono group buffer
+std::vector<std::vector<float>> m_group_buffers;  // [group][frame]
+```
+
+**Fixed Code:**
+```cpp
+// ORP121 A-02: Stereo group buffers
+// Each group has L/R channel pair for true stereo imaging
+
+// In routing_matrix.h:
+struct GroupBuffer {
+  std::vector<float> left;   // Left channel samples
+  std::vector<float> right;  // Right channel samples
+
+  void resize(size_t frames) {
+    left.resize(frames, 0.0f);
+    right.resize(frames, 0.0f);
+  }
+
+  void clear() {
+    std::fill(left.begin(), left.end(), 0.0f);
+    std::fill(right.begin(), right.end(), 0.0f);
+  }
+};
+
+std::vector<GroupBuffer> m_group_buffers;
+
+// In processRouting():
+// Clear group buffers
+for (auto& group : m_group_buffers) {
+  group.clear();
+}
+
+// Sum channels into groups (stereo-aware)
+for (uint8_t ch = 0; ch < m_config.num_channels; ++ch) {
+  auto& channel = m_channels[ch];
+  if (channel.group_index == UNASSIGNED_GROUP) continue;
+
+  auto& group = m_group_buffers[channel.group_index];
+
+  // Get stereo input (from transport controller)
+  const float* input_L = channel_inputs_L[ch];
+  const float* input_R = channel_inputs_R[ch];
+  if (!input_L || !input_R) continue;
+
+  for (uint32_t frame = 0; frame < num_frames; ++frame) {
+    float channel_gain = channel.gain_smoother->process();
+    float pan_L = channel.pan_left->process();
+    float pan_R = channel.pan_right->process();
+
+    // Apply gain and pan
+    float sample_L = input_L[frame] * channel_gain * pan_L;
+    float sample_R = input_R[frame] * channel_gain * pan_R;
+
+    // Check mute/solo
+    if (!isChannelEffectivelyMuted(ch)) {
+      group.left[frame] += sample_L;
+      group.right[frame] += sample_R;
+    }
+  }
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Group outputs are stereo (L/R pair)
+- [ ] Panning affects L/R balance correctly
+- [ ] Multiple clips sum correctly to group
+- [ ] Group gain applies equally to L/R
+
+---
+
+### 3.3 Task A-03: Wire Output Bus Routing
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code (Lines 623-626):**
+```cpp
+// All groups sum to outputs 0-1 regardless of output_bus setting
+for (uint8_t out = 0; out < std::min(config.num_outputs, (uint8_t)2); ++out) {
+  master_output[out][frame] += sample;
+}
+```
+
+**Fixed Code:**
+```cpp
+// ORP121 A-03: Route groups to configured output buses
+// GroupConfig.output_bus determines which stereo pair receives the group
+
+// Sum groups into master outputs based on output_bus assignment
+for (uint8_t g = 0; g < m_config.num_groups; ++g) {
+  auto& group = m_groups[g];
+  auto& buffer = m_group_buffers[g];
+
+  if (group.config.mute || isGroupEffectivelyMuted(g)) continue;
+
+  // Determine output channel pair from output_bus
+  // output_bus 0 = channels 0-1 (stereo pair 1)
+  // output_bus 1 = channels 2-3 (stereo pair 2)
+  // etc.
+  uint8_t out_L = group.config.output_bus * 2;
+  uint8_t out_R = group.config.output_bus * 2 + 1;
+
+  // Validate output channels exist
+  if (out_R >= m_config.num_outputs) continue;
+
+  float group_gain = group.gain_smoother->process();
+
+  for (uint32_t frame = 0; frame < num_frames; ++frame) {
+    float sample_L = buffer.left[frame] * group_gain;
+    float sample_R = buffer.right[frame] * group_gain;
+
+    master_output[out_L][frame] += sample_L;
+    master_output[out_R][frame] += sample_R;
+  }
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Group with output_bus=0 routes to channels 0-1
+- [ ] Group with output_bus=1 routes to channels 2-3
+- [ ] Groups with different buses don't interfere
+- [ ] Invalid output_bus (>= num_outputs/2) handled gracefully
+
+---
+
+### 3.4 Task A-06: Document Gain Staging Model
+
+**File:** Create `docs/orp/GAIN_STAGING.md`
+
+**Content:**
+```markdown
+# Orpheus SDK Gain Staging Model
+
+## Signal Flow
+
+```
+Source File (0 dBFS normalized)
+       │
+       ▼
+┌──────────────────────┐
+│ Clip Gain            │  User setting: -inf to +12 dB
+│ (clip.gainLinear)    │  Applied in: TransportController::processAudio()
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Fade Gain            │  Envelope: 0.0 to 1.0
+│ (calculateFadeGain)  │  Types: FadeIn, FadeOut, RestartCrossfade, StopFade
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Channel Gain         │  User setting: -inf to +12 dB
+│ (channel.gain)       │  Applied in: RoutingMatrix::processRouting()
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Pan Law              │  Position: -1.0 to +1.0
+│ (constant power)     │  L/R coefficients sum to constant energy
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Group Summing        │  Additive (linear sum)
+│ (group_buffer +=)    │  No automatic gain compensation
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Group Gain           │  User setting: -inf to +12 dB
+│ (group.gain)         │  Applied per-group before master sum
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Master Summing       │  Additive (linear sum)
+│ (master_output +=)   │  Groups → Output buses
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Master Gain          │  User setting: -inf to +12 dB
+│ (master.gain)        │  Final output level control
+└──────────────────────┘
+       │
+       ▼
+┌──────────────────────┐
+│ Soft Limiter         │  Threshold: -2 dBFS
+│ (tanh soft-knee)     │  Ceiling: -0.001 dBFS
+└──────────────────────┘
+       │
+       ▼
+Output (-1.0 to +1.0)
+```
+
+## Gain Ranges
+
+| Stage | Min | Max | Unit |
+|-------|-----|-----|------|
+| Clip Gain | -inf | +12 | dB |
+| Channel Gain | -inf | +12 | dB |
+| Group Gain | -inf | +12 | dB |
+| Master Gain | -inf | +12 | dB |
+| Pan | -1.0 | +1.0 | position |
+
+## Headroom Considerations
+
+32-bit float provides ~1528 dB of dynamic range. Internal headroom is effectively unlimited.
+
+**Clipping occurs only at:**
+1. Soft limiter (intentional, gradual saturation)
+2. DAC output (hardware, must stay within +-1.0)
+
+**Recommended gain structure:**
+- Source files: Normalized to -6 dBFS peak
+- Clip gains: Unity (0 dB) unless adjustment needed
+- Channel gains: Unity (0 dB)
+- Group gains: Adjust for submix balance (-6 to 0 dB)
+- Master gain: Final trim (-3 to 0 dB)
+
+This structure provides ~15 dB of headroom at each summing stage.
+```
+
+**Acceptance Criteria:**
+- [ ] Document accurately reflects implementation
+- [ ] All gain stages are listed with ranges
+- [ ] Headroom guidance is correct for 32-bit float
+
+---
+
+## 4. Phase 3: Multi-Channel Architecture
+
+**Objective:** Enable surround sound and immersive audio formats
+**Effort:** 16-20 hours
+**Risk:** Medium-High (significant API changes)
+**Dependencies:** Phase 2 complete
+
+### 4.1 Task A-04: Channel Format Abstraction
+
+**File:** Create `include/orpheus/channel_format.h`
+
+```cpp
+// ORP121 A-04: Multi-channel format abstraction
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace orpheus {
+
+/// Standard channel layouts
+enum class ChannelLayout : uint8_t {
+  Mono = 1,
+  Stereo = 2,
+  LCR = 3,           // Left, Center, Right (theater)
+  Quad = 4,          // L, R, Ls, Rs (legacy surround)
+  Surround_5_0 = 5,  // L, R, C, Ls, Rs
+  Surround_5_1 = 6,  // L, R, C, LFE, Ls, Rs
+  Surround_7_1 = 8,  // L, R, C, LFE, Ls, Rs, Lb, Rb
+  Atmos_5_1_2 = 8,   // 5.1 + 2 height (Ltm, Rtm)
+  Atmos_5_1_4 = 10,  // 5.1 + 4 height
+  Atmos_7_1_4 = 12,  // 7.1 + 4 height
+  Ambisonics_FOA = 4,   // First-order: W, X, Y, Z (ACN/SN3D)
+  Ambisonics_HOA2 = 9,  // Second-order
+  Ambisonics_HOA3 = 16, // Third-order
+  Custom = 255       // User-defined
+};
+
+/// Speaker positions for channel mapping
+enum class Speaker : uint8_t {
+  L = 0,    // Left
+  R = 1,    // Right
+  C = 2,    // Center
+  LFE = 3,  // Low Frequency Effects
+  Ls = 4,   // Left Surround
+  Rs = 5,   // Right Surround
+  Lb = 6,   // Left Back
+  Rb = 7,   // Right Back
+  Ltf = 8,  // Left Top Front
+  Rtf = 9,  // Right Top Front
+  Ltb = 10, // Left Top Back
+  Rtb = 11, // Right Top Back
+  // Ambisonics (ACN order)
+  W = 0,    // Omnidirectional
+  Y = 1,    // Front-back
+  Z = 2,    // Up-down
+  X = 3,    // Left-right
+  // Higher-order ambisonics continue ACN sequence...
+  None = 255
+};
+
+/// Channel format descriptor
+struct ChannelFormat {
+  ChannelLayout layout;
+  uint8_t num_channels;
+  std::array<Speaker, 32> channel_map;  // Speaker assignment per channel
+  std::string name;                     // Human-readable name
+
+  /// Check if format is bed-based (speaker feeds)
+  bool isBedFormat() const {
+    return layout != ChannelLayout::Ambisonics_FOA &&
+           layout != ChannelLayout::Ambisonics_HOA2 &&
+           layout != ChannelLayout::Ambisonics_HOA3;
+  }
+
+  /// Check if format is scene-based (ambisonics)
+  bool isAmbisonics() const {
+    return !isBedFormat();
+  }
+
+  // Factory methods
+  static ChannelFormat Mono();
+  static ChannelFormat Stereo();
+  static ChannelFormat Surround51();
+  static ChannelFormat Surround71();
+  static ChannelFormat Atmos714();
+  static ChannelFormat Ambisonics(uint8_t order);
+  static ChannelFormat Custom(uint8_t numChannels);
+};
+
+/// Downmix/upmix coefficient matrix
+/// Usage: output[out_ch] = sum(input[in_ch] * coefficients[out_ch][in_ch])
+struct MixMatrix {
+  uint8_t input_channels;
+  uint8_t output_channels;
+  std::array<std::array<float, 32>, 32> coefficients;  // [out][in]
+
+  /// Apply mix matrix to audio buffer
+  void apply(const float* const* input, float** output, size_t num_frames) const;
+
+  // Standard matrices
+  static MixMatrix Downmix_51_to_Stereo();
+  static MixMatrix Downmix_71_to_Stereo();
+  static MixMatrix Downmix_71_to_51();
+  static MixMatrix Upmix_Stereo_to_51();  // Phantom center, no rear
+  static MixMatrix Upmix_Mono_to_Stereo();
+};
+
+} // namespace orpheus
+```
+
+**Implementation File:** `src/core/channel_format.cpp`
+
+```cpp
+#include <orpheus/channel_format.h>
+#include <cmath>
+
+namespace orpheus {
+
+// ITU-R BS.775-3 coefficients
+static constexpr float K_CENTER = 0.7071067811865476f;    // sqrt(0.5), -3 dB
+static constexpr float K_SURROUND = 0.7071067811865476f;  // sqrt(0.5), -3 dB
+static constexpr float K_LFE = 0.0f;                       // LFE typically omitted in downmix
+
+ChannelFormat ChannelFormat::Mono() {
+  ChannelFormat fmt;
+  fmt.layout = ChannelLayout::Mono;
+  fmt.num_channels = 1;
+  fmt.channel_map[0] = Speaker::C;  // Mono is conceptually center
+  fmt.name = "Mono";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Stereo() {
+  ChannelFormat fmt;
+  fmt.layout = ChannelLayout::Stereo;
+  fmt.num_channels = 2;
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.name = "Stereo";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Surround51() {
+  ChannelFormat fmt;
+  fmt.layout = ChannelLayout::Surround_5_1;
+  fmt.num_channels = 6;
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.name = "5.1 Surround";
+  return fmt;
+}
+
+MixMatrix MixMatrix::Downmix_51_to_Stereo() {
+  MixMatrix m;
+  m.input_channels = 6;
+  m.output_channels = 2;
+  std::fill(&m.coefficients[0][0], &m.coefficients[0][0] + 32*32, 0.0f);
+
+  // L_out = L + K_CENTER*C + K_SURROUND*Ls
+  m.coefficients[0][0] = 1.0f;       // L -> L
+  m.coefficients[0][2] = K_CENTER;   // C -> L
+  m.coefficients[0][4] = K_SURROUND; // Ls -> L
+
+  // R_out = R + K_CENTER*C + K_SURROUND*Rs
+  m.coefficients[1][1] = 1.0f;       // R -> R
+  m.coefficients[1][2] = K_CENTER;   // C -> R
+  m.coefficients[1][5] = K_SURROUND; // Rs -> R
+
+  return m;
+}
+
+void MixMatrix::apply(const float* const* input, float** output, size_t num_frames) const {
+  for (size_t frame = 0; frame < num_frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      float sum = 0.0f;
+      for (uint8_t in_ch = 0; in_ch < input_channels; ++in_ch) {
+        sum += input[in_ch][frame] * coefficients[out_ch][in_ch];
+      }
+      output[out_ch][frame] = sum;
+    }
+  }
+}
+
+} // namespace orpheus
+```
+
+**Acceptance Criteria:**
+- [ ] All standard formats constructible via factory methods
+- [ ] MixMatrix correctly applies ITU-R BS.775 downmix
+- [ ] Coefficient matrices are symmetric where applicable
+- [ ] Unit tests verify all conversions
+
+---
+
+### 4.2 Task A-05: Integrate Mix Matrices into Routing
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Changes:**
+1. Add `ChannelFormat` to `ChannelConfig` and `GroupConfig`
+2. Store per-channel input format
+3. Apply format conversion during channel→group summing
+4. Apply format conversion during group→output summing
+
+```cpp
+// In routing_matrix.h:
+struct ChannelConfig {
+  // ... existing fields ...
+  ChannelFormat input_format;   // Source file format
+  ChannelFormat output_format;  // Format for group summing (usually stereo)
+  MixMatrix format_converter;   // Pre-computed conversion matrix
+};
+
+// In processRouting():
+for (uint8_t ch = 0; ch < m_config.num_channels; ++ch) {
+  auto& channel = m_channels[ch];
+
+  // Apply format conversion if needed
+  if (channel.input_format.num_channels != channel.output_format.num_channels) {
+    channel.format_converter.apply(
+      channel_inputs[ch],       // Multi-channel input
+      temp_converted_buffer,    // Stereo (or group format) output
+      num_frames
+    );
+    // Use converted buffer for further processing
+    input_for_summing = temp_converted_buffer;
+  } else {
+    input_for_summing = channel_inputs[ch];
+  }
+
+  // Continue with gain/pan/sum...
+}
+```
+
+**Acceptance Criteria:**
+- [ ] 5.1 source file correctly downmixes to stereo group
+- [ ] Stereo source file passes through unchanged to stereo group
+- [ ] Mono source file upmixes to stereo (phantom center)
+- [ ] Format conversion is seamless (no glitches)
+
+---
+
+## 5. Phase 4: Quality & Nomenclature
+
+**Objective:** Improve code quality, consistency, and maintainability
+**Effort:** 16-20 hours
+**Risk:** Low (non-breaking changes, documentation)
+
+### 5.1 Task Q-01: Standardize Case Style
+
+**Standard:** `snake_case` for member variables, `PascalCase` for types
+
+**Files to Update:**
+- `include/orpheus/transport_controller.h`
+- `include/orpheus/routing_matrix.h`
+- `include/orpheus/clip_routing.h`
+- `src/core/transport/transport_controller.cpp`
+- `src/core/routing/routing_matrix.cpp`
+
+**Before:**
+```cpp
+struct AudioFileEntry {
+  int64_t trimInSamples;    // camelCase
+  double fadeInSeconds;     // camelCase
+  float gainDb;             // camelCase (inconsistent dB casing)
+};
+```
+
+**After:**
+```cpp
+struct AudioFileEntry {
+  int64_t trim_in_samples;   // snake_case
+  double fade_in_seconds;    // snake_case
+  float gain_dB;             // snake_case with proper unit suffix
+};
+```
+
+**Migration Strategy:**
+1. Create type aliases for backward compatibility
+2. Mark old names `[[deprecated]]`
+3. Update internal code to use new names
+4. Update tests and examples
+5. Remove aliases in next major version
+
+---
+
+### 5.2 Task Q-02: Normalize Terminology
+
+| Old Term | New Term | Rationale |
+|----------|----------|-----------|
+| `group_index` | `bus_index` | Industry standard (Pro Tools, Logic, Dante) |
+| `ClipHandle` | `ClipId` | "Handle" implies ownership; "Id" is identifier |
+| `num_channels` (input) | `num_inputs` | Disambiguate from L/R channels |
+| `num_outputs` | `num_output_channels` | Explicit meaning |
+| `UNASSIGNED_GROUP` | `BUS_NONE` | Shorter, clearer |
+| `stopOthersOnPlay` | `exclusive_mode` | Clearer intent |
+| `m_activeClipCount` | `m_active_voice_count` | Reflects multi-voice |
+
+**Migration:** Same as Q-01 (aliases + deprecation)
+
+---
+
+### 5.3 Task Q-03: Remove Hardcoded Sample Rate
+
+**Files:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code (Line 59):**
+```cpp
+m_gainSmoothingTimeMs = 10.0f;  // Assumes 48kHz for sample count
+```
+
+**Fixed Code:**
+```cpp
+// Pass sample rate to initialize()
+SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config, uint32_t sample_rate) {
+  m_sampleRate = sample_rate;
+  m_gainSmoothingSamples = static_cast<uint32_t>(
+    config.gain_smoothing_ms * 0.001f * static_cast<float>(sample_rate)
+  );
+  // ...
+}
+```
+
+---
+
+### 5.4 Task Q-04: Implement True-Peak Metering
+
+**File:** `src/core/routing/routing_matrix.cpp`
+
+**Current Code:**
+```cpp
+enum class MeteringMode : uint8_t {
+  Peak = 0,
+  RMS = 1,
+  TruePeak = 2,  // Stub only
+  LUFS = 3       // Stub only
+};
+```
+
+**Implementation for TruePeak (ITU-R BS.1770-4):**
+```cpp
+// True-peak requires 4x oversampling
+class TruePeakMeter {
+  static constexpr int OVERSAMPLE_FACTOR = 4;
+  std::array<float, 48> m_filterCoeffs;  // FIR filter for interpolation
+  std::array<float, 48> m_history;
+
+public:
+  TruePeakMeter() {
+    // Initialize ITU-R BS.1770 filter coefficients
+    initializeFilter();
+  }
+
+  float process(float sample) {
+    // Shift history
+    std::memmove(&m_history[1], &m_history[0], 47 * sizeof(float));
+    m_history[0] = sample;
+
+    // Calculate 4 interpolated samples
+    float peak = 0.0f;
+    for (int phase = 0; phase < OVERSAMPLE_FACTOR; ++phase) {
+      float interpolated = 0.0f;
+      for (int tap = 0; tap < 12; ++tap) {
+        interpolated += m_history[tap] * m_filterCoeffs[phase * 12 + tap];
+      }
+      peak = std::max(peak, std::abs(interpolated));
+    }
+
+    return peak;
+  }
+};
+```
+
+---
+
+### 5.5 Task Q-05: Add Headroom Management
+
+**File:** `include/orpheus/routing_matrix.h`
+
+```cpp
+struct RoutingConfig {
+  // ... existing fields ...
+
+  /// Automatic gain compensation mode
+  enum class HeadroomMode : uint8_t {
+    None = 0,           ///< No compensation (sum can exceed 0 dBFS)
+    PerGroup = 1,       ///< Divide by number of channels per group
+    Global = 2,         ///< Divide by total active channels
+    Logarithmic = 3     ///< -3 dB per doubling of channels
+  };
+
+  HeadroomMode headroom_mode = HeadroomMode::None;  ///< Default: no compensation
+};
+```
+
+**Implementation:**
+```cpp
+// In processRouting(), calculate compensation factor
+float getHeadroomCompensation(uint8_t group_index) const {
+  switch (m_config.headroom_mode) {
+    case HeadroomMode::None:
+      return 1.0f;
+    case HeadroomMode::PerGroup: {
+      int active = countActiveChannelsInGroup(group_index);
+      return active > 0 ? 1.0f / static_cast<float>(active) : 1.0f;
+    }
+    case HeadroomMode::Global: {
+      int active = countTotalActiveChannels();
+      return active > 0 ? 1.0f / static_cast<float>(active) : 1.0f;
+    }
+    case HeadroomMode::Logarithmic: {
+      int active = countActiveChannelsInGroup(group_index);
+      // -3 dB per doubling: 1/sqrt(n)
+      return active > 0 ? 1.0f / std::sqrt(static_cast<float>(active)) : 1.0f;
+    }
+  }
+  return 1.0f;
+}
+```
+
+---
+
+### 5.6 Tasks Q-06 through Q-13: Documentation and Testing
+
+| Task | Deliverable |
+|------|-------------|
+| Q-06 | `docs/orp/GAIN_STAGING.md` (see Phase 2) |
+| Q-07 | `tests/transport/threading_stress_test.cpp` |
+| Q-08 | `tests/performance/waveform_benchmark.cpp` |
+| Q-09 | Logging framework integration in AudioEngine |
+| Q-10 | Fixed-size Cue buss pool in AudioEngine |
+| Q-11 | Dynamic button count support |
+| Q-12 | `include/orpheus/performance_monitor.h` API |
+| Q-13 | Doxygen comments on all public APIs |
+
+---
+
+## 6. Acceptance Criteria
+
+### Phase 1 Complete When:
+- [ ] All unit tests pass
+- [ ] GainSmoother allows +12 dB boost
+- [ ] No audible artifacts from limiter
+- [ ] ThreadSanitizer clean (no mutex in audio path)
+- [ ] Pan positions audibly affect L/R balance
+
+### Phase 2 Complete When:
+- [ ] Stereo files preserve L/R separation
+- [ ] Multi-channel files downmix correctly
+- [ ] Groups output stereo pairs
+- [ ] Output bus routing works (group → specific output pair)
+- [ ] GAIN_STAGING.md document complete
+
+### Phase 3 Complete When:
+- [ ] ChannelFormat API implemented
+- [ ] MixMatrix applies ITU-R BS.775 coefficients
+- [ ] 5.1 → stereo downmix verified
+- [ ] Ambisonics to stereo conversion works
+- [ ] Format negotiation automatic
+
+### Phase 4 Complete When:
+- [ ] snake_case applied to all new code
+- [ ] Deprecated aliases for old names
+- [ ] Sample rate parameterized
+- [ ] True-peak metering functional
+- [ ] Headroom modes implemented
+- [ ] 90%+ Doxygen coverage on public APIs
+- [ ] Threading stress tests pass
+
+---
+
+## 7. Test Plan
+
+### 7.1 Unit Tests (New)
+
+```cpp
+// tests/routing/gain_smoother_test.cpp
+TEST(GainSmoother, AllowsPositiveGainBoost) {
+  GainSmoother smoother(48000, 10.0f);  // 10ms smoothing
+  smoother.setTarget(dbToLinear(6.0f));  // +6 dB
+
+  // Process enough samples for smoothing to complete
+  for (int i = 0; i < 480; ++i) {
+    smoother.process();
+  }
+
+  EXPECT_NEAR(smoother.process(), dbToLinear(6.0f), 0.01f);
+}
+
+TEST(GainSmoother, AllowsMaxGainBoost) {
+  GainSmoother smoother(48000, 10.0f);
+  smoother.setTarget(dbToLinear(12.0f));  // +12 dB = 3.981
+
+  for (int i = 0; i < 480; ++i) {
+    smoother.process();
+  }
+
+  EXPECT_NEAR(smoother.process(), 3.981f, 0.01f);
+}
+
+// tests/routing/limiter_test.cpp
+TEST(SoftLimiter, ContinuousAtThreshold) {
+  // Verify no discontinuity at 0.9 threshold
+  float below = applySoftLimit(0.89f);
+  float at = applySoftLimit(0.90f);
+  float above = applySoftLimit(0.91f);
+
+  // Should be monotonically increasing with no jump
+  EXPECT_LT(below, at);
+  EXPECT_LT(at, above);
+  EXPECT_LT(above - at, 0.02f);  // No large jump
+}
+
+// tests/routing/pan_law_test.cpp
+TEST(PanLaw, ConstantPower) {
+  RoutingMatrix routing;
+  routing.initialize({.num_channels = 1, .num_groups = 1, .num_outputs = 2});
+
+  // Pan center: L and R should both be ~0.707 (-3 dB)
+  routing.setChannelPan(0, 0.0f);
+
+  float pan_L, pan_R;
+  routing.getChannelPanCoefficients(0, pan_L, pan_R);
+
+  EXPECT_NEAR(pan_L, 0.707f, 0.01f);
+  EXPECT_NEAR(pan_R, 0.707f, 0.01f);
+
+  // Verify constant power: L^2 + R^2 = 1
+  EXPECT_NEAR(pan_L * pan_L + pan_R * pan_R, 1.0f, 0.01f);
+}
+
+// tests/routing/stereo_routing_test.cpp
+TEST(StereoRouting, PreservesStereoWidth) {
+  TransportController transport;
+  // Load stereo test file (L=sine, R=silence)
+  auto handle = transport.registerClipAudio(1, "test_stereo_lr.wav");
+
+  float output_L[256], output_R[256];
+  float* outputs[2] = {output_L, output_R};
+
+  transport.startClip(handle);
+  transport.processAudio(outputs, 2, 256);
+
+  // Left channel should have signal
+  float rms_L = calculateRMS(output_L, 256);
+  // Right channel should be silent
+  float rms_R = calculateRMS(output_R, 256);
+
+  EXPECT_GT(rms_L, 0.1f);
+  EXPECT_LT(rms_R, 0.001f);  // Essentially silent
+}
+```
+
+### 7.2 Integration Tests
+
+```cpp
+// tests/integration/multi_channel_test.cpp
+TEST(MultiChannel, Downmix51ToStereo) {
+  TransportController transport;
+  RoutingMatrix routing;
+
+  routing.initialize({.num_channels = 1, .num_groups = 1, .num_outputs = 2});
+
+  // Load 5.1 test file
+  auto handle = transport.registerClipAudio(1, "test_51_surround.wav");
+  transport.startClip(handle);
+
+  // Process through routing
+  float* clip_outputs[6];  // 5.1 channels
+  float* master_output[2]; // Stereo
+
+  transport.processAudio(clip_outputs, 6, 256);
+  routing.processRouting(clip_outputs, master_output, 256);
+
+  // Verify downmix coefficients applied
+  // C channel should appear in both L and R at -3 dB
+  // Ls should appear in L only
+  // Rs should appear in R only
+  // (Verify with known test tones)
+}
+```
+
+### 7.3 Stress Tests
+
+```cpp
+// tests/stress/callback_queue_test.cpp
+TEST(CallbackQueue, HighThroughput) {
+  TransportController transport;
+  std::atomic<int> callback_count{0};
+
+  // Simulate 10,000 callbacks/second for 1 second
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < std::chrono::seconds(1)) {
+    transport.postCallback([&callback_count]() {
+      callback_count++;
+    });
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+
+  // Process callbacks on "UI thread"
+  transport.processCallbacks();
+
+  // Should have received most callbacks (some may be dropped if queue fills)
+  EXPECT_GT(callback_count.load(), 9000);
+}
+```
+
+---
+
+## 8. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| API breaking changes | Medium | High | Use deprecation aliases, semver |
+| Performance regression | Low | Medium | Benchmark before/after each phase |
+| Threading bugs | Medium | High | ThreadSanitizer in CI |
+| Format conversion artifacts | Low | Medium | A/B test against reference DAW |
+| Backward incompatibility | Medium | Medium | Maintain old codepaths behind flags |
+
+---
+
+## 9. File Index
+
+### Core Files Modified
+
+| File | Phase | Tasks |
+|------|-------|-------|
+| `src/core/routing/gain_smoother.cpp` | 1 | C-01 |
+| `src/core/routing/gain_smoother.h` | 1 | C-01 |
+| `src/core/routing/routing_matrix.cpp` | 1, 2 | C-02, C-04, A-02, A-03 |
+| `src/core/routing/routing_matrix.h` | 2, 4 | A-02, Q-05 |
+| `src/core/transport/transport_controller.cpp` | 1, 2 | C-03, A-01 |
+| `src/core/transport/transport_controller.h` | 1, 2, 4 | C-03, A-01, Q-01, Q-02 |
+
+### New Files Created
+
+| File | Phase | Task |
+|------|-------|------|
+| `include/orpheus/channel_format.h` | 3 | A-04 |
+| `src/core/channel_format.cpp` | 3 | A-04 |
+| `docs/orp/GAIN_STAGING.md` | 2 | A-06 |
+| `tests/routing/gain_smoother_test.cpp` | 1 | C-01 |
+| `tests/routing/limiter_test.cpp` | 1 | C-02 |
+| `tests/routing/pan_law_test.cpp` | 1 | C-04 |
+| `tests/routing/stereo_routing_test.cpp` | 2 | A-01, A-02 |
+| `tests/integration/multi_channel_test.cpp` | 3 | A-04, A-05 |
+| `tests/stress/callback_queue_test.cpp` | 1 | C-03 |
+
+---
+
+## 10. References
+
+- **ORP114:** Gain staging bug investigation (trim race condition, restart crossfade)
+- **ORP117:** Routing matrix technical explainer
+- **ORP118:** Multi-voice architecture and audio summing topology
+- **ITU-R BS.775-3:** Multichannel stereophonic sound system with or without accompanying picture
+- **ITU-R BS.1770-4:** Algorithms to measure audio programme loudness and true-peak audio level
+- **AES17-2020:** AES standard method for digital audio engineering - Measurement of digital audio equipment
+
+---
+
+## 11. Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-18 | Claude (Audio Consultant) | Initial comprehensive plan |
+
+---
+
+**Document Status:** Ready for Implementation
+**Handoff Target:** Local Agent
+**Estimated Total Effort:** 48-64 hours across 4 phases

--- a/include/orpheus/channel_format.h
+++ b/include/orpheus/channel_format.h
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// ORP121 A-04: Multi-channel format abstraction
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace orpheus {
+
+/// Standard channel layouts (ST2110/SMPTE aligned)
+/// Values match channel count for bed formats
+enum class ChannelLayout : uint8_t {
+  Mono = 1,
+  Stereo = 2,
+  LCR = 3,          // Left, Center, Right (film/theater)
+  Quad = 4,         // L, R, Ls, Rs (legacy quad)
+  Surround_5_0 = 5, // L, R, C, Ls, Rs (film without LFE)
+  Surround_5_1 = 6, // L, R, C, LFE, Ls, Rs (ITU-R BS.775)
+  Surround_7_1 = 8, // L, R, C, LFE, Ls, Rs, Lb, Rb
+  Atmos_5_1_2 = 8,  // 5.1 + 2 height (Ltf, Rtf)
+  Atmos_5_1_4 = 10, // 5.1 + 4 height (Ltf, Rtf, Ltb, Rtb)
+  Atmos_7_1_4 = 12, // 7.1 + 4 height
+
+  // Scene-based formats (ambisonics)
+  Ambisonics_FOA = 4,   // First-order: W, Y, Z, X (ACN/SN3D)
+  Ambisonics_HOA2 = 9,  // Second-order (9 channels)
+  Ambisonics_HOA3 = 16, // Third-order (16 channels)
+
+  Custom = 255 // User-defined layout
+};
+
+/// Speaker positions for channel mapping (SMPTE/ITU standard order)
+enum class Speaker : uint8_t {
+  // Front layer
+  L = 0,   // Left
+  R = 1,   // Right
+  C = 2,   // Center
+  LFE = 3, // Low Frequency Effects
+  Ls = 4,  // Left Surround
+  Rs = 5,  // Right Surround
+
+  // Rear layer (7.1+)
+  Lb = 6, // Left Back
+  Rb = 7, // Right Back
+
+  // Height layer (Atmos/Auro)
+  Ltf = 8,  // Left Top Front
+  Rtf = 9,  // Right Top Front
+  Ltb = 10, // Left Top Back
+  Rtb = 11, // Right Top Back
+
+  // Extended height (22.2, etc.)
+  Ctf = 12, // Center Top Front
+  Ctb = 13, // Center Top Back
+  Ts = 14,  // Top Surround (zenith)
+
+  // Ambisonics (ACN channel ordering)
+  // Note: These overlap with speaker positions intentionally
+  // Ambisonics uses indices 0-N where N = (order+1)^2 - 1
+  W = 0, // Omni (ACN 0)
+  Y = 1, // Front-back dipole (ACN 1)
+  Z = 2, // Up-down dipole (ACN 2)
+  X = 3, // Left-right dipole (ACN 3)
+  // HOA continues ACN sequence: V, T, R, S, U (order 2), etc.
+
+  None = 255
+};
+
+/// Maximum supported channels per format
+static constexpr size_t MAX_FORMAT_CHANNELS = 32;
+
+/// Channel format descriptor
+/// Describes the speaker layout and channel ordering for an audio format
+struct ChannelFormat {
+  ChannelLayout layout;
+  uint8_t num_channels;
+  std::array<Speaker, MAX_FORMAT_CHANNELS> channel_map; // Speaker per channel
+  std::string name;
+
+  /// Check if format is bed-based (discrete speaker feeds)
+  [[nodiscard]] bool isBedFormat() const {
+    return layout != ChannelLayout::Ambisonics_FOA && layout != ChannelLayout::Ambisonics_HOA2 &&
+           layout != ChannelLayout::Ambisonics_HOA3;
+  }
+
+  /// Check if format is scene-based (ambisonics)
+  [[nodiscard]] bool isAmbisonics() const {
+    return !isBedFormat();
+  }
+
+  /// Get speaker position for a channel index
+  [[nodiscard]] Speaker getSpeaker(size_t channel_index) const {
+    if (channel_index >= num_channels)
+      return Speaker::None;
+    return channel_map[channel_index];
+  }
+
+  // Factory methods for standard formats
+  static ChannelFormat Mono();
+  static ChannelFormat Stereo();
+  static ChannelFormat LCR();
+  static ChannelFormat Surround51();
+  static ChannelFormat Surround71();
+  static ChannelFormat Atmos714();
+  static ChannelFormat Ambisonics(uint8_t order);
+  static ChannelFormat Custom(uint8_t numChannels);
+};
+
+/// Downmix/upmix coefficient matrix
+/// Implements format conversion following ITU-R BS.775-3 and Dolby specifications
+///
+/// Usage: output[out_ch] = sum(input[in_ch] * coefficients[out_ch][in_ch])
+struct MixMatrix {
+  uint8_t input_channels;
+  uint8_t output_channels;
+  std::array<std::array<float, MAX_FORMAT_CHANNELS>, MAX_FORMAT_CHANNELS> coefficients; // [out][in]
+
+  /// Apply mix matrix to audio buffer
+  /// @param input Array of input channel pointers
+  /// @param output Array of output channel pointers
+  /// @param num_frames Number of samples per channel
+  void apply(const float* const* input, float** output, size_t num_frames) const;
+
+  /// Apply mix matrix to interleaved buffer
+  /// @param input Interleaved input samples
+  /// @param output Interleaved output samples (must be sized for output_channels)
+  /// @param num_frames Number of frames
+  void applyInterleaved(const float* input, float* output, size_t num_frames) const;
+
+  // Standard ITU-R BS.775-3 downmix matrices
+  static MixMatrix Downmix_51_to_Stereo();
+  static MixMatrix Downmix_71_to_Stereo();
+  static MixMatrix Downmix_71_to_51();
+
+  // Upmix matrices (phantom/derived)
+  static MixMatrix Upmix_Mono_to_Stereo();
+  static MixMatrix Upmix_Stereo_to_51(); // Phantom center, silent rears
+
+  // Identity (pass-through)
+  static MixMatrix Identity(uint8_t channels);
+};
+
+/// Get appropriate downmix matrix for format conversion
+/// @param from Source format
+/// @param to Target format
+/// @return Mix matrix, or identity if no conversion needed
+MixMatrix getDownmixMatrix(const ChannelFormat& from, const ChannelFormat& to);
+
+/// Get appropriate upmix matrix for format conversion
+/// @param from Source format
+/// @param to Target format
+/// @return Mix matrix, or identity if no conversion needed
+MixMatrix getUpmixMatrix(const ChannelFormat& from, const ChannelFormat& to);
+
+} // namespace orpheus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(orpheus_core_runtime OBJECT
   core/session/scene_manager.cpp
   core/otio/reconform_plan.cpp
   dsp/oscillator.cpp
+  core/channel_format.cpp  # ORP121 A-04/A-05: Multi-channel format abstraction
 )
 
 target_compile_features(orpheus_core_runtime PUBLIC cxx_std_20)

--- a/src/core/channel_format.cpp
+++ b/src/core/channel_format.cpp
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+// ORP121 A-04/A-05: Multi-channel format abstraction and mix matrices
+#include <orpheus/channel_format.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace orpheus {
+
+// ============================================================================
+// ITU-R BS.775-3 Downmix Coefficients
+// These are the standard coefficients for professional broadcast downmix
+// ============================================================================
+
+/// Center channel coefficient: 1/sqrt(2) = -3 dB
+static constexpr float K_CENTER = 0.7071067811865476f;
+
+/// Surround channel coefficient: 1/sqrt(2) = -3 dB
+static constexpr float K_SURROUND = 0.7071067811865476f;
+
+/// LFE coefficient: typically 0 for dialogue-normalized content
+/// Some standards use 0.707 or 0.25 depending on content type
+static constexpr float K_LFE = 0.0f;
+
+// ============================================================================
+// ChannelFormat Factory Methods
+// ============================================================================
+
+ChannelFormat ChannelFormat::Mono() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Mono;
+  fmt.num_channels = 1;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.channel_map[0] = Speaker::C; // Mono is conceptually center
+  fmt.name = "Mono";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Stereo() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Stereo;
+  fmt.num_channels = 2;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.name = "Stereo";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::LCR() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::LCR;
+  fmt.num_channels = 3;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::C;
+  fmt.channel_map[2] = Speaker::R;
+  fmt.name = "LCR";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Surround51() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Surround_5_1;
+  fmt.num_channels = 6;
+  fmt.channel_map.fill(Speaker::None);
+  // ITU/SMPTE standard order: L, R, C, LFE, Ls, Rs
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.name = "5.1 Surround";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Surround71() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Surround_7_1;
+  fmt.num_channels = 8;
+  fmt.channel_map.fill(Speaker::None);
+  // ITU/SMPTE standard order: L, R, C, LFE, Ls, Rs, Lb, Rb
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.channel_map[6] = Speaker::Lb;
+  fmt.channel_map[7] = Speaker::Rb;
+  fmt.name = "7.1 Surround";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Atmos714() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Atmos_7_1_4;
+  fmt.num_channels = 12;
+  fmt.channel_map.fill(Speaker::None);
+  // Dolby Atmos 7.1.4 channel order
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.channel_map[6] = Speaker::Lb;
+  fmt.channel_map[7] = Speaker::Rb;
+  fmt.channel_map[8] = Speaker::Ltf;
+  fmt.channel_map[9] = Speaker::Rtf;
+  fmt.channel_map[10] = Speaker::Ltb;
+  fmt.channel_map[11] = Speaker::Rtb;
+  fmt.name = "Dolby Atmos 7.1.4";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Ambisonics(uint8_t order) {
+  ChannelFormat fmt{};
+  uint8_t num_ch = static_cast<uint8_t>((order + 1) * (order + 1));
+
+  if (order == 1) {
+    fmt.layout = ChannelLayout::Ambisonics_FOA;
+  } else if (order == 2) {
+    fmt.layout = ChannelLayout::Ambisonics_HOA2;
+  } else if (order == 3) {
+    fmt.layout = ChannelLayout::Ambisonics_HOA3;
+  } else {
+    fmt.layout = ChannelLayout::Custom;
+  }
+
+  fmt.num_channels = num_ch;
+  fmt.channel_map.fill(Speaker::None);
+  // ACN channel ordering (0, 1, 2, 3, ..., N-1)
+  // Speaker enum values W, Y, Z, X map to ACN 0-3
+  if (num_ch >= 4) {
+    fmt.channel_map[0] = Speaker::W;
+    fmt.channel_map[1] = Speaker::Y;
+    fmt.channel_map[2] = Speaker::Z;
+    fmt.channel_map[3] = Speaker::X;
+  }
+  fmt.name = "Ambisonics Order " + std::to_string(order);
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Custom(uint8_t numChannels) {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Custom;
+  fmt.num_channels = numChannels;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.name = "Custom " + std::to_string(numChannels) + "ch";
+  return fmt;
+}
+
+// ============================================================================
+// MixMatrix Implementation
+// ============================================================================
+
+void MixMatrix::apply(const float* const* input, float** output, size_t num_frames) const {
+  // Clear output buffers first
+  for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+    std::memset(output[out_ch], 0, num_frames * sizeof(float));
+  }
+
+  // Apply matrix: output[out] = sum(input[in] * coeff[out][in])
+  for (size_t frame = 0; frame < num_frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      float sum = 0.0f;
+      for (uint8_t in_ch = 0; in_ch < input_channels; ++in_ch) {
+        sum += input[in_ch][frame] * coefficients[out_ch][in_ch];
+      }
+      output[out_ch][frame] = sum;
+    }
+  }
+}
+
+void MixMatrix::applyInterleaved(const float* input, float* output, size_t num_frames) const {
+  for (size_t frame = 0; frame < num_frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      float sum = 0.0f;
+      for (uint8_t in_ch = 0; in_ch < input_channels; ++in_ch) {
+        sum += input[frame * input_channels + in_ch] * coefficients[out_ch][in_ch];
+      }
+      output[frame * output_channels + out_ch] = sum;
+    }
+  }
+}
+
+MixMatrix MixMatrix::Identity(uint8_t channels) {
+  MixMatrix m{};
+  m.input_channels = channels;
+  m.output_channels = channels;
+  // Initialize all to zero
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+  // Set diagonal to 1.0
+  for (uint8_t i = 0; i < channels; ++i) {
+    m.coefficients[i][i] = 1.0f;
+  }
+  return m;
+}
+
+MixMatrix MixMatrix::Downmix_51_to_Stereo() {
+  // ITU-R BS.775-3 standard downmix
+  // L_out = L + 0.707*C + 0.707*Ls
+  // R_out = R + 0.707*C + 0.707*Rs
+  // LFE omitted (K_LFE = 0)
+
+  MixMatrix m{};
+  m.input_channels = 6;  // L, R, C, LFE, Ls, Rs
+  m.output_channels = 2; // L, R
+
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+
+  // Left output: L + 0.707*C + 0.707*Ls
+  m.coefficients[0][0] = 1.0f;       // L
+  m.coefficients[0][2] = K_CENTER;   // C
+  m.coefficients[0][3] = K_LFE;      // LFE
+  m.coefficients[0][4] = K_SURROUND; // Ls
+
+  // Right output: R + 0.707*C + 0.707*Rs
+  m.coefficients[1][1] = 1.0f;       // R
+  m.coefficients[1][2] = K_CENTER;   // C
+  m.coefficients[1][3] = K_LFE;      // LFE
+  m.coefficients[1][5] = K_SURROUND; // Rs
+
+  return m;
+}
+
+MixMatrix MixMatrix::Downmix_71_to_Stereo() {
+  // Extended ITU-R BS.775-3 for 7.1
+  // L_out = L + 0.707*C + 0.707*Ls + 0.5*Lb
+  // R_out = R + 0.707*C + 0.707*Rs + 0.5*Rb
+
+  MixMatrix m{};
+  m.input_channels = 8; // L, R, C, LFE, Ls, Rs, Lb, Rb
+  m.output_channels = 2;
+
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+
+  // Left output
+  m.coefficients[0][0] = 1.0f;       // L
+  m.coefficients[0][2] = K_CENTER;   // C
+  m.coefficients[0][4] = K_SURROUND; // Ls
+  m.coefficients[0][6] = 0.5f;       // Lb (attenuated backs)
+
+  // Right output
+  m.coefficients[1][1] = 1.0f;       // R
+  m.coefficients[1][2] = K_CENTER;   // C
+  m.coefficients[1][5] = K_SURROUND; // Rs
+  m.coefficients[1][7] = 0.5f;       // Rb (attenuated backs)
+
+  return m;
+}
+
+MixMatrix MixMatrix::Downmix_71_to_51() {
+  // 7.1 to 5.1: Fold back channels into surrounds
+  // Ls_out = Ls + 0.707*Lb
+  // Rs_out = Rs + 0.707*Rb
+
+  MixMatrix m{};
+  m.input_channels = 8;
+  m.output_channels = 6;
+
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+
+  // Pass through L, R, C, LFE
+  m.coefficients[0][0] = 1.0f; // L
+  m.coefficients[1][1] = 1.0f; // R
+  m.coefficients[2][2] = 1.0f; // C
+  m.coefficients[3][3] = 1.0f; // LFE
+
+  // Fold backs into surrounds
+  m.coefficients[4][4] = 1.0f;       // Ls
+  m.coefficients[4][6] = K_SURROUND; // + Lb
+  m.coefficients[5][5] = 1.0f;       // Rs
+  m.coefficients[5][7] = K_SURROUND; // + Rb
+
+  return m;
+}
+
+MixMatrix MixMatrix::Upmix_Mono_to_Stereo() {
+  // Mono to stereo: Equal to both channels
+  MixMatrix m{};
+  m.input_channels = 1;
+  m.output_channels = 2;
+
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+
+  m.coefficients[0][0] = 1.0f; // L = Mono
+  m.coefficients[1][0] = 1.0f; // R = Mono
+
+  return m;
+}
+
+MixMatrix MixMatrix::Upmix_Stereo_to_51() {
+  // Stereo to 5.1: Phantom center, silent rears
+  // This is a basic "compatibility" upmix, not a creative upmixer
+
+  MixMatrix m{};
+  m.input_channels = 2;
+  m.output_channels = 6;
+
+  for (auto& row : m.coefficients) {
+    row.fill(0.0f);
+  }
+
+  // Direct stereo to L/R
+  m.coefficients[0][0] = 1.0f; // L
+  m.coefficients[1][1] = 1.0f; // R
+
+  // Phantom center: average of L+R at reduced level
+  // This is optional and may cause phase issues - often better to leave at 0
+  // m.coefficients[2][0] = K_CENTER;
+  // m.coefficients[2][1] = K_CENTER;
+
+  // LFE, Ls, Rs = 0 (silent)
+
+  return m;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+MixMatrix getDownmixMatrix(const ChannelFormat& from, const ChannelFormat& to) {
+  // Same format - identity
+  if (from.num_channels == to.num_channels) {
+    return MixMatrix::Identity(from.num_channels);
+  }
+
+  // Standard downmix paths
+  if (from.layout == ChannelLayout::Surround_7_1 && to.layout == ChannelLayout::Stereo) {
+    return MixMatrix::Downmix_71_to_Stereo();
+  }
+  if (from.layout == ChannelLayout::Surround_7_1 && to.layout == ChannelLayout::Surround_5_1) {
+    return MixMatrix::Downmix_71_to_51();
+  }
+  if (from.layout == ChannelLayout::Surround_5_1 && to.layout == ChannelLayout::Stereo) {
+    return MixMatrix::Downmix_51_to_Stereo();
+  }
+
+  // Fallback: identity with channel count of minimum
+  return MixMatrix::Identity(std::min(from.num_channels, to.num_channels));
+}
+
+MixMatrix getUpmixMatrix(const ChannelFormat& from, const ChannelFormat& to) {
+  // Same format - identity
+  if (from.num_channels == to.num_channels) {
+    return MixMatrix::Identity(from.num_channels);
+  }
+
+  // Standard upmix paths
+  if (from.layout == ChannelLayout::Mono && to.layout == ChannelLayout::Stereo) {
+    return MixMatrix::Upmix_Mono_to_Stereo();
+  }
+  if (from.layout == ChannelLayout::Stereo && to.layout == ChannelLayout::Surround_5_1) {
+    return MixMatrix::Upmix_Stereo_to_51();
+  }
+
+  // Fallback: identity
+  return MixMatrix::Identity(from.num_channels);
+}
+
+} // namespace orpheus

--- a/src/core/routing/gain_smoother.cpp
+++ b/src/core/routing/gain_smoother.cpp
@@ -18,8 +18,10 @@ GainSmoother::GainSmoother(uint32_t sample_rate, float smoothing_time_ms)
 }
 
 void GainSmoother::setTarget(float target) {
-  // Clamp to valid range
-  target = std::clamp(target, 0.0f, 1.0f);
+  // ORP121 C-01: Allow gains up to +12 dB (3.981 linear)
+  // Rationale: Professional mixing requires boost capability
+  // 32-bit float provides ~1528 dB headroom, clipping at output stage is sufficient
+  target = std::clamp(target, 0.0f, MAX_LINEAR_GAIN);
 
   // Atomic write (lock-free)
   m_pending_target.store(target, std::memory_order_release);
@@ -63,7 +65,8 @@ float GainSmoother::process() {
 }
 
 void GainSmoother::reset(float gain) {
-  gain = std::clamp(gain, 0.0f, 1.0f);
+  // ORP121 C-01: Allow gains up to +12 dB (3.981 linear)
+  gain = std::clamp(gain, 0.0f, MAX_LINEAR_GAIN);
   m_current = gain;
   m_target = gain;
   m_pending_target.store(gain, std::memory_order_release);

--- a/src/core/routing/gain_smoother.h
+++ b/src/core/routing/gain_smoother.h
@@ -42,9 +42,16 @@ public:
   GainSmoother(uint32_t sample_rate, float smoothing_time_ms);
 
   /// Set target gain (thread-safe, lock-free)
-  /// @param target Target gain value (linear, 0.0 = silence, 1.0 = unity)
+  /// @param target Target gain value (linear, 0.0 = silence, 1.0 = unity, max = +12 dB)
   /// @note Called from UI thread, takes effect on next audio callback
   void setTarget(float target);
+
+  /// Maximum gain in dB (allows boost capability for professional mixing)
+  static constexpr float MAX_GAIN_DB = 12.0f;
+
+  /// Maximum linear gain value (10^(12/20) ≈ 3.981)
+  /// 32-bit float provides ~1528 dB headroom; clipping at output stage is sufficient
+  static constexpr float MAX_LINEAR_GAIN = 3.981071705534972f;
 
   /// Get current target gain (thread-safe read)
   /// @return Current target gain

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -60,11 +60,11 @@ SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config) {
   m_master_gain_smoother = std::make_unique<GainSmoother>(sample_rate, config.gain_smoothing_ms);
   m_master_gain_smoother->reset(1.0f); // Unity gain
 
-  // Pre-allocate audio processing buffers
+  // ORP121 A-02: Pre-allocate stereo audio processing buffers
   m_group_buffers.clear();
   m_group_buffers.resize(config.num_groups);
   for (auto& buffer : m_group_buffers) {
-    buffer.resize(MAX_BUFFER_SIZE, 0.0f);
+    buffer.resize(MAX_BUFFER_SIZE); // Allocates both L and R channels
   }
 
   m_temp_buffer.clear();
@@ -526,14 +526,14 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
   const RoutingConfig& config = m_config_buffers[config_idx];
 
   // ========================================================================
-  // Step 1: Clear group buffers
+  // Step 1: Clear stereo group buffers (ORP121 A-02)
   // ========================================================================
   for (uint8_t grp = 0; grp < config.num_groups; ++grp) {
-    std::memset(m_group_buffers[grp].data(), 0, num_frames * sizeof(float));
+    m_group_buffers[grp].clear();
   }
 
   // ========================================================================
-  // Step 2: Process channels → groups
+  // Step 2: Process channels → groups (ORP121 A-02/C-04: Stereo with pan law)
   // ========================================================================
   // Note: Use Instruments/perf for audio thread profiling, not file I/O
 
@@ -548,50 +548,68 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
 
     // Check if channel is effectively muted (explicit mute or solo)
     if (isChannelMuted(ch)) {
+      // Still need to advance smoothers to stay in sync
+      for (uint32_t frame = 0; frame < num_frames; ++frame) {
+        channel.gain_smoother->process();
+        channel.pan_left->process();
+        channel.pan_right->process();
+      }
       continue;
     }
 
     // Get input buffer for this channel
     const float* input = channel_inputs[ch];
-
-    // Get group buffer
-    float* group_buffer = m_group_buffers[group_idx].data();
-
-    // Process channel gain + sum into group
-    // For stereo: mono input → pan to L/R → sum into group buffer
-    for (uint32_t frame = 0; frame < num_frames; ++frame) {
-      // Get smoothed gain values for this sample
-      float channel_gain = channel.gain_smoother->process();
-
-      // TODO: Stereo panning requires dual group buffers (L/R per group)
-      // For now, just advance pan smoothers to keep them in sync
-      float pan_left = channel.pan_left->process();
-      float pan_right = channel.pan_right->process();
-      (void)pan_left;  // Unused for now
-      (void)pan_right; // Unused for now
-
-      // Read input sample
-      float sample = input[frame];
-
-      // Apply channel gain
-      sample *= channel_gain;
-
-      // For stereo output: sum L/R panned samples
-      // (For now, sum mono signal - full stereo panning requires 2 group buffers per group)
-      group_buffer[frame] += sample; // Mono sum for now
+    if (!input) {
+      // No input for this channel - advance smoothers and skip
+      for (uint32_t frame = 0; frame < num_frames; ++frame) {
+        channel.gain_smoother->process();
+        channel.pan_left->process();
+        channel.pan_right->process();
+      }
+      continue;
     }
 
-    // Update channel meters (if enabled)
+    // Get stereo group buffer (ORP121 A-02)
+    auto& group_buffer = m_group_buffers[group_idx];
+
+    // ORP121 A-02/C-04: Process channel gain + pan → stereo group buffer
+    // Pan law: constant-power (-3 dB at center)
+    // pan_left/pan_right are pre-computed in updatePanLaw()
+    for (uint32_t frame = 0; frame < num_frames; ++frame) {
+      // Get smoothed gain and pan values for this sample
+      float channel_gain = channel.gain_smoother->process();
+      float pan_left = channel.pan_left->process();
+      float pan_right = channel.pan_right->process();
+
+      // Read input sample and apply channel gain
+      float sample = input[frame] * channel_gain;
+
+      // ORP121 C-04: Apply pan law (constant-power stereo positioning)
+      // pan_left/pan_right encode the constant-power coefficients:
+      // - Center (pan=0): L=R=0.707 (-3 dB each, total energy preserved)
+      // - Hard left (pan=-1): L=1.0, R=0.0
+      // - Hard right (pan=+1): L=0.0, R=1.0
+      float sample_L = sample * pan_left;
+      float sample_R = sample * pan_right;
+
+      // Sum into stereo group buffer
+      group_buffer.left[frame] += sample_L;
+      group_buffer.right[frame] += sample_R;
+    }
+
+    // Update channel meters using left channel (if enabled)
+    // TODO: Proper stereo metering would meter both channels
     if (config.enable_metering) {
-      processMetering(group_buffer, num_frames, channel.peak_level, channel.rms_level);
-      if (detectClipping(group_buffer, num_frames)) {
+      processMetering(group_buffer.left.data(), num_frames, channel.peak_level, channel.rms_level);
+      if (detectClipping(group_buffer.left.data(), num_frames) ||
+          detectClipping(group_buffer.right.data(), num_frames)) {
         channel.clip_count.fetch_add(1, std::memory_order_relaxed);
       }
     }
   }
 
   // ========================================================================
-  // Step 3: Process groups → master
+  // Step 3: Process groups → master (ORP121 A-02: Stereo groups)
   // ========================================================================
   // Clear master output first
   for (uint8_t out = 0; out < config.num_outputs; ++out) {
@@ -603,33 +621,53 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
 
     // Check if group is effectively muted
     if (isGroupMuted(grp)) {
+      // Still need to advance gain smoother to stay in sync
+      for (uint32_t frame = 0; frame < num_frames; ++frame) {
+        group.gain_smoother->process();
+      }
       continue;
     }
 
-    // Get group buffer
-    float* group_buffer = m_group_buffers[grp].data();
+    // Get stereo group buffer (ORP121 A-02)
+    auto& group_buffer = m_group_buffers[grp];
 
-    // Process group gain + sum into master
+    // ORP121 A-03: Get output bus assignment (stereo pair)
+    // output_bus 0 = channels 0-1 (stereo pair 1)
+    // output_bus 1 = channels 2-3 (stereo pair 2)
+    // etc.
+    uint8_t output_bus = group.config.output_bus;
+    uint8_t out_L = output_bus * 2;
+    uint8_t out_R = output_bus * 2 + 1;
+
+    // Validate output channels exist
+    if (out_R >= config.num_outputs) {
+      // Output bus doesn't exist - route to master (0-1)
+      out_L = 0;
+      out_R = std::min((uint8_t)1, (uint8_t)(config.num_outputs - 1));
+    }
+
+    // Process group gain + sum into master (ORP121 A-02: stereo)
     for (uint32_t frame = 0; frame < num_frames; ++frame) {
       // Get smoothed group gain for this sample
       float group_gain = group.gain_smoother->process();
 
-      // Read group sample
-      float sample = group_buffer[frame];
+      // Read stereo group samples and apply gain
+      float sample_L = group_buffer.left[frame] * group_gain;
+      float sample_R = group_buffer.right[frame] * group_gain;
 
-      // Apply group gain
-      sample *= group_gain;
-
-      // Sum into master output (stereo: same to both L/R for now)
-      for (uint8_t out = 0; out < std::min(config.num_outputs, (uint8_t)2); ++out) {
-        master_output[out][frame] += sample;
+      // Sum into master output at configured output bus
+      master_output[out_L][frame] += sample_L;
+      if (out_L != out_R) { // Only write R if stereo output
+        master_output[out_R][frame] += sample_R;
       }
     }
 
-    // Update group meters (if enabled)
+    // Update group meters using left channel (if enabled)
+    // TODO: Proper stereo metering would meter both channels
     if (config.enable_metering) {
-      processMetering(group_buffer, num_frames, group.peak_level, group.rms_level);
-      if (detectClipping(group_buffer, num_frames)) {
+      processMetering(group_buffer.left.data(), num_frames, group.peak_level, group.rms_level);
+      if (detectClipping(group_buffer.left.data(), num_frames) ||
+          detectClipping(group_buffer.right.data(), num_frames)) {
         group.clip_count.fetch_add(1, std::memory_order_relaxed);
       }
     }
@@ -676,20 +714,35 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
   // ========================================================================
   // OCC109 v0.2.2: Fix "Stop All" distortion when 32 clips fade out simultaneously
   // Soft limiter prevents audible distortion when summed gains exceed 0dBFS
+  //
+  // ORP121 C-02: Fixed discontinuity in soft-knee limiter
+  // Previous implementation had discontinuity at 0.9 threshold causing audible clicks
+  // New implementation uses continuous soft-knee compression starting at -2 dBFS
   if (config.enable_clipping_protection) {
+    // Soft-knee limiter constants (ORP121 C-02)
+    static constexpr float THRESHOLD = 0.794f; // -2 dBFS (10^(-2/20))
+    static constexpr float KNEE_WIDTH = 0.3f;  // Soft knee range for gradual compression
+    static constexpr float CEILING = 0.9999f;  // Final hard limit (-0.001 dBFS)
+
     for (uint8_t out = 0; out < config.num_outputs; ++out) {
       for (uint32_t frame = 0; frame < num_frames; ++frame) {
         float sample = master_output[out][frame];
+        float abs_sample = std::abs(sample);
 
-        // Soft-knee limiter using tanh (smooth compression near ±1.0)
-        // tanh(x) naturally compresses values approaching ±infinity to ±1.0
-        // Scale factor 0.9 provides headroom and prevents hard clipping
-        if (std::abs(sample) > 0.9f) {
-          sample = std::tanh(sample * 0.9f) / 0.9f;
+        // ORP121 C-02: Continuous soft-knee limiter
+        // Uses soft-knee compression starting at -2 dBFS with smooth transition
+        // Curve is C1 continuous (no jumps, smooth derivative)
+        //
+        // Mathematical verification:
+        // - At threshold (0.794): excess=0, tanh(0)=0, output=0.794 (continuous)
+        // - At 1.0: excess=0.206, tanh(0.687)=0.596, output=0.794+0.179=0.973
+        // - At 2.0: excess=1.206, tanh(4.02)=0.999, output clamped to 0.9999
+        if (abs_sample > THRESHOLD) {
+          float excess = abs_sample - THRESHOLD;
+          float knee_ratio = excess / KNEE_WIDTH;
+          float compressed = THRESHOLD + std::tanh(knee_ratio) * KNEE_WIDTH;
+          sample = std::copysign(std::min(compressed, CEILING), sample);
         }
-
-        // Hard clip as safety (broadcast-safe, never exceeds ±1.0)
-        sample = std::max(-1.0f, std::min(1.0f, sample));
 
         master_output[out][frame] = sample;
       }

--- a/src/core/routing/routing_matrix.h
+++ b/src/core/routing/routing_matrix.h
@@ -81,6 +81,23 @@ struct GroupState {
   GroupState& operator=(GroupState&&) = delete;
 };
 
+/// ORP121 A-02: Stereo group buffer for true stereo imaging
+/// Each group has L/R channel pair instead of mono
+struct StereoGroupBuffer {
+  std::vector<float> left;  ///< Left channel samples
+  std::vector<float> right; ///< Right channel samples
+
+  void resize(size_t frames) {
+    left.resize(frames, 0.0f);
+    right.resize(frames, 0.0f);
+  }
+
+  void clear() {
+    std::fill(left.begin(), left.end(), 0.0f);
+    std::fill(right.begin(), right.end(), 0.0f);
+  }
+};
+
 /// Routing matrix implementation
 class RoutingMatrix : public IRoutingMatrix {
 public:
@@ -166,9 +183,9 @@ private:
   // Callback
   IRoutingCallback* m_callback;
 
-  // Audio processing buffers (pre-allocated)
-  std::vector<std::vector<float>> m_group_buffers; // [num_groups][max_buffer_size]
-  std::vector<float> m_temp_buffer;                // Temp buffer for processing
+  // ORP121 A-02: Audio processing buffers (pre-allocated, stereo)
+  std::vector<StereoGroupBuffer> m_group_buffers; // [num_groups] stereo L/R pairs
+  std::vector<float> m_temp_buffer;               // Temp buffer for processing
 
   static constexpr size_t MAX_BUFFER_SIZE = 2048;
   static constexpr uint8_t UNASSIGNED_GROUP = 255;

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -914,17 +914,51 @@ void TransportController::removeActiveClip(ClipHandle handle) {
 }
 
 void TransportController::postCallback(std::function<void()> callback) {
-  std::lock_guard<std::mutex> lock(m_callbackMutex);
-  m_callbackQueue.push(std::move(callback));
+  // ORP121 C-03: Lock-free SPSC callback queue
+  // Audio thread writes to ring buffer (no mutex, no blocking)
+  //
+  // Memory ordering rationale:
+  // - relaxed for same-thread reads (writeIdx in postCallback)
+  // - acquire for cross-thread reads (readIdx check for full detection)
+  // - release for writes (ensures callback data visible before index update)
+
+  size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_relaxed);
+  size_t nextIdx = (writeIdx + 1) & (CALLBACK_QUEUE_SIZE - 1); // Mask for wrap (power of 2)
+
+  // Check if queue full (read index caught up)
+  if (nextIdx == m_callbackReadIndex.load(std::memory_order_acquire)) {
+    // Queue full - drop callback (better than blocking audio thread)
+    // Increment dropped callback counter for diagnostics
+    m_droppedCallbackCount.fetch_add(1, std::memory_order_relaxed);
+    return;
+  }
+
+  m_callbackRing[writeIdx] = std::move(callback);
+  m_callbackWriteIndex.store(nextIdx, std::memory_order_release);
 }
 
 void TransportController::processCallbacks() {
-  std::lock_guard<std::mutex> lock(m_callbackMutex);
-  while (!m_callbackQueue.empty()) {
-    auto callback = std::move(m_callbackQueue.front());
-    m_callbackQueue.pop();
-    callback();
+  // ORP121 C-03: Lock-free SPSC callback queue
+  // UI thread reads from ring buffer (no mutex, no blocking)
+  //
+  // Memory ordering rationale:
+  // - relaxed for same-thread reads (readIdx in processCallbacks)
+  // - acquire for cross-thread reads (writeIdx to see all pending callbacks)
+  // - release for writes (ensures slot cleared before index update)
+
+  size_t readIdx = m_callbackReadIndex.load(std::memory_order_relaxed);
+  size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_acquire);
+
+  while (readIdx != writeIdx) {
+    auto& callback = m_callbackRing[readIdx];
+    if (callback) {
+      callback();
+      callback = nullptr; // Clear slot to release captured resources
+    }
+    readIdx = (readIdx + 1) & (CALLBACK_QUEUE_SIZE - 1);
   }
+
+  m_callbackReadIndex.store(readIdx, std::memory_order_release);
 }
 
 SessionGraphError TransportController::registerClipAudio(ClipHandle handle,

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -26,10 +26,16 @@ TransportController::TransportController(core::SessionGraph* sessionGraph, uint3
   // Create and initialize routing matrix
   m_routingMatrix = createRoutingMatrix();
 
+  // ORP121 A-01: ST2110-aligned channel architecture
+  // Each clip can use up to 2 routing channels (L/R for stereo sources)
+  // Mono sources use 1 channel, stereo sources use 2 independent channels
+  // This follows ST2110-30 principle: audio as discrete independent channels
+  static constexpr size_t MAX_ROUTING_CHANNELS = MAX_ACTIVE_CLIPS * 2;
+
   RoutingConfig routingConfig;
-  routingConfig.num_channels = MAX_ACTIVE_CLIPS; // One channel per possible active clip
-  routingConfig.num_groups = 4;                  // 4 Clip Groups (as per ORP070)
-  routingConfig.num_outputs = 2;                 // Stereo output
+  routingConfig.num_channels = MAX_ROUTING_CHANNELS; // 2 channels per clip (stereo support)
+  routingConfig.num_groups = 4;                      // 4 Clip Groups (as per ORP070)
+  routingConfig.num_outputs = 2;                     // Stereo output
   routingConfig.solo_mode = SoloMode::SIP;
   routingConfig.metering_mode = MeteringMode::Peak;
   routingConfig.gain_smoothing_ms =
@@ -41,21 +47,49 @@ TransportController::TransportController(core::SessionGraph* sessionGraph, uint3
 
   m_routingMatrix->initialize(routingConfig);
 
+  // ORP121 A-01: Configure channel pairs for stereo routing
+  // Each clip's L channel: pan = -1.0 (hard left)
+  // Each clip's R channel: pan = +1.0 (hard right)
+  // Both channels route to the same group (group 0 by default)
+  for (size_t clip = 0; clip < MAX_ACTIVE_CLIPS; ++clip) {
+    size_t ch_L = clip * 2;
+    size_t ch_R = clip * 2 + 1;
+
+    // Configure L channel (hard left pan)
+    ChannelConfig configL;
+    configL.gain_db = 0.0f;
+    configL.pan = -1.0f; // Hard left for stereo L channel
+    configL.mute = false;
+    configL.solo = false;
+    m_routingMatrix->configureChannel(static_cast<uint8_t>(ch_L), configL);
+    m_routingMatrix->setChannelGroup(static_cast<uint8_t>(ch_L), 0);
+
+    // Configure R channel (hard right pan)
+    ChannelConfig configR;
+    configR.gain_db = 0.0f;
+    configR.pan = 1.0f; // Hard right for stereo R channel
+    configR.mute = false;
+    configR.solo = false;
+    m_routingMatrix->configureChannel(static_cast<uint8_t>(ch_R), configR);
+    m_routingMatrix->setChannelGroup(static_cast<uint8_t>(ch_R), 0);
+  }
+
   // Pre-allocate per-clip read buffers (interleaved audio from files)
   m_clipReadBuffers.resize(MAX_ACTIVE_CLIPS);
   for (auto& buffer : m_clipReadBuffers) {
     buffer.resize(MAX_BUFFER_FRAMES * MAX_FILE_CHANNELS, 0.0f);
   }
 
-  // Pre-allocate per-clip channel buffers (mono output for routing)
-  m_clipChannelBuffers.resize(MAX_ACTIVE_CLIPS);
+  // ORP121 A-01: Pre-allocate stereo clip channel buffers
+  // Each clip has L and R buffers: index = clip * 2 + (0 for L, 1 for R)
+  m_clipChannelBuffers.resize(MAX_ROUTING_CHANNELS);
   for (auto& buffer : m_clipChannelBuffers) {
     buffer.resize(MAX_BUFFER_FRAMES, 0.0f);
   }
 
   // Pre-allocate pointer array for processRouting()
-  m_clipChannelPointers.resize(MAX_ACTIVE_CLIPS);
-  for (size_t i = 0; i < MAX_ACTIVE_CLIPS; ++i) {
+  m_clipChannelPointers.resize(MAX_ROUTING_CHANNELS);
+  for (size_t i = 0; i < MAX_ROUTING_CHANNELS; ++i) {
     m_clipChannelPointers[i] = m_clipChannelBuffers[i].data();
   }
 
@@ -279,8 +313,9 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
   // Clamp frames to max buffer size
   numFrames = std::min(numFrames, MAX_BUFFER_FRAMES);
 
-  // Clear all clip channel buffers
-  for (size_t i = 0; i < MAX_ACTIVE_CLIPS; ++i) {
+  // ORP121 A-01: Clear all clip channel buffers (stereo - 2 per clip)
+  static constexpr size_t MAX_ROUTING_CHANNELS = MAX_ACTIVE_CLIPS * 2;
+  for (size_t i = 0; i < MAX_ROUTING_CHANNELS; ++i) {
     std::memset(m_clipChannelBuffers[i].data(), 0, numFrames * sizeof(float));
   }
 
@@ -399,8 +434,8 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
 
     size_t framesRead = readResult.value;
 
-    // Output to this clip's channel buffer (mono sum for routing)
-    float* clipChannelBuffer = m_clipChannelBuffers[i].data();
+    // ORP121 A-01: Stereo output to L/R channel buffers (indices i*2 and i*2+1)
+    // No mono sum - preserves source channel separation per ST2110-30
 
     // Load precomputed linear gain (atomic read, no pow() call in audio thread!)
     float clipGainLinear = clip.gainLinear.load(std::memory_order_acquire);
@@ -457,15 +492,32 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
         }
       }
 
-      // Mix all file channels to mono for routing
-      float monoSample = 0.0f;
-      for (size_t ch = 0; ch < numFileChannels; ++ch) {
-        size_t srcIndex = frame * numFileChannels + ch;
-        monoSample += clipReadBuffer[srcIndex];
-      }
-      monoSample /= static_cast<float>(numFileChannels); // Average channels
+      // ORP121 A-01: Preserve stereo from source (ST2110-aligned)
+      // Each file channel maps to discrete routing channels
+      // - Mono: Duplicate to L/R (phantom center image)
+      // - Stereo: Direct L→L, R→R mapping
+      // - Multi-channel (>2): ITU-R BS.775-3 downmix to stereo
+      float sample_L, sample_R;
 
-      clipChannelBuffer[frame] = monoSample * gain;
+      if (numFileChannels == 1) {
+        // Mono source: Duplicate to both L/R (centered phantom image)
+        float mono = clipReadBuffer[frame];
+        sample_L = mono;
+        sample_R = mono;
+      } else if (numFileChannels == 2) {
+        // Stereo source: Preserve L/R separation
+        sample_L = clipReadBuffer[frame * 2 + 0];
+        sample_R = clipReadBuffer[frame * 2 + 1];
+      } else {
+        // Multi-channel (>2): Apply ITU-R BS.775-3 downmix to stereo
+        sample_L = applyDownmixLeft(clipReadBuffer, frame, numFileChannels);
+        sample_R = applyDownmixRight(clipReadBuffer, frame, numFileChannels);
+      }
+
+      // Apply gain and write to stereo clip buffers
+      // L channel at index i*2, R channel at index i*2+1
+      m_clipChannelBuffers[i * 2][frame] = sample_L * gain;
+      m_clipChannelBuffers[i * 2 + 1][frame] = sample_R * gain;
     }
 
     // Advance clip position by actual frames read (not buffer size!)
@@ -1691,6 +1743,77 @@ SessionGraphError TransportController::removeCuePoint(ClipHandle handle, uint32_
   cuePoints.erase(cuePoints.begin() + cueIndex);
 
   return SessionGraphError::OK;
+}
+
+// ============================================================================
+// ORP121 A-01: ITU-R BS.775-3 Downmix Helper Functions
+// Standard coefficients for multi-channel to stereo conversion
+// ============================================================================
+
+/// ITU-R BS.775-3 standard downmix coefficients
+/// These values ensure energy-preserving downmix from surround to stereo
+static constexpr float DOWNMIX_CENTER = 0.7071067811865476f;   // 1/sqrt(2) = -3dB
+static constexpr float DOWNMIX_SURROUND = 0.7071067811865476f; // 1/sqrt(2) = -3dB
+
+float TransportController::applyDownmixLeft(const float* src, size_t frame, size_t numCh) const {
+  // ITU-R BS.775-3 downmix to left channel
+  // Standard 5.1 layout: L=0, R=1, C=2, LFE=3, Ls=4, Rs=5
+  // Formula: L_out = L + 0.707*C + 0.707*Ls
+
+  if (numCh < 3) {
+    // Mono or stereo - just return left channel (or mono)
+    return src[frame * numCh];
+  }
+
+  if (numCh < 6) {
+    // 3-5 channels (unusual layouts) - simple left-weighted average
+    float sum = 0.0f;
+    for (size_t ch = 0; ch < numCh; ch += 2) {
+      sum += src[frame * numCh + ch];
+    }
+    return sum / static_cast<float>((numCh + 1) / 2);
+  }
+
+  // 5.1 or higher: Full ITU-R BS.775-3 downmix
+  float L = src[frame * numCh + 0];  // Left
+  float C = src[frame * numCh + 2];  // Center
+  float Ls = src[frame * numCh + 4]; // Left Surround
+
+  // Note: LFE (channel 3) typically excluded from stereo downmix per spec
+  return L + DOWNMIX_CENTER * C + DOWNMIX_SURROUND * Ls;
+}
+
+float TransportController::applyDownmixRight(const float* src, size_t frame, size_t numCh) const {
+  // ITU-R BS.775-3 downmix to right channel
+  // Standard 5.1 layout: L=0, R=1, C=2, LFE=3, Ls=4, Rs=5
+  // Formula: R_out = R + 0.707*C + 0.707*Rs
+
+  if (numCh < 2) {
+    // Mono - return the single channel
+    return src[frame * numCh];
+  }
+
+  if (numCh < 3) {
+    // Stereo - return right channel
+    return src[frame * numCh + 1];
+  }
+
+  if (numCh < 6) {
+    // 3-5 channels (unusual layouts) - simple right-weighted average
+    float sum = 0.0f;
+    for (size_t ch = 1; ch < numCh; ch += 2) {
+      sum += src[frame * numCh + ch];
+    }
+    return sum / static_cast<float>(numCh / 2);
+  }
+
+  // 5.1 or higher: Full ITU-R BS.775-3 downmix
+  float R = src[frame * numCh + 1];  // Right
+  float C = src[frame * numCh + 2];  // Center
+  float Rs = src[frame * numCh + 5]; // Right Surround
+
+  // Note: LFE (channel 3) typically excluded from stereo downmix per spec
+  return R + DOWNMIX_CENTER * C + DOWNMIX_SURROUND * Rs;
 }
 
 // Factory function

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -9,7 +9,6 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <unordered_map>
 
 namespace orpheus {
@@ -253,9 +252,16 @@ private:
   // Transport position (audio thread writes, UI thread reads)
   std::atomic<int64_t> m_currentSample{0};
 
-  // Callback queue (Audio → UI thread)
-  std::mutex m_callbackMutex;
-  std::queue<std::function<void()>> m_callbackQueue;
+  // ORP121 C-03: Lock-free callback queue (Audio → UI thread)
+  // SPSC ring buffer: Audio thread writes, UI thread reads - no contention
+  // Power of 2 size for efficient modulo via bitwise AND
+  static constexpr size_t CALLBACK_QUEUE_SIZE = 256;
+  std::array<std::function<void()>, CALLBACK_QUEUE_SIZE> m_callbackRing;
+  std::atomic<size_t> m_callbackWriteIndex{0};
+  std::atomic<size_t> m_callbackReadIndex{0};
+
+  // Diagnostic counter for dropped callbacks (queue overflow)
+  std::atomic<uint32_t> m_droppedCallbackCount{0};
 
   // Fade parameters
   static constexpr float FADE_OUT_DURATION_MS = 10.0f;

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -303,9 +303,15 @@ private:
   std::vector<std::vector<float>>
       m_clipReadBuffers; // [MAX_ACTIVE_CLIPS][MAX_BUFFER_FRAMES * MAX_FILE_CHANNELS]
 
-  // Each clip gets its own channel buffer for routing (mono summed output)
-  std::vector<std::vector<float>> m_clipChannelBuffers; // [MAX_ACTIVE_CLIPS][MAX_BUFFER_FRAMES]
+  // ORP121 A-01: Stereo clip buffers for routing (preserves source L/R)
+  // Each clip has L and R buffers: [clip_index * 2 + 0] = L, [clip_index * 2 + 1] = R
+  // Total channels = MAX_ACTIVE_CLIPS * 2 for stereo preservation
+  std::vector<std::vector<float>> m_clipChannelBuffers; // [MAX_ACTIVE_CLIPS * 2][MAX_BUFFER_FRAMES]
   std::vector<float*> m_clipChannelPointers;            // Pointers for processRouting()
+
+  // ORP121 A-01: ITU-R BS.775-3 downmix helpers for multi-channel sources
+  float applyDownmixLeft(const float* src, size_t frame, size_t numCh) const;
+  float applyDownmixRight(const float* src, size_t frame, size_t numCh) const;
 };
 
 } // namespace orpheus

--- a/tests/routing/routing_matrix_test.cpp
+++ b/tests/routing/routing_matrix_test.cpp
@@ -221,15 +221,16 @@ TEST_F(RoutingMatrixTest, ChannelGainAttenuation) {
   // After smoothing, output should be attenuated
   // -6 dB = 0.5 linear, so peak should be ~0.5
   // For sine wave: avg(abs(x)) = (2/π) * amplitude ≈ 0.637 * amplitude
-  // Expected: 0.637 * 0.5 = 0.318
+  // ORP121 C-04: Constant-power pan law applies -3 dB (0.707) at center
+  // Expected: 0.637 * 0.5 * 0.707 = 0.225
   float avg_output = 0.0f;
   for (uint32_t i = BUFFER_SIZE / 2; i < BUFFER_SIZE; ++i) { // Second half (after transient)
     avg_output += std::abs(outputs[0][i]);
   }
   avg_output /= (BUFFER_SIZE / 2);
 
-  // Expect approximately 0.318 (0.5 peak × 0.637 sine wave factor)
-  EXPECT_NEAR(avg_output, 0.318f, 0.05f);
+  // Expect approximately 0.225 (0.5 peak × 0.637 sine × 0.707 pan law)
+  EXPECT_NEAR(avg_output, 0.225f, 0.05f);
 }
 
 TEST_F(RoutingMatrixTest, MasterGainAttenuation) {
@@ -259,13 +260,16 @@ TEST_F(RoutingMatrixTest, MasterGainAttenuation) {
 
   // Output should be attenuated by master gain
   // For sine wave with -6 dB gain: avg(abs(x)) ≈ 0.318
+  // ORP121 C-04: Constant-power pan law applies -3 dB (0.707) at center
+  // Expected: 0.637 * 0.5 * 0.707 = 0.225
   float avg_output = 0.0f;
   for (uint32_t i = BUFFER_SIZE / 2; i < BUFFER_SIZE; ++i) {
     avg_output += std::abs(outputs[0][i]);
   }
   avg_output /= (BUFFER_SIZE / 2);
 
-  EXPECT_NEAR(avg_output, 0.318f, 0.05f);
+  // Expect approximately 0.225 (0.5 peak × 0.637 sine × 0.707 pan law)
+  EXPECT_NEAR(avg_output, 0.225f, 0.05f);
 }
 
 // ============================================================================
@@ -375,8 +379,9 @@ TEST_F(RoutingMatrixTest, MeteringDetectsPeak) {
   // Check master meter
   auto meter = matrix->getMasterMeter();
 
-  // Peak should be close to 1.0 (unity gain)
-  EXPECT_NEAR(meter.peak_db, 0.0f, 1.0f); // 0 dB = unity
+  // ORP121 C-04: Constant-power pan law applies -3 dB (0.707) at center
+  // Peak should be close to -3 dB (unity input × 0.707 pan law)
+  EXPECT_NEAR(meter.peak_db, -3.0f, 1.0f); // -3 dB due to pan law at center
 }
 
 TEST_F(RoutingMatrixTest, MeteringDetectsClipping) {


### PR DESCRIPTION
## Summary

This PR implements the ORP121 Audio Backend Refactoring Master Plan (Phases 1-3), addressing critical bugs and architectural gaps to achieve production-ready status for broadcast/theater applications.

### Phase 1: Critical Bug Fixes (P0)
- **C-01**: GainSmoother now supports +12 dB boost (was clamped at 0 dB)
- **C-02**: Soft-knee tanh limiter with C1-continuous curve at -2 dBFS threshold (fixes audible click at 0.9)
- **C-03**: Lock-free SPSC ring buffer for callback queue (eliminates priority inversion risk)
- **C-04**: Constant-power pan law implementation (-3 dB at center, stereo positioning now works)

### Phase 2: Stereo Routing (P1)
- **A-01**: Preserve stereo from source files (ST2110-aligned discrete channel routing)
- **A-02**: Stereo group buffers with proper L/R separation
- **A-03**: Output bus routing respected (groups route to configured stereo pairs)
- **A-06**: Complete gain staging documentation (GAIN_STAGING.md)

### Phase 3: Multi-Channel Architecture (P1)
- **A-04**: Channel format abstraction (ChannelLayout enum, Speaker positions, ChannelFormat struct)
- **A-05**: ITU-R BS.775-3 compliant downmix/upmix matrices (5.1→stereo, 7.1→stereo, 7.1→5.1)

### Key Technical Details
- Follows ST2110-30 principles for discrete independent channel routing
- ITU-R BS.775-3 standard downmix coefficients (K_CENTER = K_SURROUND = 0.707)
- 64 routing channels (MAX_ACTIVE_CLIPS × 2) for full stereo preservation
- Lock-free SPSC queue with 256-slot ring buffer (memory order: relaxed/acquire/release)

### Files Changed
- `include/orpheus/channel_format.h` - New multi-channel format abstraction
- `src/core/channel_format.cpp` - Format factories and mix matrices
- `src/core/routing/gain_smoother.{h,cpp}` - +12 dB boost support
- `src/core/routing/routing_matrix.{h,cpp}` - Pan law, stereo groups, soft limiter
- `src/core/transport/transport_controller.{h,cpp}` - Stereo preservation, lock-free callbacks
- `docs/orp/GAIN_STAGING.md` - Complete gain staging documentation
- `tests/routing/routing_matrix_test.cpp` - Updated for constant-power pan law

## Test plan
- [x] All 23 routing_matrix_test cases pass
- [x] Build succeeds on macOS (Debug)
- [ ] Run full CI pipeline
- [ ] Verify stereo files preserve L/R separation
- [ ] Verify panning affects L/R balance correctly
- [ ] Test 5.1 downmix with reference material

## References
- ORP121 Audio Backend Refactoring Master Plan
- ITU-R BS.775-3 (Multichannel stereophonic sound system downmix)
- ST2110-30 (Professional media over IP - audio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)