### PR TITLE
feat(audio-io/dsp): variable-rate + reverse scrub reader (FTR018 §1/§2)

### DIFF
--- a/docs/orp/ORP.md
+++ b/docs/orp/ORP.md
@@ -4,13 +4,13 @@ Project documentation index for orpheus-sdk.
 
 ## Recent Documents
 
+- [[ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation]]
 - [[ORP128 CoreAudio Device Sample-Rate Change Resilience]]
 - [[ORP127 Transport Voice Model and Gain Integrity Sprint]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP124 Architecture Cross-Reference Matrix]]
 - [[ORP123 Wireframes and Documentation Update]]
-- [[ORP118 Multi-Voice Architecture and Audio Summing Topology]]
 
 ## All Documents
 
@@ -87,6 +87,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP127 Transport Voice Model and Gain Integrity Sprint]]
 - [[ORP128 CoreAudio Device Sample-Rate Change Resilience]]
+- [[ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation]]
 
 ## Navigation
 

--- a/docs/orp/ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation.md
+++ b/docs/orp/ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation.md
@@ -1,0 +1,153 @@
+# ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation
+
+**Status:** Implemented — branch `feat/orp-scrub-reader`, PR open against `main`
+**Author:** ORP129 scrub-reader sprint, 2026-07-09
+**Scope:** SDK audio I/O (`include/orpheus/audio_file_reader.h`, `src/core/audio_io/`) and DSP (`include/orpheus/dsp/`)
+**Related:** FTR018 (inbound handoff spec, FourTrack), FTR017 (jog-wheel consumer), ORP127 (voice/SRC sprint — PolyphaseResampler), ORP128 (CoreAudio SR resilience)
+
+---
+
+## Summary
+
+Implements the two primitives requested by the FourTrack FTR018 handoff so the
+SDK can serve an audible, time-varying, forward-**and-backward** scrub (tape/CDJ
+jog), lifting the capability out of FourTrack's local stopgap
+(`fourtrack::dsp::ScrubResampler`) and into the shared SDK per the "fix at the
+source" convention:
+
+1. **§1 — backward/windowed read** (`IAudioFileReader::readSamplesEndingAt`): the
+   primary ask. A reader can now return a window of frames *ending at* an
+   arbitrary position, in forward order, for the caller to play out in reverse —
+   removing the reverse-depth bound of a fixed local history ring.
+2. **§2 — variable-rate + reverse resampler** (`orpheus::ScrubResampler`): a
+   per-track, RT-safe, linear-interpolating resampler at an arbitrary, mutable,
+   **signed** rate, with persistent fractional phase for click-free rate changes.
+
+Both are host-neutral, dependency-free, and built into `Orpheus::audio_utils`
+(alongside `PolyphaseResampler`). No existing consumer changed behavior.
+
+## §1 — `readSamplesEndingAt` (backward/windowed read)
+
+```cpp
+// IAudioFileReader — DEFAULTED virtual (not = 0).
+virtual Result<size_t> readSamplesEndingAt(int64_t end_sample, float* buffer,
+                                           size_t num_frames);
+```
+
+- Fills `buffer` with the frame window `[end_sample - num_frames + 1, end_sample]`
+  in **forward** (ascending-index) order; the caller emits it in reverse.
+- Underflow below index 0 clamps to the in-range trailing frames; the returned
+  count reflects only the frames actually read.
+- **Restores** the read position observed on entry, so it composes with ordinary
+  forward `readSamples()` streaming.
+
+**Defaulted, not pure — a hard constraint.** A pure-virtual `= 0` would
+transitively break every existing `IAudioFileReader` implementation
+(`AudioFileReaderLibsndfile`, `AudioFileReaderExtended`,
+`ResamplingAudioFileReader`) and Clip Composer, plus their tests. The base class
+therefore ships a portable default (`src/core/audio_io/audio_file_reader.cpp`,
+always built) implemented purely on the existing `seek` + `readSamples`
+primitives, so every reader gets reverse for free.
+`AudioFileReaderLibsndfile` overrides it with a single locked
+seek/read/restore directly on the sndfile handle.
+
+## §2 — `ScrubResampler` (variable-rate + reverse)
+
+`include/orpheus/dsp/scrub_resampler.h` + `src/core/audio_io/scrub_resampler.cpp`.
+Ported from `fourtrack::dsp::ScrubResampler` (the FTR017 reference) with a
+namespace change. Two ways to drive it, sharing one ring and one continuity
+guarantee:
+
+- **Ring model** (`push_forward` + `render`) — the reference/tested API. `rate < 0`
+  walks a persistent fractional cursor **down** through buffered history; reverse
+  replays forward-decoded samples. Reverse depth is ring-bounded; pair with §1 to
+  remove the bound.
+- **Per-call model** (`processVariable`) — the FTR018 §2 shape:
+
+  ```cpp
+  size_t processVariable(const float* input, size_t in_frames,
+                         float* output, size_t out_n, double rate);
+  ```
+
+  Feeds `input` as fresh forward history then renders `out_n` frames at `rate`,
+  carrying the fractional phase across calls. `input` may be null / `in_frames` 0
+  to render from existing history while reversing or holding.
+
+**RT-safety:** all storage is allocated in `prepare()`; no other method
+allocates, locks, or does I/O.
+
+**Scope boundary (honored):** `ScrubResampler` is a **pure varispeed** resampler
+— rate changes pitch and duration together, exactly as jogging a reel does.
+Independent pitch-shift / time-stretch is deliberately **out of scope**, so a
+pitch stage can compose downstream later. Linear interpolation ships; a
+cubic/Hermite kernel over the same ring is a drop-in fidelity upgrade that does
+not change the interface.
+
+## Tests
+
+Ported the FTR018 contract suite into the SDK, all green:
+
+| Case | Where |
+|------|-------|
+| pass-through 1.0×, fractional 0.5× / 2.0× | `scrub_resampler_test` |
+| reverse from mid-ring −1.0× (descending ramp) | `scrub_resampler_test` |
+| hold at 0.0 (cursor frozen) | `scrub_resampler_test` |
+| reverse/forward past buffered edge → silence (never OOB) | `scrub_resampler_test` |
+| ring-wrap keeps absolute indexing correct | `scrub_resampler_test` |
+| `processVariable` pass-through + cross-call phase + signed reverse | `scrub_resampler_test` |
+| `readSamplesEndingAt` forward-order / position-restore / underflow-clamp / guards / reverse-emit (base default) | `reverse_read_test` |
+| `readSamplesEndingAt` libsndfile override over a temp WAV | `reverse_read_test` (gated on `ORPHEUS_HAVE_SNDFILE`) |
+
+`scrub_resampler_test` links only `orpheus_audio_utils` (host-neutral, no
+libsndfile), matching `polyphase_resampler_test`.
+
+**Full suite:** 122 tests, all functional tests pass. The lone red on the run
+machine — `WaveformProcessorTest.PerformanceTest10MinuteWav` — is a hardcoded
+2000 ms wall-clock assertion that flakes on either side of the threshold on
+pristine `main` (measured 1985–2049 ms across repeated runs under Debug+ASan),
+touches no code in this change, and is not a regression.
+
+## Consumer impact
+
+None. The defaulted virtual and the new DSP class are additive; the full SDK and
+its 122-test suite build and pass unchanged. Per FTR018's migration plan,
+FourTrack can later swap its local `ScrubResampler` for `orpheus::ScrubResampler`
+behind the same engine seam and drive reverse via §1 — **not done here** (no pin
+bump, no FourTrack edits).
+
+## Spec friction / deviations from FTR018
+
+- **§1 signature:** the handoff sketched `readSamplesEndingAt(...) = 0`. Shipped
+  as a **defaulted** virtual (constraint: pure-virtual breaks existing
+  consumers). Behavior is otherwise as specified.
+- **§2 shape:** the handoff named the `processVariable(input, output, rate)`
+  convenience form *and* referenced the ScrubResampler push/render/ring reference.
+  Both are exposed: the ring API is preserved (it is what the ring-wrap /
+  reverse-from-history contract tests exercise), and `processVariable` layers on
+  it so the two paths share one continuity guarantee rather than duplicating the
+  interpolation.
+- **Ownership note (deferred):** FTR018 suggests the ring could migrate to a
+  reader decorator paired with §1. This sprint keeps the ring caller-owned (as in
+  the reference) and ships §1 as the on-demand backward primitive; wiring a
+  decorator that internally drives §1 is a natural follow-up, not required to
+  unblock the consumer.
+
+## Files
+
+```
+ include/orpheus/audio_file_reader.h                |  35 +   (§1 defaulted virtual)
+ include/orpheus/dsp/scrub_resampler.h              | 141 +   (§2 class + factory)
+ src/core/audio_io/audio_file_reader.cpp            |  72 +   (§1 base default)
+ src/core/audio_io/audio_file_reader_libsndfile.*   |  59 +   (§1 override)
+ src/core/audio_io/scrub_resampler.cpp              | 122 +   (§2 impl)
+ src/core/audio_io/CMakeLists.txt                   |   8 +
+ tests/audio_io/reverse_read_test.cpp               | 249 +   (§1 suite)
+ tests/audio_io/scrub_resampler_test.cpp            | 281 +   (§2 suite)
+ tests/audio_io/CMakeLists.txt                      |  51 +
+```
+
+## Navigation
+
+- **Repo:** orpheus-sdk
+- **Docs:** `docs/orp/`
+- **Branch:** `feat/orp-scrub-reader`

--- a/include/orpheus/audio_file_reader.h
+++ b/include/orpheus/audio_file_reader.h
@@ -79,6 +79,41 @@ public:
   /// @note Buffer format: [L0, R0, L1, R1, ...] for stereo
   virtual Result<size_t> readSamples(float* buffer, size_t num_samples) = 0;
 
+  /// Read a window of frames ending at (and including) `end_sample`, for
+  /// reverse / backward playback (ORP128, FTR018).
+  ///
+  /// Fills `buffer` with up to `num_frames` interleaved frames whose absolute
+  /// frame indices are `[end_sample - num_frames + 1, end_sample]`, written in
+  /// FORWARD (ascending-index) order — the caller walks them out in reverse.
+  /// Frame indices below 0 are clamped away (the corresponding leading slots of
+  /// `buffer` are left as written by the reader; the returned count reflects only
+  /// the frames actually read, always the trailing/most-recent frames of the
+  /// window). This is the minimal primitive that lets a host stream backward
+  /// without buffering forward history itself, lifting the reverse-depth bound of
+  /// a fixed local ring.
+  ///
+  /// The base implementation is a portable seek + read that restores the prior
+  /// read position, so every reader supports reverse out of the box; concrete
+  /// readers may override with a more efficient path. This is a DEFAULTED virtual
+  /// (not pure) precisely so existing readers and consumers keep compiling.
+  ///
+  /// @param end_sample Absolute frame index of the last (highest-index) frame to
+  ///        read. If `end_sample < 0`, nothing is read (returns 0).
+  /// @param buffer Output buffer (must hold at least `num_frames * num_channels`
+  ///        floats). Frames are written contiguously starting at buffer[0]; when
+  ///        the window is clamped at the file start, fewer than `num_frames` are
+  ///        written (the caller sees the count in the Result).
+  /// @param num_frames Window length in frames.
+  /// @return Result containing the number of frames actually read (<= num_frames),
+  ///         or an error.
+  ///
+  /// @note Real-time-safe on readers that pre-reserve scratch; the base
+  ///       implementation performs I/O and is intended for background/streaming
+  ///       use unless the concrete reader documents otherwise.
+  /// @note Restores the read position (`getCurrentPosition()`) it observed on
+  ///       entry, so it composes with ordinary forward `readSamples()` streaming.
+  virtual Result<size_t> readSamplesEndingAt(int64_t end_sample, float* buffer, size_t num_frames);
+
   /// Seek to a specific sample position
   ///
   /// Sets the read position for subsequent readSamples() calls.

--- a/include/orpheus/dsp/scrub_resampler.h
+++ b/include/orpheus/dsp/scrub_resampler.h
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace orpheus {
+
+// -----------------------------------------------------------------------------
+// ScrubResampler — a real-time-safe, per-track variable-rate + reverse reader.
+//
+// ORP128 / FTR018. This is the SDK home for the audible jog-wheel scrub engine
+// FourTrack built locally (fourtrack::dsp::ScrubResampler) and handed upstream.
+// PolyphaseResampler cannot serve it: its ratio is fixed at construction and its
+// process() allocates per call. ScrubResampler drives an arbitrary, time-varying
+// rate (which may be negative) with no allocation, lock, or I/O after prepare().
+//
+// SCOPE. This is a *pure varispeed resampler*: rate changes pitch and duration
+// together (tape/CDJ scrub), exactly as jogging a reel does. Independent
+// pitch-shift / time-stretch is deliberately OUT OF SCOPE — processVariable()
+// stays a plain resampler so a pitch stage can compose downstream later.
+//
+// TWO WAYS TO DRIVE IT.
+//
+//   (a) Ring model (push_forward + render) — the reference/tested API. Feed the
+//       ring the forward-decoded samples the engine already reads at 1.0x, then
+//       render() at a persistent fractional cursor. rate < 0 walks the cursor
+//       DOWN through buffered history: reverse *replays* samples decoded forward,
+//       because a plain file reader cannot stream backward. This is what the
+//       FourTrack jog seam uses today. Its reverse depth is bounded by the ring;
+//       lift that bound by pairing it with the backward-capable reader
+//       (IAudioFileReader::readSamplesEndingAt, ORP128 §1).
+//
+//   (b) Per-call model (processVariable) — the convenience shape named by the
+//       FTR018 handoff §2: hand a block of input and get out_n output frames at
+//       `rate`, with the fractional phase carried across calls so rate changes
+//       stay click-free. Implemented on top of the same ring, so both paths share
+//       one code path and one continuity guarantee.
+//
+// REAL-TIME SAFETY. All storage is allocated in prepare() (control thread). No
+// other method allocates, locks, or does I/O: render()/processVariable() only
+// index a fixed vector and do float math, so they are safe in the audio callback.
+// Continuity — and therefore click-free rate changes — comes from the cursor
+// being *persistent* across buffers: the caller changes `rate` each buffer but
+// never re-seeds the cursor mid-gesture, so the output stays C0-continuous
+// (linear interp). The fidelity trade-off is mild high-frequency imaging at
+// extreme rates, acceptable for a live monitoring gesture; a cubic/Hermite
+// kernel is a drop-in upgrade that does not change this interface.
+//
+// OWNERSHIP. One instance per track, touched only on the audio thread after
+// prepare(). Not thread-safe; a jog rate reaches the audio thread as an atomic
+// set by the control thread, never through this object.
+// -----------------------------------------------------------------------------
+
+class ScrubResampler {
+public:
+  ScrubResampler() = default;
+
+  /// Allocate the ring. Call once off the audio thread, never from the audio
+  /// callback. `ring_capacity_frames` bounds the reverse depth (ring model).
+  void prepare(size_t ring_capacity_frames);
+
+  /// Clear buffered history and place the read cursor at `anchor_sample` (an
+  /// absolute sample index). Used on jog begin (prime) and jog end (seek/hold).
+  /// Cheap: no allocation. After reset the ring is empty; the first push_forward
+  /// must supply the samples at and after `anchor_sample`.
+  void reset(int64_t anchor_sample);
+
+  /// Append `n` freshly-decoded forward mono samples whose absolute indices are
+  /// [first_sample_index, first_sample_index + n). Samples are expected to be
+  /// contiguous with, or overlapping, what is already held; a gap forward simply
+  /// advances the newest index. Overruns the ring capacity by overwriting the
+  /// oldest samples (that is the reverse-depth bound). No allocation.
+  void push_forward(const float* mono, size_t n, int64_t first_sample_index);
+
+  /// Produce `out_n` output samples at `rate` (the cursor advances by `rate` per
+  /// output frame). Reads only from the ring: positions outside the buffered
+  /// range yield 0.0 (clamped, no out-of-bounds). Returns `out_n` (always fills
+  /// the buffer, padding with silence past the buffered edges). No allocation.
+  size_t render(float* out, size_t out_n, double rate);
+
+  /// Per-call variable-rate resample (FTR018 §2). Pushes `in_frames` of `input`
+  /// as fresh forward mono history starting at the current newest index + 1, then
+  /// renders `out_n` output frames at `rate` from the persistent cursor. `rate`
+  /// may change every call and may be negative (reverse, replaying buffered
+  /// history). No allocation: all scratch is reserved in prepare(). Returns the
+  /// number of output frames produced (== out_n; edges beyond the buffered range
+  /// are silence).
+  ///
+  /// This is the plain resampler shape the handoff names; it composes the ring
+  /// (a) API rather than duplicating it, so both paths share one continuity
+  /// guarantee. `input` may be null / `in_frames` 0 to render from existing
+  /// history without feeding new samples (e.g. while reversing or holding).
+  size_t processVariable(const float* input, size_t in_frames, float* output, size_t out_n,
+                         double rate);
+
+  /// How many forward source frames the engine should decode and push_forward()
+  /// next buffer to keep the ring ahead of the cursor for `out_n` output frames
+  /// at `rate`. Returns 0 when reversing or holding (rate <= 0) — reverse replays
+  /// buffered history and needs no new reads. Forward: enough to cover the cursor
+  /// advance plus a one-sample interpolation margin, capped to the ring capacity.
+  [[nodiscard]] size_t forward_refill_hint(double rate, size_t out_n) const;
+
+  /// The current fractional read position (absolute sample index). The engine's
+  /// integer playhead is floor(position()).
+  [[nodiscard]] double position() const {
+    return cursor_;
+  }
+
+  /// Absolute index of the newest buffered sample (highest index held), or the
+  /// last reset/push anchor even when empty.
+  [[nodiscard]] int64_t newest_sample() const {
+    return newest_sample_;
+  }
+
+  [[nodiscard]] size_t capacity() const {
+    return ring_.size();
+  }
+
+private:
+  // Fetch the buffered sample at absolute index `s`, or 0.0 if `s` is outside the
+  // currently-held range. Audio-thread only; no bounds surprises.
+  [[nodiscard]] float sample_at(int64_t s) const;
+
+  std::vector<float> ring_;    ///< Pre-allocated ring of forward-decoded samples.
+  size_t write_pos_ = 0;       ///< Next write slot in the ring (mod capacity).
+  size_t filled_ = 0;          ///< Valid samples held (<= capacity()).
+  int64_t newest_sample_ = -1; ///< Absolute index of the most recently pushed sample.
+  double cursor_ = 0.0;        ///< Absolute fractional read position.
+};
+
+/// Factory: an owned, prepared ScrubResampler (FTR018 §2 createScrubResampler
+/// shape). `ring_capacity_frames` bounds the ring-model reverse depth.
+inline ScrubResampler createScrubResampler(size_t ring_capacity_frames) {
+  ScrubResampler r;
+  r.prepare(ring_capacity_frames);
+  return r;
+}
+
+} // namespace orpheus

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -26,6 +26,10 @@ set(ORPHEUS_AUDIO_UTILS_SOURCES)
 # ORP127 G6: host-neutral, dependency-free sample-rate conversion. Always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES polyphase_resampler.cpp)
 
+# ORP128/FTR018 §1: base-interface default (readSamplesEndingAt). Host-neutral,
+# dependency-free — always built.
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader.cpp)
+
 if(SNDFILE_FOUND)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader_libsndfile.cpp)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES resampling_audio_file_reader.cpp)

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -30,6 +30,10 @@ list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES polyphase_resampler.cpp)
 # dependency-free — always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader.cpp)
 
+# ORP128/FTR018 §2: variable-rate + reverse scrub resampler. Host-neutral,
+# dependency-free — always built.
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES scrub_resampler.cpp)
+
 if(SNDFILE_FOUND)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader_libsndfile.cpp)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES resampling_audio_file_reader.cpp)

--- a/src/core/audio_io/audio_file_reader.cpp
+++ b/src/core/audio_io/audio_file_reader.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+//
+// Default (base-interface) implementations for IAudioFileReader. Kept in a
+// dedicated, always-built translation unit so the out-of-line definition of the
+// defaulted `readSamplesEndingAt` virtual is available to every consumer,
+// whether or not libsndfile is present.
+
+#include <orpheus/audio_file_reader.h>
+
+namespace orpheus {
+
+// Portable backward/windowed read (ORP128, FTR018). Implemented purely on top of
+// the existing forward primitives (seek + readSamples), so it works for any
+// reader out of the box; concrete readers may override with a faster path.
+//
+// Reads the frame window [end_sample - num_frames + 1, end_sample] in forward
+// order. When the window underflows the file start (index < 0), only the
+// in-range trailing frames are read and the returned count is reduced. The read
+// position observed on entry is restored before returning, so this call composes
+// cleanly with ordinary forward streaming.
+Result<size_t> IAudioFileReader::readSamplesEndingAt(int64_t end_sample, float* buffer,
+                                                     size_t num_frames) {
+  Result<size_t> result;
+  result.value = 0;
+
+  if (buffer == nullptr) {
+    result.error = SessionGraphError::InvalidParameter;
+    result.errorMessage = "readSamplesEndingAt: null buffer";
+    return result;
+  }
+  if (!isOpen()) {
+    result.error = SessionGraphError::NotReady;
+    result.errorMessage = "readSamplesEndingAt: reader not open";
+    return result;
+  }
+  if (num_frames == 0 || end_sample < 0) {
+    return result; // nothing to read; value == 0, OK
+  }
+
+  // Window start, clamped so we never request negative indices. The number of
+  // in-range frames shrinks by however much the window underflows below 0.
+  const int64_t requested_start = end_sample - static_cast<int64_t>(num_frames) + 1;
+  const int64_t start = requested_start < 0 ? 0 : requested_start;
+  const size_t in_range = static_cast<size_t>(end_sample - start + 1);
+
+  // Preserve the caller's forward-streaming position and restore it afterward.
+  const int64_t prior_position = getCurrentPosition();
+
+  const SessionGraphError seek_err = seek(start);
+  if (seek_err != SessionGraphError::OK) {
+    seek(prior_position); // best-effort restore
+    result.error = seek_err;
+    result.errorMessage = "readSamplesEndingAt: seek failed";
+    return result;
+  }
+
+  Result<size_t> read = readSamples(buffer, in_range);
+
+  // Restore the read cursor regardless of the read outcome.
+  seek(prior_position);
+
+  if (!read.isOk()) {
+    result.error = read.error;
+    result.errorMessage = read.errorMessage;
+    return result;
+  }
+
+  result.value = read.value;
+  return result;
+}
+
+} // namespace orpheus

--- a/src/core/audio_io/audio_file_reader_libsndfile.cpp
+++ b/src/core/audio_io/audio_file_reader_libsndfile.cpp
@@ -112,6 +112,64 @@ Result<size_t> AudioFileReaderLibsndfile::readSamples(float* buffer, size_t num_
   return result;
 }
 
+Result<size_t> AudioFileReaderLibsndfile::readSamplesEndingAt(int64_t end_sample, float* buffer,
+                                                              size_t num_frames) {
+  // Backward/windowed read (ORP128, FTR018). Reads the frame window
+  // [end_sample - num_frames + 1, end_sample] in forward order and restores the
+  // prior read position. Locked like seek()/open()/close() — this is a
+  // background/streaming primitive, not an audio-callback path.
+  Result<size_t> result;
+  result.value = 0;
+
+  if (buffer == nullptr) {
+    result.error = SessionGraphError::InvalidParameter;
+    result.errorMessage = "readSamplesEndingAt: null buffer";
+    return result;
+  }
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (!m_file) {
+    result.error = SessionGraphError::NotReady;
+    result.errorMessage = "readSamplesEndingAt: file not open";
+    return result;
+  }
+  if (num_frames == 0 || end_sample < 0) {
+    return result; // nothing to read; value == 0, OK
+  }
+
+  // Window start, clamped so we never request negative indices. The in-range
+  // span shrinks by however much the window underflows below 0.
+  const int64_t requested_start = end_sample - static_cast<int64_t>(num_frames) + 1;
+  const int64_t start = requested_start < 0 ? 0 : requested_start;
+  const sf_count_t in_range = static_cast<sf_count_t>(end_sample - start + 1);
+
+  const int64_t prior_position = m_current_position.load(std::memory_order_relaxed);
+
+  if (sf_seek(m_file, start, SEEK_SET) < 0) {
+    sf_seek(m_file, prior_position, SEEK_SET); // best-effort restore
+    result.error = SessionGraphError::InternalError;
+    result.errorMessage = "readSamplesEndingAt: seek failed";
+    return result;
+  }
+
+  const sf_count_t read = sf_readf_float(m_file, buffer, in_range);
+
+  // Restore the read cursor regardless of the read outcome.
+  sf_seek(m_file, prior_position, SEEK_SET);
+  m_current_position.store(prior_position, std::memory_order_release);
+
+  if (read < 0) {
+    result.error = SessionGraphError::InternalError;
+    result.errorMessage =
+        "readSamplesEndingAt: failed to read samples: " + std::string(sf_strerror(m_file));
+    return result;
+  }
+
+  result.value = static_cast<size_t>(read);
+  return result;
+}
+
 SessionGraphError AudioFileReaderLibsndfile::seek(int64_t sample_position) {
   std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/core/audio_io/audio_file_reader_libsndfile.h
+++ b/src/core/audio_io/audio_file_reader_libsndfile.h
@@ -21,6 +21,7 @@ public:
   // IAudioFileReader interface
   Result<AudioFileMetadata> open(const std::string& file_path) override;
   Result<size_t> readSamples(float* buffer, size_t num_samples) override;
+  Result<size_t> readSamplesEndingAt(int64_t end_sample, float* buffer, size_t num_frames) override;
   SessionGraphError seek(int64_t sample_position) override;
   void close() override;
   int64_t getCurrentPosition() const override;

--- a/src/core/audio_io/scrub_resampler.cpp
+++ b/src/core/audio_io/scrub_resampler.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+//
+// ORP128 / FTR018 §2 — variable-rate + reverse scrub resampler. Ported from
+// fourtrack::dsp::ScrubResampler (FTR017), the working reference for this shape,
+// with a namespace change and the per-call processVariable() convenience form
+// layered on the same ring.
+
+#include "orpheus/dsp/scrub_resampler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace orpheus {
+
+void ScrubResampler::prepare(size_t ring_capacity_frames) {
+  // The only allocation. Called off the audio thread, never the audio callback.
+  ring_.assign(ring_capacity_frames, 0.0f);
+  write_pos_ = 0;
+  filled_ = 0;
+  newest_sample_ = -1;
+  cursor_ = 0.0;
+}
+
+void ScrubResampler::reset(int64_t anchor_sample) {
+  // Empty the history and park the cursor. No allocation. The ring keeps its
+  // capacity; filled_ = 0 means "nothing buffered yet" so the first push after a
+  // reset defines the new contiguous run. newest_sample_ is set one below the
+  // anchor so the first pushed sample (at anchor_sample) becomes newest.
+  write_pos_ = 0;
+  filled_ = 0;
+  newest_sample_ = anchor_sample - 1;
+  cursor_ = static_cast<double>(anchor_sample);
+}
+
+void ScrubResampler::push_forward(const float* mono, size_t n, int64_t first_sample_index) {
+  if (ring_.empty() || n == 0 || mono == nullptr) {
+    return;
+  }
+  const size_t cap = ring_.size();
+
+  // If the incoming block is larger than the ring, only the last `cap` samples
+  // can survive — skip the prefix we would immediately overwrite.
+  size_t start = 0;
+  if (n > cap) {
+    start = n - cap;
+  }
+  for (size_t i = start; i < n; ++i) {
+    ring_[write_pos_] = mono[i];
+    write_pos_ = (write_pos_ + 1) % cap;
+    if (filled_ < cap) {
+      ++filled_;
+    }
+  }
+  // The newest absolute index is that of the last sample we actually stored.
+  newest_sample_ = first_sample_index + static_cast<int64_t>(n) - 1;
+}
+
+float ScrubResampler::sample_at(int64_t s) const {
+  if (filled_ == 0) {
+    return 0.0f;
+  }
+  const int64_t oldest = newest_sample_ - static_cast<int64_t>(filled_) + 1;
+  if (s < oldest || s > newest_sample_) {
+    return 0.0f; // Outside buffered history — clamp to silence (reverse depth bound).
+  }
+  const size_t cap = ring_.size();
+  // Distance (in samples) back from the newest; newest lives just before write_pos_.
+  const int64_t back = newest_sample_ - s; // 0 == newest
+  const int64_t newest_slot = (static_cast<int64_t>(write_pos_) - 1 + static_cast<int64_t>(cap)) %
+                              static_cast<int64_t>(cap);
+  int64_t slot = (newest_slot - back) % static_cast<int64_t>(cap);
+  if (slot < 0) {
+    slot += static_cast<int64_t>(cap);
+  }
+  return ring_[static_cast<size_t>(slot)];
+}
+
+size_t ScrubResampler::render(float* out, size_t out_n, double rate) {
+  if (out == nullptr) {
+    return 0;
+  }
+  for (size_t i = 0; i < out_n; ++i) {
+    // Linear interpolation between the two samples bracketing the cursor.
+    const double base = std::floor(cursor_);
+    const double frac = cursor_ - base;
+    const int64_t i0 = static_cast<int64_t>(base);
+    const float s0 = sample_at(i0);
+    const float s1 = sample_at(i0 + 1);
+    out[i] = static_cast<float>(s0 + (s1 - s0) * frac);
+    cursor_ += rate;
+  }
+  return out_n;
+}
+
+size_t ScrubResampler::processVariable(const float* input, size_t in_frames, float* output,
+                                       size_t out_n, double rate) {
+  // Per-call convenience form (FTR018 §2). Treat `input` as fresh forward mono
+  // history contiguous with what is already held (starting at newest_sample_ + 1),
+  // then render from the persistent cursor. Both steps are alloc-free, so the
+  // whole call is RT-safe once prepare() has run.
+  if (input != nullptr && in_frames > 0 && !ring_.empty()) {
+    push_forward(input, in_frames, newest_sample_ + 1);
+  }
+  return render(output, out_n, rate);
+}
+
+size_t ScrubResampler::forward_refill_hint(double rate, size_t out_n) const {
+  if (rate <= 0.0 || out_n == 0) {
+    return 0; // Reverse/hold replays buffered history; no new reads needed.
+  }
+  // Samples the cursor will consume this buffer, plus a 1-sample interpolation
+  // margin (we read i0 and i0+1). Capped to the ring capacity so a single refill
+  // can never exceed what the ring can hold.
+  const double consumed = static_cast<double>(out_n) * rate;
+  size_t need = static_cast<size_t>(std::ceil(consumed)) + 1;
+  if (!ring_.empty()) {
+    need = std::min(need, ring_.size());
+  }
+  return need;
+}
+
+} // namespace orpheus

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -20,6 +20,26 @@ target_include_directories(polyphase_resampler_test
 
 add_test(NAME polyphase_resampler_test COMMAND polyphase_resampler_test)
 
+# ORP128/FTR018 §2: scrub resampler unit test. Standalone — links only
+# orpheus_audio_utils (no libsndfile, no JUCE, host-neutral).
+add_executable(scrub_resampler_test
+    scrub_resampler_test.cpp
+)
+
+target_link_libraries(scrub_resampler_test
+    PRIVATE
+        orpheus_audio_utils
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(scrub_resampler_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+add_test(NAME scrub_resampler_test COMMAND scrub_resampler_test)
+
 # Find libsndfile (needed because orpheus_audio_io is static)
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
@@ -33,6 +53,37 @@ if(NOT SNDFILE_FOUND)
         set(SNDFILE_FOUND TRUE)
     endif()
 endif()
+
+# ORP128/FTR018 §1: backward/windowed read (readSamplesEndingAt). The base-default
+# half (in-memory fake reader) is host-neutral; the libsndfile-override half is
+# compiled in only when sndfile is present (guarded by ORPHEUS_HAVE_SNDFILE).
+add_executable(reverse_read_test
+    reverse_read_test.cpp
+)
+
+target_link_libraries(reverse_read_test
+    PRIVATE
+        orpheus_audio_utils
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(reverse_read_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/src/core
+)
+
+if(SNDFILE_FOUND)
+    target_compile_definitions(reverse_read_test PRIVATE ORPHEUS_HAVE_SNDFILE)
+    target_include_directories(reverse_read_test PRIVATE ${SNDFILE_INCLUDE_DIRS})
+    target_link_libraries(reverse_read_test PRIVATE ${SNDFILE_LIBRARIES})
+    if(SNDFILE_LIBRARY_DIRS)
+        target_link_directories(reverse_read_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+    endif()
+endif()
+
+add_test(NAME reverse_read_test COMMAND reverse_read_test)
 
 # Audio file reader tests (requires libsndfile)
 if(SNDFILE_FOUND)

--- a/tests/audio_io/reverse_read_test.cpp
+++ b/tests/audio_io/reverse_read_test.cpp
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+//
+// ORP128 / FTR018 §1 — tests for the backward/windowed read
+// (IAudioFileReader::readSamplesEndingAt). Two layers:
+//
+//   1. The portable BASE DEFAULT via a minimal in-memory fake reader, so the
+//      default seek+read path is covered without any file dependency.
+//   2. The libsndfile OVERRIDE via a temporary WAV written with sf_write, so the
+//      concrete fast path is covered end to end.
+//
+// The window [end_sample - num_frames + 1, end_sample] is filled in forward
+// (ascending-index) order; the caller walks it out in reverse. Underflow below 0
+// clamps to the in-range trailing frames; the prior read position is restored.
+
+#include <orpheus/audio_file_reader.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+
+namespace {
+
+// -----------------------------------------------------------------------------
+// A minimal mono in-memory reader that implements ONLY the pure-virtuals, so it
+// inherits the base default readSamplesEndingAt. Samples are a ramp: value == idx.
+// -----------------------------------------------------------------------------
+class RampReader : public IAudioFileReader {
+public:
+  explicit RampReader(int64_t frames) : m_frames(frames) {}
+
+  Result<AudioFileMetadata> open(const std::string&) override {
+    m_open = true;
+    Result<AudioFileMetadata> r;
+    r.value.sample_rate = 48000;
+    r.value.num_channels = 1;
+    r.value.duration_samples = m_frames;
+    return r;
+  }
+
+  Result<size_t> readSamples(float* buffer, size_t num_samples) override {
+    Result<size_t> r;
+    if (!m_open) {
+      r.error = SessionGraphError::NotReady;
+      return r;
+    }
+    size_t n = 0;
+    for (; n < num_samples && m_pos < m_frames; ++n, ++m_pos) {
+      buffer[n] = static_cast<float>(m_pos);
+    }
+    r.value = n;
+    return r;
+  }
+
+  SessionGraphError seek(int64_t sample_position) override {
+    if (!m_open) {
+      return SessionGraphError::NotReady;
+    }
+    if (sample_position < 0) {
+      sample_position = 0;
+    }
+    if (sample_position > m_frames) {
+      sample_position = m_frames;
+    }
+    m_pos = sample_position;
+    return SessionGraphError::OK;
+  }
+
+  void close() override {
+    m_open = false;
+    m_pos = 0;
+  }
+  int64_t getCurrentPosition() const override {
+    return m_pos;
+  }
+  bool isOpen() const override {
+    return m_open;
+  }
+
+private:
+  int64_t m_frames;
+  int64_t m_pos = 0;
+  bool m_open = false;
+};
+
+} // namespace
+
+// --- Base default (fake reader) ---------------------------------------------
+
+TEST(ReverseReadBaseTest, WindowEndingAtReadsForwardOrder) {
+  RampReader r(1000);
+  r.open("");
+
+  std::vector<float> buf(8, -1.0f);
+  auto res = r.readSamplesEndingAt(107, buf.data(), 8); // frames 100..107
+  ASSERT_TRUE(res.isOk());
+  EXPECT_EQ(res.value, 8u);
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_NEAR(buf[i], static_cast<float>(100 + i), 1e-4f) << "at " << i;
+  }
+}
+
+TEST(ReverseReadBaseTest, RestoresPriorForwardPosition) {
+  RampReader r(1000);
+  r.open("");
+
+  // Establish a forward position, then a windowed read must not disturb it.
+  std::vector<float> fwd(10);
+  r.readSamples(fwd.data(), 10); // pos -> 10
+  ASSERT_EQ(r.getCurrentPosition(), 10);
+
+  std::vector<float> buf(4);
+  r.readSamplesEndingAt(500, buf.data(), 4);
+  EXPECT_EQ(r.getCurrentPosition(), 10); // restored
+
+  // Forward streaming resumes where it left off.
+  std::vector<float> more(4);
+  r.readSamples(more.data(), 4);
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_NEAR(more[i], static_cast<float>(10 + i), 1e-4f);
+  }
+}
+
+TEST(ReverseReadBaseTest, WindowUnderflowClampsToInRangeTail) {
+  RampReader r(1000);
+  r.open("");
+
+  // end_sample 3, window 8 -> requested start -4, clamps to 0; in-range = 0..3.
+  std::vector<float> buf(8, -1.0f);
+  auto res = r.readSamplesEndingAt(3, buf.data(), 8);
+  ASSERT_TRUE(res.isOk());
+  EXPECT_EQ(res.value, 4u); // only frames 0..3 exist
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_NEAR(buf[i], static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+}
+
+TEST(ReverseReadBaseTest, NegativeEndSampleReadsNothing) {
+  RampReader r(1000);
+  r.open("");
+  std::vector<float> buf(4, 9.0f);
+  auto res = r.readSamplesEndingAt(-1, buf.data(), 4);
+  ASSERT_TRUE(res.isOk());
+  EXPECT_EQ(res.value, 0u);
+}
+
+TEST(ReverseReadBaseTest, NotOpenReturnsNotReady) {
+  RampReader r(1000);
+  std::vector<float> buf(4);
+  auto res = r.readSamplesEndingAt(10, buf.data(), 4);
+  EXPECT_FALSE(res.isOk());
+  EXPECT_EQ(res.error, SessionGraphError::NotReady);
+}
+
+TEST(ReverseReadBaseTest, ReversePlaybackDescendsWhenWalkedBackward) {
+  // The intended use: read a forward window, then the caller emits it in reverse.
+  RampReader r(1000);
+  r.open("");
+
+  std::vector<float> win(16);
+  ASSERT_TRUE(r.readSamplesEndingAt(215, win.data(), 16).isOk()); // 200..215
+  // Emitting win in reverse yields a descending ramp 215, 214, ... 200.
+  for (size_t i = 0; i < 16; ++i) {
+    float reversed = win[win.size() - 1 - i];
+    EXPECT_NEAR(reversed, static_cast<float>(215 - static_cast<int>(i)), 1e-4f) << "at " << i;
+  }
+}
+
+// --- libsndfile override (temp WAV) -----------------------------------------
+// Guarded so the file only compiles/runs its integration half when the concrete
+// reader is available. createAudioFileReader() returns nullptr in the stub build.
+
+#if defined(ORPHEUS_HAVE_SNDFILE)
+#include <sndfile.h>
+
+namespace {
+// Write a mono 48k WAV ramp (value == frame index) and return its path.
+std::string writeRampWav(int64_t frames) {
+  std::string path = std::string(::testing::TempDir()) + "orpheus_reverse_read_ramp.wav";
+  SF_INFO info;
+  info.samplerate = 48000;
+  info.channels = 1;
+  info.format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
+  info.frames = 0;
+  info.sections = 0;
+  info.seekable = 0;
+  SNDFILE* f = sf_open(path.c_str(), SFM_WRITE, &info);
+  if (!f) {
+    return "";
+  }
+  std::vector<float> ramp(static_cast<size_t>(frames));
+  for (int64_t i = 0; i < frames; ++i) {
+    ramp[static_cast<size_t>(i)] = static_cast<float>(i);
+  }
+  sf_writef_float(f, ramp.data(), frames);
+  sf_close(f);
+  return path;
+}
+} // namespace
+
+TEST(ReverseReadSndfileTest, OverrideMatchesForwardOrderAndRestoresPosition) {
+  auto reader = createAudioFileReader();
+  ASSERT_NE(reader, nullptr);
+
+  const std::string path = writeRampWav(1000);
+  ASSERT_FALSE(path.empty());
+  ASSERT_TRUE(reader->open(path).isOk());
+
+  // Forward-stream a bit to set a position.
+  std::vector<float> fwd(10);
+  reader->readSamples(fwd.data(), 10);
+  ASSERT_EQ(reader->getCurrentPosition(), 10);
+
+  std::vector<float> buf(8, -1.0f);
+  auto res = reader->readSamplesEndingAt(107, buf.data(), 8); // 100..107
+  ASSERT_TRUE(res.isOk());
+  EXPECT_EQ(res.value, 8u);
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_NEAR(buf[i], static_cast<float>(100 + i), 1e-3f) << "at " << i;
+  }
+  EXPECT_EQ(reader->getCurrentPosition(), 10); // restored
+
+  reader->close();
+  std::remove(path.c_str());
+}
+
+TEST(ReverseReadSndfileTest, OverrideUnderflowClampsToTail) {
+  auto reader = createAudioFileReader();
+  ASSERT_NE(reader, nullptr);
+
+  const std::string path = writeRampWav(1000);
+  ASSERT_FALSE(path.empty());
+  ASSERT_TRUE(reader->open(path).isOk());
+
+  std::vector<float> buf(8, -1.0f);
+  auto res = reader->readSamplesEndingAt(3, buf.data(), 8); // clamps to 0..3
+  ASSERT_TRUE(res.isOk());
+  EXPECT_EQ(res.value, 4u);
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_NEAR(buf[i], static_cast<float>(i), 1e-3f) << "at " << i;
+  }
+
+  reader->close();
+  std::remove(path.c_str());
+}
+#endif // ORPHEUS_HAVE_SNDFILE

--- a/tests/audio_io/scrub_resampler_test.cpp
+++ b/tests/audio_io/scrub_resampler_test.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+//
+// ORP128 / FTR018 §2 — unit tests for orpheus::ScrubResampler, the variable-rate
+// + reverse scrub resampler. Ported from FourTrack's contract suite
+// (fourtrack tests/unit/scrub_resampler_test.cpp), the load-bearing correctness
+// spec named in the FTR018 handoff. Pure DSP, no engine: push a known ramp
+// forward, then render at forward, fractional, and reverse rates and assert the
+// interpolated output. The reverse cases are the load-bearing ones: they prove
+// reverse plays back buffered history (a plain file reader cannot stream
+// backward — the reason this class exists).
+
+#include <orpheus/dsp/scrub_resampler.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace orpheus;
+
+namespace {
+
+// Push a contiguous ramp 0,1,2,... starting at absolute index `first`.
+void push_ramp(ScrubResampler& r, int64_t first, size_t count) {
+  std::vector<float> ramp(count);
+  for (size_t i = 0; i < count; ++i) {
+    ramp[i] = static_cast<float>(static_cast<int64_t>(i) + first);
+  }
+  r.push_forward(ramp.data(), count, first);
+}
+
+TEST(ScrubResamplerTest, PassThroughAtUnityReturnsInput) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 512);
+
+  std::vector<float> out(256, -1.0f);
+  EXPECT_EQ(r.render(out.data(), out.size(), 1.0), out.size());
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+  // Cursor advanced by exactly one sample per output frame.
+  EXPECT_NEAR(r.position(), 256.0, 1e-9);
+}
+
+TEST(ScrubResamplerTest, HalfRateInterpolatesMidpoints) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 512);
+
+  std::vector<float> out(8, 0.0f);
+  r.render(out.data(), out.size(), 0.5);
+  // cursor: 0.0, 0.5, 1.0, 1.5, ... -> ramp values 0, 0.5, 1.0, 1.5, ...
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], 0.5f * static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+  EXPECT_NEAR(r.position(), 4.0, 1e-9);
+}
+
+TEST(ScrubResamplerTest, DoubleRateSkipsEveryOther) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 512);
+
+  std::vector<float> out(8, 0.0f);
+  r.render(out.data(), out.size(), 2.0);
+  // cursor: 0, 2, 4, 6, ... -> ramp values 0, 2, 4, 6, ...
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], 2.0f * static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+  EXPECT_NEAR(r.position(), 16.0, 1e-9);
+}
+
+TEST(ScrubResamplerTest, ReversePlaysBufferedHistoryBackward) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 512);
+
+  // Park the cursor mid-ring by playing forward first.
+  std::vector<float> fwd(100, 0.0f);
+  r.render(fwd.data(), fwd.size(), 1.0);
+  ASSERT_NEAR(r.position(), 100.0, 1e-9);
+
+  // Now reverse at -1.0x: output should descend from 100 downward.
+  std::vector<float> rev(10, 0.0f);
+  r.render(rev.data(), rev.size(), -1.0);
+  for (size_t i = 0; i < rev.size(); ++i) {
+    EXPECT_NEAR(rev[i], static_cast<float>(100 - static_cast<int>(i)), 1e-4f) << "at " << i;
+  }
+  EXPECT_NEAR(r.position(), 90.0, 1e-9);
+}
+
+TEST(ScrubResamplerTest, ZeroRateHolds) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 512);
+
+  // Advance to a fractional position, then hold.
+  std::vector<float> seek(5, 0.0f);
+  r.render(seek.data(), seek.size(), 0.5); // cursor -> 2.5
+  const double held = r.position();
+
+  std::vector<float> out(16, -99.0f);
+  r.render(out.data(), out.size(), 0.0);
+  const float expected = out[0];
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], expected, 1e-6f) << "at " << i; // frozen value
+  }
+  // The held sample is the interpolation at 2.5 == 2.5 on the ramp.
+  EXPECT_NEAR(expected, 2.5f, 1e-4f);
+  EXPECT_NEAR(r.position(), held, 1e-9); // cursor did not move
+}
+
+TEST(ScrubResamplerTest, ReversePastBufferStartClampsToSilence) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 64); // only indices 0..63 buffered
+
+  // Start near the beginning, reverse well past 0.
+  std::vector<float> out(40, 7.0f);
+  r.render(out.data(), out.size(), -1.0); // cursor 0 -> -40 across the buffer
+  // out[0] at cursor 0 == sample 0 == 0.0; once cursor goes below the oldest
+  // buffered sample (index 0), output must be silence — never out of bounds.
+  EXPECT_NEAR(out[0], 0.0f, 1e-4f);
+  for (size_t i = 1; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], 0.0f, 1e-4f) << "at " << i; // below index 0 -> silence
+  }
+  EXPECT_LT(r.position(), 0.0); // cursor is allowed to go negative internally
+}
+
+TEST(ScrubResamplerTest, ForwardPastNewestClampsToSilence) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 16); // indices 0..15
+
+  std::vector<float> out(32, 3.0f);
+  r.render(out.data(), out.size(), 1.0);
+  for (size_t i = 0; i < 16; ++i) {
+    EXPECT_NEAR(out[i], static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+  for (size_t i = 16; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], 0.0f, 1e-4f) << "past newest at " << i;
+  }
+}
+
+TEST(ScrubResamplerTest, RingWrapKeepsAbsoluteIndexingCorrect) {
+  // Push more than capacity so the ring wraps; the newest samples must still read
+  // back at their correct absolute positions and the oldest must have fallen off.
+  ScrubResampler r;
+  r.prepare(64);
+  r.reset(0);
+  push_ramp(r, 0, 200); // capacity 64 -> only indices 136..199 survive
+
+  // newest_sample_ should be 199; oldest held is 136.
+  EXPECT_EQ(r.newest_sample(), 199);
+
+  // The ramp value equals the absolute index, so a unity render from cursor 0
+  // (reset put it at 0; push advanced newest but NOT the cursor) reads from 0 —
+  // but indices < 136 have fallen off => silence, and 136..199 read as value.
+  std::vector<float> out(200, -1.0f);
+  r.render(out.data(), out.size(), 1.0);
+  for (int i = 0; i < 136; ++i) {
+    EXPECT_NEAR(out[static_cast<size_t>(i)], 0.0f, 1e-4f) << "fell off at " << i;
+  }
+  for (int i = 136; i < 200; ++i) {
+    EXPECT_NEAR(out[static_cast<size_t>(i)], static_cast<float>(i), 1e-4f) << "held at " << i;
+  }
+}
+
+TEST(ScrubResamplerTest, ForwardRefillHintIsZeroWhenReversingOrHolding) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  EXPECT_EQ(r.forward_refill_hint(-1.0, 512), 0u);
+  EXPECT_EQ(r.forward_refill_hint(0.0, 512), 0u);
+  // Forward needs at least the consumed span plus interpolation margin.
+  EXPECT_GE(r.forward_refill_hint(1.0, 512), 512u);
+  EXPECT_GE(r.forward_refill_hint(2.0, 512), 1024u - 1u); // ~2x, capped at capacity
+  EXPECT_LE(r.forward_refill_hint(2.0, 512), 1024u);
+}
+
+TEST(ScrubResamplerTest, ResetReparksCursorAndClearsHistory) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+  push_ramp(r, 0, 128);
+
+  r.reset(1000);
+  EXPECT_NEAR(r.position(), 1000.0, 1e-9);
+  // History cleared: nothing buffered, so render yields silence until refilled.
+  std::vector<float> out(8, 5.0f);
+  r.render(out.data(), out.size(), 1.0);
+  for (float v : out) {
+    EXPECT_NEAR(v, 0.0f, 1e-6f);
+  }
+  // After a fresh push at the new anchor, reads resume.
+  r.reset(1000); // re-park (push never moves the cursor)
+  push_ramp(r, 1000, 64);
+  std::vector<float> out2(8, 0.0f);
+  r.render(out2.data(), out2.size(), 1.0);
+  for (size_t i = 0; i < out2.size(); ++i) {
+    EXPECT_NEAR(out2[i], static_cast<float>(1000 + static_cast<int>(i)), 1e-4f) << "at " << i;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// processVariable() — the per-call convenience shape named by the FTR018 §2
+// handoff. It layers on the same ring, so it inherits the continuity guarantee;
+// these cases prove the input->output form and cross-call phase persistence.
+// -----------------------------------------------------------------------------
+
+TEST(ScrubResamplerTest, ProcessVariablePassThroughAtUnity) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+
+  // Feed a ramp block, render it back at 1.0x.
+  std::vector<float> in(256);
+  for (size_t i = 0; i < in.size(); ++i) {
+    in[i] = static_cast<float>(i);
+  }
+  std::vector<float> out(256, -1.0f);
+  EXPECT_EQ(r.processVariable(in.data(), in.size(), out.data(), out.size(), 1.0), out.size());
+  for (size_t i = 0; i < out.size(); ++i) {
+    EXPECT_NEAR(out[i], static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+}
+
+TEST(ScrubResamplerTest, ProcessVariableKeepsFractionalPhaseAcrossCalls) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+
+  // First feed the whole ramp so both calls read from the same history.
+  std::vector<float> in(64);
+  for (size_t i = 0; i < in.size(); ++i) {
+    in[i] = static_cast<float>(i);
+  }
+
+  std::vector<float> a(4, 0.0f);
+  r.processVariable(in.data(), in.size(), a.data(), a.size(), 0.5);
+  // cursor: 0.0, 0.5, 1.0, 1.5 -> values 0, 0.5, 1.0, 1.5; cursor ends at 2.0.
+  EXPECT_NEAR(r.position(), 2.0, 1e-9);
+
+  // Second call feeds nothing new (null input); phase continues from 2.0.
+  std::vector<float> b(4, 0.0f);
+  r.processVariable(nullptr, 0, b.data(), b.size(), 0.5);
+  for (size_t i = 0; i < b.size(); ++i) {
+    EXPECT_NEAR(b[i], 2.0f + 0.5f * static_cast<float>(i), 1e-4f) << "at " << i;
+  }
+  EXPECT_NEAR(r.position(), 4.0, 1e-9);
+}
+
+TEST(ScrubResamplerTest, ProcessVariableReverseIsSignedRate) {
+  ScrubResampler r;
+  r.prepare(1024);
+  r.reset(0);
+
+  std::vector<float> in(128);
+  for (size_t i = 0; i < in.size(); ++i) {
+    in[i] = static_cast<float>(i);
+  }
+  // Advance forward, then reverse at -1.0x from mid-history with no new input.
+  std::vector<float> fwd(50, 0.0f);
+  r.processVariable(in.data(), in.size(), fwd.data(), fwd.size(), 1.0);
+  ASSERT_NEAR(r.position(), 50.0, 1e-9);
+
+  std::vector<float> rev(10, 0.0f);
+  r.processVariable(nullptr, 0, rev.data(), rev.size(), -1.0);
+  for (size_t i = 0; i < rev.size(); ++i) {
+    EXPECT_NEAR(rev[i], static_cast<float>(50 - static_cast<int>(i)), 1e-4f) << "at " << i;
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Implements the two primitives from the FourTrack **FTR018** handoff so the SDK can serve an audible, time-varying, forward-**and-backward** scrub (tape/CDJ jog). Lifts the capability out of FourTrack's local stopgap (`fourtrack::dsp::ScrubResampler`) into the shared SDK per the "fix at the source" convention. Sprint doc: **ORP129**.

## §1 — backward/windowed read (primary)

```cpp
// IAudioFileReader — DEFAULTED virtual (not = 0)
virtual Result<size_t> readSamplesEndingAt(int64_t end_sample, float* buffer, size_t num_frames);
```

- Fills `buffer` with the window `[end_sample - num_frames + 1, end_sample]` in **forward** order; caller emits it in reverse.
- Underflow below index 0 clamps to the in-range trailing frames; the returned count reflects frames actually read.
- **Restores** the prior read position, so it composes with forward `readSamples()` streaming.
- **Defaulted, not pure** — a hard constraint: a pure-virtual would transitively break `AudioFileReaderLibsndfile`, `AudioFileReaderExtended`, `ResamplingAudioFileReader`, Clip Composer, and their tests. Base ships a portable `seek + read` default (always built); `AudioFileReaderLibsndfile` overrides with a single locked seek/read/restore.

## §2 — variable-rate + reverse resampler (secondary)

`orpheus::ScrubResampler` (`include/orpheus/dsp/scrub_resampler.h`), ported from the FTR017 reference with a namespace change. RT-safe (all scratch reserved in `prepare()`), persistent fractional phase for click-free rate changes. Two drivers sharing one ring:

- **ring model** (`push_forward` + `render`) — `rate < 0` walks the cursor down through buffered history (reverse replays forward-decoded samples).
- **per-call model** (`processVariable(input, in_frames, output, out_n, rate)`) — the FTR018 §2 shape; phase carried across calls.

**Scope:** pure **varispeed** (pitch + duration move together). Independent pitch-shift / time-stretch is deliberately out of scope so a pitch stage can compose downstream later. Linear interp; cubic/Hermite is a drop-in upgrade that does not change the interface.

## Tests

Ported the FTR018 contract suite into the SDK — pass-through 1.0×, fractional 0.5×/2.0×, reverse from mid-ring −1.0×, hold at 0.0, out-of-bounds → silence, ring-wrap indexing — plus `processVariable` phase/reverse cases and `readSamplesEndingAt` coverage (base default over an in-memory ramp reader + libsndfile override over a temp WAV).

- **Full suite: 122 tests, all functional tests pass.** The one red on the run machine — `WaveformProcessorTest.PerformanceTest10MinuteWav` — is a hardcoded 2000 ms wall-clock assertion that flakes on either side of the threshold on pristine `main` (1985–2049 ms across repeated Debug+ASan runs), touches no code in this change, and is not a regression.

## Consumer impact

**None.** Additive defaulted virtual + new DSP class; the full SDK and its 122-test suite build and pass unchanged. Per FTR018's migration plan, FourTrack can later swap its local `ScrubResampler` and drive reverse via §1 behind the same engine seam — **not done here** (no submodule pin bump, no FourTrack edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)