### PR TITLE
ORP133/ORP134: Realtime safety hardening & streaming clip sources

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -199,6 +199,9 @@ jobs:
           find src include -name "*.cpp" -o -name "*.h" -o -name "*.hpp" | \
           xargs clang-format-14 --dry-run --Werror
 
+      - name: Validate docs paths (ORP133 G6)
+        run: python3 tools/docs_path_audit.py --root .
+
       - name: Lint Windows includes
         run: |
           python3 - <<'PY'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,9 +15,8 @@ Orpheus is a professional audio SDK built around a deterministic, host-neutral C
 - [Design Principles](#design-principles)
 - [System Architecture](#system-architecture)
 - [Core Library](#core-library-src--include)
-- [Driver Architecture](#driver-architecture-packages)
+- [Shared App Packages](#shared-app-packages-packages)
 - [Transport Controller](#transport-controller)
-- [Contract System](#contract-system)
 - [Applications](#applications-apps)
 - [Adapters](#adapters-adapters)
 - [Testing](#testing-tests--tools)
@@ -50,8 +49,8 @@ Orpheus is organized into distinct layers, each with clear responsibilities:
 
 ```mermaid
 graph TD
-    A[Applications: OCC, Wave Finder, FX Engine] --> B[Adapters: REAPER, minhost]
-    A --> C[Driver Layer: Service/Native/WASM]
+    A[External apps: Clip Composer, FourTrack, FreqFinder] --> B[Adapters: REAPER, minhost]
+    A --> C[Shared app packages: occ-app-platform, shmui-juce]
     B --> D[Core SDK: Transport, Session, Audio I/O]
     C --> D
     D --> E[Platform: CoreAudio, WASAPI, ALSA, libsndfile]
@@ -67,9 +66,15 @@ graph TD
 
 - **Core SDK** (`src/`, `include/`) – Minimal, deterministic primitives. No UI, no network, no host assumptions.
 - **Adapters** (`adapters/`) – Optional, platform-specific integrations. Thin wrappers around core SDK.
-- **Driver Layer** (`packages/`) – TypeScript/JavaScript bindings for web and Node.js environments.
-- **Applications** (`apps/`) – Complete solutions that compose adapters and drivers (OCC, Wave Finder, etc.).
-- **UI Prototypes** (`packages/shmui/`) – Demos only, not production. Local-mocked, no SaaS dependencies.
+- **Shared app packages** (`packages/`) – Active C++/JUCE building blocks for
+  downstream applications: `occ-app-platform` (session recovery, preferences,
+  health telemetry) and `shmui-juce` (JUCE UI components). Not part of the
+  core SDK libraries. (The former TypeScript driver layer is archived — see
+  `docs/DECISION_PACKAGES.md`.)
+- **In-tree apps** (`apps/`) – `wave-finder` (app-platform smoke-test shell)
+  and `juce-demo-host` (JUCE demo host). Production applications — Clip
+  Composer, FourTrack, FreqFinder — live in their own repositories and consume
+  the SDK as a git submodule.
 
 ---
 
@@ -137,7 +142,7 @@ Platform-agnostic audio I/O abstraction:
 Session serialization utilities:
 
 - **Load/Save** – Human-readable JSON format for version control
-- **Validation** – Schema-based validation (see Contract System)
+- **Validation** – Structural validation on load
 - **Filesystem Helpers** – Path resolution, filename generation
 
 **File:** `include/orpheus/session_json.h`, `src/core/session/session_json.cpp`
@@ -160,124 +165,32 @@ Version compatibility helpers:
 
 ---
 
-## Driver Architecture (`packages/`)
+## Shared App Packages (`packages/`)
 
-The driver layer provides JavaScript/TypeScript bindings for web and Node.js environments. Implemented in ORP068 Phases 1-2.
+The `packages/` directory contains **active C++/JUCE building blocks** shared
+by downstream applications (they are consumed through each app repo's SDK
+submodule):
 
-### Driver Types
+### `occ-app-platform`
 
-#### 1. Service Driver (`@orpheus/engine-service`)
+Application-platform helpers extracted from Clip Composer for reuse: session
+recovery/autosave scaffolding, preferences persistence, and realtime health
+telemetry surfaces. Exercised in-tree by the `apps/wave-finder` smoke shell.
 
-**Architecture:** Node.js HTTP server + WebSocket event streaming
+### `shmui-juce`
 
-- **Process Model** – Spawns `orpheus_minhost` as child process
-- **Communication** – HTTP POST for commands, WebSocket for events
-- **Security** – Bearer token authentication, 127.0.0.1 bind
-- **Use Cases** – Web apps, Electron apps, remote control scenarios
+JUCE UI component library (waveform displays, meters, transport widgets,
+audio/UI thread-safe communication helpers) for application-level UI. NOT part
+of the core SDK libraries — the core stays UI-free.
 
-**Endpoints:**
+### Archived TypeScript driver layer
 
-- `GET /health` – Health check (public)
-- `GET /version` – SDK version info (public)
-- `GET /contract` – Available commands/events (authenticated)
-- `POST /command` – Execute SDK command (authenticated)
-- `WS /ws` – WebSocket event stream (authenticated)
-
-**File:** `packages/engine-service/src/server.ts`
-
-#### 2. Native Driver (`@orpheus/engine-native`)
-
-**Architecture:** N-API native addon with direct C++ SDK integration
-
-- **Process Model** – In-process, no IPC overhead
-- **Communication** – Direct function calls via N-API bindings
-- **Performance** – Lowest latency, highest throughput
-- **Use Cases** – Desktop apps (Electron), server-side rendering
-
-**Bindings:**
-
-- `loadSession()` – Load session from JSON file
-- `renderClick()` – Render click track to WAV
-- `getTempo()`, `setTempo()` – Session tempo access
-- `getSessionInfo()` – Query session metadata
-- `subscribe()` – Event callback registration
-
-**File:** `packages/engine-native/src/bindings/session_wrapper.cpp`
-
-#### 3. WASM Driver (`@orthpeus/engine-wasm`)
-
-**Architecture:** Emscripten-compiled WASM module in Web Worker
-
-- **Process Model** – Main thread client + worker thread engine
-- **Communication** – Structured cloning via `postMessage()`
-- **Security** – Subresource Integrity (SRI) verification
-- **Use Cases** – Browser-based DAWs, offline-capable web apps
-
-**Status:** Infrastructure complete (ORP068 Phase 2), requires Emscripten SDK for compilation.
-
-**File:** `packages/engine-wasm/src/worker.ts`, `packages/engine-wasm/src/wasm_bindings.cpp`
-
-### Client Broker (`@orpheus/client`)
-
-Unified interface across all driver types:
-
-- **Driver Selection** – Automatic priority-based selection (Native → WASM → Service)
-- **Handshake Protocol** – Capability verification, version negotiation
-- **Health Monitoring** – Automatic reconnection, heartbeat checks
-- **Event Forwarding** – Unified event interface across drivers
-
-**File:** `packages/client/src/client.ts`
-
----
-
-## Contract System
-
-The **Orpheus Contract** defines the JSON schema for all commands and events between drivers and the SDK.
-
-### Version History
-
-- **v0.1.0-alpha** – Initial minimal contract (LoadSession, RenderClick)
-- **v1.0.0-beta** – Expanded contract with real-time features (SaveSession, TriggerClipGridScene, SetTransport, TransportTick, RenderProgress)
-
-### Command Schema Example
-
-```json
-{
-  "command": "LoadSession",
-  "params": {
-    "sessionPath": "/path/to/session.json"
-  }
-}
-```
-
-### Event Schema Example
-
-```json
-{
-  "event": "SessionChanged",
-  "data": {
-    "trackCount": 4,
-    "clipCount": 12,
-    "tempo": 120.0
-  }
-}
-```
-
-### Event Frequency Validation
-
-To prevent client overload, the contract enforces maximum event frequencies:
-
-- **TransportTick** – ≤30 Hz (real-time transport position)
-- **RenderProgress** – ≤10 Hz (offline render progress)
-- **Heartbeat** – 1 Hz (liveness check)
-
-**File:** `packages/contract/src/frequency-validator.ts`
-
-### Documentation
-
-- **Contract Development Guide** – `docs/CONTRACT_DEVELOPMENT.md`
-- **Migration Guide** – `packages/contract/MIGRATION.md`
-- **Schemas** – `packages/contract/schemas/v1.0.0-beta/`
+The former JavaScript/TypeScript driver packages (`@orpheus/engine-service`,
+`@orpheus/engine-native`, `@orpheus/engine-wasm`, `@orpheus/client`) and the
+JSON contract system built for them (ORP068 Phases 1-2) were **archived** when
+the project refocused on the C++ SDK. They are not in the tree. See
+[`docs/orp/_process/archive/DECISION_PACKAGES.md`](docs/orp/_process/archive/DECISION_PACKAGES.md)
+for the rationale and `docs/orp/` history (ORP068) for the original design.
 
 ---
 
@@ -340,11 +253,26 @@ See [Threading Model](#threading-model) section below for full details.
 
 ## Applications (`apps/`)
 
-The `apps/` directory contains complete applications built on the Orpheus SDK.
+The `apps/` directory contains **in-tree development apps only**:
 
-### Orpheus Clip Composer (OCC)
+- **`apps/wave-finder/`** – app-platform smoke-test shell exercising
+  `packages/occ-app-platform`. (This is NOT the real FreqFinder analyzer,
+  which lives in its own external repository.)
+- **`apps/juce-demo-host/`** – JUCE demo host for SDK integration
+  experiments (`ORPHEUS_ENABLE_APP_JUCE_HOST=ON`).
 
-**Status:** ✅ v0.2.0-alpha (Sprint 1-2 Complete)
+**Production applications are external consumers** that vendor this SDK as a
+git submodule and bump the pin to pick up SDK changes:
+
+- **Clip Composer** ([`chrislyons/clip-composer`](https://github.com/chrislyons/clip-composer))
+- **FourTrack** (`chrislyons/fourtrack`)
+- **FreqFinder** (`~/dev/freqfinder`)
+
+### Orpheus Clip Composer (OCC) — external repo
+
+**Status:** extracted from this repo's former `apps/clip-composer/`
+subdirectory on 2026-07-09 (archival report: `docs/orp/ORP131`). Its build,
+CI, and OCC documentation live in the Clip Composer repository.
 
 Professional soundboard application for broadcast, theater, and live performance.
 
@@ -366,19 +294,13 @@ Professional soundboard application for broadcast, theater, and live performance
 
 **Performance:** <15% CPU with 8 clips, ~100MB memory, 10.7ms latency
 
-**Documentation:** `apps/clip-composer/docs/OCC/`, `apps/clip-composer/CHANGELOG.md`
-
-### Orpheus Wave Finder (Planned)
-
-Harmonic calculator and frequency scope for audio analysis.
-
-**Status:** Planned for v1.0 (Months 7-12)
+**Documentation:** `docs/occ/` in the Clip Composer repo (not here)
 
 ### Orpheus FX Engine (Planned)
 
 LLM-powered effects processing and creative workflows.
 
-**Status:** Planned for v1.0 (Months 10-12)
+**Status:** Planned — not yet started
 
 ---
 
@@ -557,12 +479,17 @@ Orpheus follows a strict two-thread model for real-time safety.
 # Minimal build (core + minhost)
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 
-# With OCC application
-cmake -S . -B build -DORPHEUS_ENABLE_APP_CLIP_COMPOSER=ON
+# With the in-tree Wave Finder smoke-test shell
+cmake -S . -B build -DORPHEUS_ENABLE_APP_WAVE_FINDER=ON
+
+# With the JUCE demo host
+cmake -S . -B build -DORPHEUS_ENABLE_APP_JUCE_HOST=ON
 
 # Disable real-time audio (offline rendering only)
 cmake -S . -B build -DORPHEUS_ENABLE_REALTIME=OFF
 ```
+
+(Clip Composer is built from its own repository, not via an SDK CMake option.)
 
 **Build Types:**
 
@@ -581,8 +508,10 @@ cmake -S . -B build -DORPHEUS_ENABLE_REALTIME=OFF
 **Unified Pipeline** (`.github/workflows/ci-pipeline.yml`):
 
 - Matrix builds: 3 OS × 2 build types (ubuntu/windows/macos, Debug/Release)
-- 7 parallel jobs: C++ build/test, lint, native driver, TypeScript, integration, dependency check, performance
-- Target duration: <25 minutes
+- Sanitizers (ASan/UBSan) on Debug for ubuntu/macos
+- C++ lint job: clang-format, Windows-include hygiene, binary-artifact
+  rejection, docs-path validation
+- Supply chain: `dep-audit.yml` (SHA-pinned Actions, npm/PyPI checks)
 
 **Specialized Workflows:**
 
@@ -599,7 +528,7 @@ cmake -S . -B build -DORPHEUS_ENABLE_REALTIME=OFF
 
 ---
 
-## ORP109 SDK Enhancements (v1.0.0-rc.2)
+## ORP109 SDK Enhancements
 
 **Added:** 2025-11-11
 **Status:** Complete, production-ready
@@ -809,24 +738,21 @@ Orpheus SDK has been extended with 7 major features for professional workflows:
 ### Getting Started
 
 - [README.md](README.md) – Quick start guide (build SDK in <10 minutes)
-- [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) – Basic integration guide
-- [docs/DRIVER_INTEGRATION_GUIDE.md](docs/DRIVER_INTEGRATION_GUIDE.md) – Platform driver integration
+- [docs/INDEX.md](docs/INDEX.md) – Documentation index (live + historical)
 
 ### Implementation Plans
 
-- [ORP068 - SDK Integration Plan v2.0](<docs/ORP/ORP068%20Implementation%20Plan%20(v2.0).md>) – Driver architecture (Phases 0-4)
-- [ORP077 - SDK Core Quality Sprint](docs/ORP/ORP077.md) – Unit tests, API docs, determinism validation
+- [ORP132 – Master Sprint Index](docs/orp/ORP132%20SDK%20Hardening%20and%20Platform%20Roadmap%20-%20Master%20Sprint%20Index.md) – Current hardening program (ORP133–ORP136)
+- [ORP068 - SDK Integration Plan v2.0](<docs/orp/ORP068%20Implementation%20Plan%20(v2.0).md>) – Historical driver architecture (Phases 0-4)
 
 ### Application Documentation
 
-- [OCC Product Vision](apps/clip-composer/docs/OCC/OCC021%20Orpheus%20Clip%20Composer%20-%20Product%20Vision.md) – Market positioning
-- [OCC CHANGELOG](apps/clip-composer/CHANGELOG.md) – Full release history
+- [Clip Composer repo](https://github.com/chrislyons/clip-composer) – application source, OCC docs, and release history (external)
 
 ### Developer Tools
 
-- [AGENTS.md](AGENTS.md) – Coding assistant guidelines
+- [AGENTS.md](docs/archive/AGENTS.md) – Coding assistant guidelines (archived)
 - [CLAUDE.md](CLAUDE.md) – Claude Code development guide
-- [CONTRIBUTING.md](docs/CONTRIBUTING.md) – Contribution guidelines
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -520,13 +520,24 @@ Orpheus follows a strict two-thread model for real-time safety.
 
 **UI → Audio Thread:**
 
-- Atomic writes to clip state (`std::atomic<float> gainLinear`)
-- Lock-free command queue (future enhancement)
+- Lock-free SPSC command queue (`TransportCommand` ring): every control
+  mutation (start/stop/update trim/fade/gain/loop/metadata/restart/seek) is
+  posted through a single `postCommand()` choke point and applied by the audio
+  thread in `processCommands()`.
+- **Single-producer contract (ORP133 G3):** exactly one control thread may
+  post commands. Hosts with multiple control sources (UI + MIDI + OSC) must
+  funnel them through one dispatcher. Debug builds assert on violation.
 
 **Audio → UI Thread:**
 
-- Lock-free callback queue (`onClipFinished`, `onClipLooped`)
-- Callbacks invoked from UI thread timer
+- Lock-free SPSC event queue carrying POD `TransportEvent`s (ORP133 G1) — no
+  `std::function` on the audio thread. `processCallbacks()` translates events
+  into `ITransportCallback` virtuals (`onClipStarted`, `onClipStopped`,
+  `onClipLooped`, `onClipRestarted`, `onClipSeeked`, `onBufferUnderrun`) on
+  the host's UI thread (typically from a UI timer).
+- Queries (`getClipState`, `getClipPosition`, voice counts) read a
+  double-buffered voice snapshot published by the audio thread (ORP127 G1) —
+  safe from any thread.
 
 ### Verification
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,7 +70,7 @@ graph TD
   downstream applications: `occ-app-platform` (session recovery, preferences,
   health telemetry) and `shmui-juce` (JUCE UI components). Not part of the
   core SDK libraries. (The former TypeScript driver layer is archived — see
-  `docs/DECISION_PACKAGES.md`.)
+  `docs/orp/_process/archive/DECISION_PACKAGES.md`.)
 - **In-tree apps** (`apps/`) – `wave-finder` (app-platform smoke-test shell)
   and `juce-demo-host` (JUCE demo host). Production applications — Clip
   Composer, FourTrack, FreqFinder — live in their own repositories and consume
@@ -224,7 +224,7 @@ struct ActiveClip {
     std::atomic<uint64_t> currentFrame;
     std::atomic<float> gainLinear;
     std::atomic<bool> loopEnabled;
-    std::shared_ptr<IAudioFileReader> reader; // Immutable after creation
+    std::shared_ptr<IClipSource> source; // Prepared/streamed PCM view (ORP134 G1)
     // ... fade state, trim points
 };
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,11 +157,25 @@ Version compatibility helpers:
 
 **File:** `include/orpheus/abi_version.h`
 
+#### 7. ORP134 Platform Primitives (2026-07-09)
+
+Additive public surfaces from the hardening program (details: `docs/orp/ORP137`):
+
+- **Clip sources** (`src/core/transport/clip_source.h`, internal) – prepared/
+  streaming PCM views; the audio thread no longer reads files (ORP134 G1)
+- **Identity & time** (`identity.h`, `time_domain.h`, `media_model.h`) –
+  stable IDs, sample-canonical time, media/launcher aggregates (G2)
+- **Graph seam** (`audio_graph.h`) – neutral routing vocabulary + soundboard
+  facade over the existing matrix (G3)
+- **File writer** (`audio_file_writer.h`) – WAV/AIFF/FLAC encoding (G5, FTR007)
+- **Analysis facade** (`audio_analysis.h`) – FFT/STFT + LUFS/waveform wrappers (G6)
+- **Capture plumbing** (`audio_input.h`) – lock-free input ring + stream contract (G7)
+
 ### Build Artifacts
 
 - **`orpheus_core`** – Static library with session/transport primitives
 - **`orpheus_transport`** – Real-time transport controller module
-- **`orpheus_audio_io`** – Audio file reader and platform drivers
+- **`orpheus_audio_io`** – Audio file reader/writer, capture ring, platform drivers
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unlabeled references to the extracted `apps/clip-composer` subdirectory, and
   references to CMake options that no longer exist.
 
+### Added - ORP134 Platform Primitives (2026-07-09)
+
+- **`IAudioFileWriter` (ORP134 G5 — FourTrack's FTR007 request).** New public
+  interface `include/orpheus/audio_file_writer.h` mirroring
+  `IAudioFileReader`'s shape and error model: `open(path, config)` /
+  `writeSamples(interleaved float32)` / `close()`, background-thread contract
+  (never the audio thread — capture feeds a ring buffer that a writer thread
+  drains). Libsndfile-backed implementation supports WAV/AIFF in
+  Int16/Int24/Float32 and FLAC in Int16/Int24 (Float32 is rejected — FLAC is
+  integer-only); out-of-range floats saturate rather than wrap
+  (`SFC_SET_CLIPPING`). `createAudioFileWriter()` returns nullptr when built
+  without libsndfile (stub, same pattern as the reader). Round-trip tests
+  prove bit-exact float32 WAV and ≤1 LSB integer encodings via the SDK's own
+  reader. FourTrack can drop its local `WavWriter` on the next submodule bump.
+
 ### Added - ORP136 Verification Bootstrap (2026-07-09)
 
 - **Runtime realtime-safety harness** (`tests/transport/realtime_harness_test.cpp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - ORP133 Realtime Callback Safety & Contract Truth (2026-07-09)
+
+- **Audio→UI event ring is now POD (ORP133 G1).** The transport's internal
+  callback ring no longer stores `std::function<void()>` payloads; the audio
+  thread enqueues trivially-copyable `TransportEvent`s and
+  `processCallbacks()` translates them into the unchanged public
+  `ITransportCallback` virtuals on the UI thread. Emission points, ordering,
+  and timing are 1:1 with the previous behavior. No public API change.
+- **Command-queue threading contract documented and enforced (ORP133 G3).**
+  Control-mutating transport methods are single-producer: exactly one control
+  thread may call them (funnel UI/MIDI/OSC through one dispatcher). Queries
+  remain lock-free and callable from any thread. Debug builds now assert if
+  commands are posted from more than one thread. All control entry points
+  funnel through a single `postCommand()` choke point.
+
+### Deprecated - ORP133
+
+- **`ITransportController::stopAllInGroup()` (ORP133 G2).** This method was a
+  silent no-op in every release (the transport has no clip→group mapping;
+  grouping is a host concern). It now returns
+  `SessionGraphError::NotSupported` and is documented as deprecated. Hosts
+  implement scoped group-stop with their own group model on top of
+  `stopOtherClips()` (ORP127 G7 choke primitive). The method is retained for
+  source compatibility and may be removed in a future major version.
+
 ### Added - ORP109 Professional Features (2025-11-11)
 
 #### Feature 1: Routing Matrix API (ORP109, ORP110)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remain lock-free and callable from any thread. Debug builds now assert if
   commands are posted from more than one thread. All control entry points
   funnel through a single `postCommand()` choke point.
+- **Version realigned to the build's truth (ORP133 G4).** The SDK version is
+  **0.3.0**, sourced from `project(orpheus VERSION 0.3.0)` in
+  `CMakeLists.txt`; README and docs now reference CMake as the single source
+  of truth. The October 2025 "v1.0.0-rc.1"/"v1.0.0-rc.2" README/docs banners
+  predated the 0.x renumbering (downstream apps pin `v0.3.0`); those labels
+  remain in this changelog as historical release names only.
+- **Documentation truth pass + CI gate (ORP133 G5/G6).** README,
+  ARCHITECTURE.md, ROADMAP.md, docs/INDEX.md, and docs/API_SURFACE_INDEX.md no
+  longer describe the extracted `apps/clip-composer` subdirectory, the removed
+  `ORPHEUS_ENABLE_APP_CLIP_COMPOSER` option, or the archived TypeScript driver
+  layer as live; `packages/occ-app-platform` and `packages/shmui-juce` are
+  documented as active C++ packages. A new `tools/docs_path_audit.py` gate
+  (ctest `docs_path_audit` + CI lint step) fails on broken internal doc links,
+  unlabeled references to the extracted `apps/clip-composer` subdirectory, and
+  references to CMake options that no longer exist.
 
 ### Deprecated - ORP133
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unlabeled references to the extracted `apps/clip-composer` subdirectory, and
   references to CMake options that no longer exist.
 
-### Deprecated - ORP133
+### Added - ORP136 Verification Bootstrap (2026-07-09)
+
+- **Runtime realtime-safety harness** (`tests/transport/realtime_harness_test.cpp`
+  + `tests/support/rt_guard.hpp`, ORP136 §2.2). Global allocation hooks count
+  any C++ alloc/dealloc performed while the calling thread is inside a marked
+  audio-callback section, and Linux `/proc/self/io` sampling observes file I/O
+  at the syscall level. Proven red/green: the pure (reader-less) 16-clip render
+  path performs ZERO allocations across 500 callbacks, while the file-backed
+  path is pinned as KNOWN DEBT (~2,400 read syscalls observed on the audio
+  thread) with an explicit flip-point marker for the ORP134 streaming reader.
+  This is the runtime gate ORP134 G1 is blocked on.
+- **Golden render-hash determinism gate**
+  (`tests/transport/transport_render_hash_test.cpp`, ORP136 §2.3). The
+  transport render path (trims, Linear/EqualPower fades, gain, OUT-point stop
+  fades, mono→stereo, routing + limiter) is proven **bit-identical across
+  block sizes 256/512/1024/2048** and across repeated runs (FNV-1a 64 over
+  raw sample bytes). Serves as the parity oracle for the ORP134 G1
+  streaming-reader migration. Cross-platform golden constants are deferred
+  until the fade math is pinned (ORP134 G4); drift is a bug to file, not mask.
 
 - **`ITransportController::stopAllInGroup()` (ORP133 G2).** This method was a
   silent no-op in every release (the transport has no clip→group mapping;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prove bit-exact float32 WAV and ≤1 LSB integer encodings via the SDK's own
   reader. FourTrack can drop its local `WavWriter` on the next submodule bump.
 
+- **Offline render determinism gate completed (ORP134 G4).** `RenderSpec` is
+  the offline render-job descriptor (sample rate, bit depth, channel layout,
+  dither + seed, output target). New `DitheredRenderIsSeedDeterministic` test
+  proves the same job descriptor reproduces byte-identical output including
+  the dither noise, and that changing the seed changes the bytes. Combined
+  with the pre-existing undithered golden hashes (`render_tracks_basic`) and
+  the transport-side block-size-invariance gate (ORP136 bootstrap), the
+  "same input → same output, always" loop is closed for both render paths.
+
 ### Added - ORP136 Verification Bootstrap (2026-07-09)
 
 - **Runtime realtime-safety harness** (`tests/transport/realtime_harness_test.cpp`
@@ -73,6 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raw sample bytes). Serves as the parity oracle for the ORP134 G1
   streaming-reader migration. Cross-platform golden constants are deferred
   until the fade math is pinned (ORP134 G4); drift is a bug to file, not mask.
+
+### Deprecated - ORP133
 
 - **`ITransportController::stopAllInGroup()` (ORP133 G2).** This method was a
   silent no-op in every release (the transport has no clip→group mapping;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   IDs serialize as decimal strings (the SDK JSON number type is a double —
   53-bit mantissa); tests round-trip IDs > 2^53 through the SDK JSON parser
   and the installed-header compile gate covers the new headers.
+- **Recorder plumbing (ORP134 G7).** New `audio_input.h`: `AudioInputRing`
+  (lock-free SPSC ring of interleaved frames — audio-thread producer never
+  blocks, drops whole buffers on overflow and counts them) and
+  `IAudioInputStream` (the capture contract hosts consume instead of hooking
+  the raw driver callback; `createAudioInputStream()` returns the ring-backed
+  implementation). Paired with `IAudioFileWriter` this makes "capture → disk"
+  an SDK-supported path (integration test drives audio-thread capture through
+  a background writer to a WAV and verifies the samples). Take/punch/latency
+  policy stays host-side by design.
+- **Analysis facade (ORP134 G6).** New `audio_analysis.h`
+  (`orpheus::analysis`): radix-2 FFT/STFT (new), RMS/peak, integrated LUFS
+  (WRAPS the existing `LoudnessMeter` — parity asserted by test, not
+  re-implemented), spectral centroid/rolloff, spectral-flux onset detection,
+  and an in-memory min/max waveform proxy (file-backed proxies remain
+  `IAudioFileReaderExtended`'s job). Offline/background utilities only.
+- **Graph-neutral routing seam (ORP134 G3).** New `audio_graph.h`:
+  sources/processors/buses/sinks/sends/taps/channel-layout vocabulary as a
+  validated `GraphDescription`, plus the soundboard facade
+  (`makeSoundboardGraph`) and `toRoutingConfig()` mapping onto the EXISTING
+  routing matrix (not replaced — ORP134 §7). Tests prove the facade's
+  translation equals the transport's hard-wired topology (64 ch / 4 groups /
+  stereo out) and that the vocabulary expresses FourTrack's bus shapes and
+  FreqFinder's analysis taps. The executing graph engine remains an ORP135
+  candidate.
+- **Scene manager wired + tested at launcher scale (ORP134 G8).**
+  `ISceneManager::setRoutingMatrix()` is now on the public interface (it
+  previously existed only on the hidden concrete class, making routing
+  capture/recall unreachable through `createSceneManager()`). New
+  `scene_routing_test` drives capture/recall of group assignments and gains
+  end-to-end, including an 8-tab page-switching round-trip. Gap documented
+  by design: `SceneSnapshot::assignedClips` is host presentation state the
+  SDK cannot derive — hosts persist grids with `media_model.h`'s
+  `ClipSlot`/`LauncherScene` shapes.
 - **Offline render determinism gate completed (ORP134 G4).** `RenderSpec` is
   the offline render-job descriptor (sample rate, bit depth, channel layout,
   dither + seed, output target). New `DitheredRenderIsSeedDeterministic` test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prove bit-exact float32 WAV and ≤1 LSB integer encodings via the SDK's own
   reader. FourTrack can drop its local `WavWriter` on the next submodule bump.
 
+- **Stable identity & time-domain primitives (ORP134 G2 — additive).** New
+  public headers `identity.h` (opaque `SessionId`/`TrackId`/`ClipId`/
+  `MediaId`/`AutomationLaneId` strong types over `uint64_t`, plus a
+  deterministic monotonic `IdAllocator` with a serializable watermark),
+  `time_domain.h` (`TimePoint`/`TimeRange` with the 64-bit sample count as
+  the canonical value and seconds/beats/timecode as derived views), and
+  `media_model.h` (`MediaRegion`, `Take`, `ClipSlot`, `LauncherScene` thin
+  aggregates). The pointer-based `SessionGraph` is untouched (ORP134 §7);
+  these types are the vocabulary new code and serialization should prefer.
+  IDs serialize as decimal strings (the SDK JSON number type is a double —
+  53-bit mantissa); tests round-trip IDs > 2^53 through the SDK JSON parser
+  and the installed-header compile gate covers the new headers.
 - **Offline render determinism gate completed (ORP134 G4).** `RenderSpec` is
   the offline render-job descriptor (sample rate, bit depth, channel layout,
   dither + seed, output target). New `DitheredRenderIsSeedDeterministic` test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prove bit-exact float32 WAV and ≤1 LSB integer encodings via the SDK's own
   reader. FourTrack can drop its local `WavWriter` on the next submodule bump.
 
+- **The audio thread no longer reads files (ORP134 G1 — the program's
+  defining migration).** `processAudio()` used to call
+  `IAudioFileReader::readSamples()`/`seek()` per clip — blocking libsndfile
+  decode on the audio callback (tracked debt since ORP121). The transport now
+  renders from immutable, position-explicit `IClipSource` views built off the
+  audio thread: whole-file PCM decoded in `prepareClipAudio()`/`startClip()`
+  (control thread) for short clips, and a background-worker-fed fixed page
+  ring for long files (> ~30 s; internal threshold). A streaming cache miss
+  NEVER blocks: the clip renders silence for that buffer and the transport
+  emits the (previously never-fired) `onBufferUnderrun` callback while the
+  worker refills. Seeks became prefetch hints — there is no file cursor
+  anywhere near the callback — which also makes multi-voice playback of one
+  clip correct by construction (voices no longer fight over a shared reader
+  position). The public transport API is unchanged.
+  **Verified:** golden render-hash parity is bit-exact against the old
+  reading path (same hash, all block sizes); the runtime harness measures the
+  file-backed callback at ~0 read syscalls (was ~2,400 / ~4.9 MB per 300
+  buffers) with zero allocations; streaming prefill plays gap-free and
+  seek-past-window underruns recover; `tools/realtime_audit.py
+  --fail-known-debt` now PASSES in-repo and runs as the strict CI gate
+  (`realtime_static_audit`). Remaining `--include-adjacent` findings are
+  app-repo debt for the downstream sprints (REALTIME_AUDIT.md).
 - **Stable identity & time-domain primitives (ORP134 G2 — additive).** New
   public headers `identity.h` (opaque `SessionId`/`TrackId`/`ClipId`/
   `MediaId`/`AutomationLaneId` strong types over `uint64_t`, plus a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current Release:** v1.0.0-rc.1 (2025-10-31)
+**Current version:** 0.3.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+version is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt) —
+docs reference it rather than restating it. (The 2025-10-31 "v1.0.0-rc.1"
+banner predated the 0.x renumbering; see `CHANGELOG.md` for history.)
 
 ## ⚡ Quick Start
 
@@ -57,7 +60,7 @@ target_link_libraries(my_app PRIVATE Orpheus::diagnostics Orpheus::audio_utils)
 
 ## Table of Contents
 
-- [What's New in v1.0](#whats-new-in-v10)
+- [Feature Highlights](#feature-highlights)
 - [Core Capabilities](#core-capabilities)
 - [Repository Layout](#repository-layout)
 - [Supported Platforms](#supported-platforms)
@@ -74,9 +77,9 @@ target_link_libraries(my_app PRIVATE Orpheus::diagnostics Orpheus::audio_utils)
 - [Contributing](#contributing)
 - [License](#license)
 
-## What's New in v1.0
+## Feature Highlights
 
-Orpheus SDK v1.0 introduces comprehensive clip playback control, metadata persistence, and professional workflow features:
+The SDK provides comprehensive clip playback control, metadata persistence, and professional workflow features:
 
 ### 🎚️ Gain Control API
 
@@ -113,7 +116,7 @@ transport->restartClip(handle);
 transport->seekClip(handle, position);
 ```
 
-### 🎛️ ORP109 Professional Features (v1.0.0-rc.2)
+### 🎛️ ORP109 Professional Features
 
 **Added 2025-11-11:** Seven major features for professional workflows:
 
@@ -218,10 +221,11 @@ The Orpheus SDK provides deterministic session/transport control for professiona
 
 ```
 ├── adapters/           # Host integrations (minhost CLI, REAPER extension)
-├── apps/               # Applications (Clip Composer, demo host)
+├── apps/               # In-tree apps (wave-finder smoke shell, juce-demo-host)
 ├── cmake/              # CMake helper modules and compiler policies
 ├── docs/               # Architecture, roadmaps, API reference, ORP documents
 ├── include/            # Public C++ headers (install these with your app)
+├── packages/           # Shared C++/JUCE app packages (occ-app-platform, shmui-juce)
 ├── src/                # Core library implementation (C++20)
 │   ├── core/           # Transport, routing, audio I/O, session
 │   └── platform/       # Platform-specific drivers (CoreAudio, WASAPI, ASIO)
@@ -229,7 +233,18 @@ The Orpheus SDK provides deterministic session/transport control for professiona
 └── CHANGELOG.md        # Release notes and version history
 ```
 
-**Note:** TypeScript packages previously in `packages/` have been archived. See [`docs/DECISION_PACKAGES.md`](docs/DECISION_PACKAGES.md) for rationale (C++ SDK focus).
+**Package status (one authoritative sentence each):**
+
+- `packages/occ-app-platform` — **active** C++ application-platform helpers
+  (session recovery, preferences, health telemetry) consumed by the external
+  Clip Composer repo through its SDK submodule.
+- `packages/shmui-juce` — **active** JUCE UI component library (waveform,
+  meters, transport widgets) consumed by downstream JUCE apps; not part of the
+  core SDK libraries.
+- The former **TypeScript** packages (`@orpheus/engine-*`, `@orpheus/client`,
+  `@orpheus/shmui`) are **archived** — see
+  [`docs/orp/_process/archive/DECISION_PACKAGES.md`](docs/orp/_process/archive/DECISION_PACKAGES.md)
+  for the rationale (C++ SDK focus).
 
 ## Supported Platforms
 
@@ -286,8 +301,8 @@ configuration:
   ```
 
 - **Host integrations** – toggle adapters via CMake cache entries. See
-  [`docs/ADAPTERS.md`](docs/ADAPTERS.md) for the full list of flags and host
-  requirements.
+  [`docs/orp/_process/archive/ADAPTERS.md`](docs/orp/_process/archive/ADAPTERS.md)
+  for the full list of flags and host requirements.
 
 ### Running Tests
 
@@ -342,30 +357,25 @@ claude-code
 
 #### Clip Composer Instance (Application Development)
 
-**Working Directory:** `~/dev/orpheus-sdk/apps/clip-composer`
+**Clip Composer is an external downstream repository** —
+[`chrislyons/clip-composer`](https://github.com/chrislyons/clip-composer)
+(local checkout: `~/dev/clip-composer`). It consumes this SDK as a git
+submodule at `third_party/orpheus-sdk`. The former in-tree
+`apps/clip-composer/` subdirectory was archived on 2026-07-09 (see
+`docs/orp/ORP131`).
 
-**Focus:** Tauri desktop application, JUCE UI components, end-user features
+**Use the Clip Composer repo for:**
 
-**Start Instance:**
+- Application-specific features, UI components, and workflows
+- OCC documentation (`docs/occ/` in that repo)
+- App builds and CI (both live there, not here)
 
-```bash
-cd ~/dev/orpheus-sdk/apps/clip-composer
-claude-code
+**Use this SDK repo for:** the transport, routing, audio_io, and ABI work
+Clip Composer depends on — then bump the submodule pin in the app repo.
 
-# Or use the shortcut script:
-~/dev/orpheus-sdk/scripts/start-clip-composer-instance.sh
-```
+#### When to Use Which Repo
 
-**Use For:**
-
-- Application-specific features
-- UI components and workflows
-- OCC-specific functionality
-- Documentation in `apps/clip-composer/docs/occ/`
-
-#### When to Use Which Instance
-
-| Task                         | Instance      | Reason                    |
+| Task                         | Repo          | Reason                    |
 | ---------------------------- | ------------- | ------------------------- |
 | Fix transport controller bug | SDK           | Core library modification |
 | Add new clip button feature  | Clip Composer | Application UI change     |
@@ -373,13 +383,6 @@ claude-code
 | Implement session dialog     | Clip Composer | Application-specific UI   |
 | Add routing matrix test      | SDK           | Core library testing      |
 | Fix waveform display         | Clip Composer | Application UI component  |
-
-#### Instance Isolation Benefits
-
-- **No config collision** – Separate `.claude/` directories
-- **Context-appropriate skills** – Different tool sets per instance
-- **Clear documentation boundaries** – ORP vs OCC prefixes
-- **Independent progress tracking** – Separate implementation logs
 
 **See also:** `CLAUDE.md` Multi-Instance Usage section for complete documentation
 
@@ -431,26 +434,36 @@ LLVM `run-clang-tidy.py` helper) on the files you want to inspect.
 
 The Orpheus SDK provides the foundation for a family of professional audio applications:
 
-### Orpheus Clip Composer (OCC)
+### Orpheus Clip Composer (OCC) — external repo
 
 **Professional soundboard for broadcast, theater, and live performance**
 
-- **Status:** v0.2.1 — active development. Operator modes (Playout/Edit/Routing/Preferences), audition paths, session recovery, real-time health strip all in place.
+- **Repo:** [`chrislyons/clip-composer`](https://github.com/chrislyons/clip-composer)
+  — a standalone downstream repository that consumes this SDK as a git
+  submodule (`third_party/orpheus-sdk`). Extracted from this repo's former
+  `apps/clip-composer/` subdirectory on 2026-07-09 (archival report:
+  `docs/orp/ORP131`).
 - **Features:** Clip triggering (384 buttons, 960-slot capacity), waveform editing, multi-channel routing, operator modes, cue-bus audition
 - **Market:** Broadcast playout, theater sound design, live performance
-- **Documentation:** [`apps/clip-composer/docs/occ/`](apps/clip-composer/docs/occ/) – 146+ docs; archive at `docs/occ/archive/`
-  - [`OCC021 Product Vision`](apps/clip-composer/docs/occ/archive/OCC021%20Orpheus%20Clip%20Composer%20-%20Product%20Vision.md) – Market positioning, competitive analysis
-  - [`OCC026 MVP Definition`](apps/clip-composer/docs/occ/archive/OCC026%20Milestone%201%20-%20MVP%20Definition%20v1.0.md) – MVP plan with deliverables
-  - [`OCC146 Post-Codex Sprint Guide`](apps/clip-composer/docs/occ/OCC146%20Post-Codex%20Integration%20Sprint%20Guide.md) – Current sprint status
+- **Documentation:** `docs/occ/` in the Clip Composer repo (not here)
 
 **SDK Requirements:** Real-time transport, audio drivers (CoreAudio/ASIO/WASAPI), routing matrix, performance monitor
 
-### Orpheus Wave Finder
+### Orpheus FourTrack — external repo
 
-**Harmonic calculator and frequency scope for audio analysis**
+**Portastudio-style multitrack recorder for macOS/iOS**
 
-- **Status:** In development (`apps/wave-finder/`)
-- **Features:** FFT analysis, harmonic detection, frequency visualization
+- **Repo:** `chrislyons/fourtrack` (local: `~/dev/fourtrack`) — consumes this
+  SDK as a git submodule; exercises the SDK's host-neutrality (routing matrix,
+  readers, CoreAudio input capture).
+
+### Orpheus Wave Finder (in-tree)
+
+**App-platform smoke-test shell** (`apps/wave-finder/`)
+
+- **Status:** In-tree development shell exercising `packages/occ-app-platform`.
+  Note: this is NOT the real FreqFinder analyzer, which lives in its own
+  external repo (`~/dev/freqfinder`).
 
 ### Orpheus FX Engine
 
@@ -467,27 +480,20 @@ The Orpheus SDK provides the foundation for a family of professional audio appli
 
 **ORP Docs (SDK):**
 **PREFIX:** ORP
-**Next Doc:** ORP126.md
+**Next Doc:** ORP137
 **Location:** `docs/orp/`
 
 **Discovery command:**
 
 ```bash
-ls -1 docs/orp/ | grep -E "^ORP[0-9]{3,4}\.(md|mdx)$" | sort
+ls -1 docs/orp/ | sort
 ```
 
-**OCC Docs (Clip Composer):**
-**PREFIX:** OCC
-**Next Doc:** OCC147.md
-**Location:** `apps/clip-composer/docs/occ/`
+**OCC Docs (Clip Composer):** live in the external Clip Composer repo
+([`chrislyons/clip-composer`](https://github.com/chrislyons/clip-composer),
+`docs/occ/`) — not in this repository.
 
-**Discovery command:**
-
-```bash
-ls -1 apps/clip-composer/docs/occ/ | grep -E "^OCC[0-9]{3,4}\.(md|mdx)$" | sort
-```
-
-Documentation follows workspace pattern `docs/<prefix>/<PREFIX><NUM>.(md|mdx)` — see `~/chrislyons/dev/CLAUDE.md` for full conventions.
+Documentation follows workspace pattern `docs/<prefix>/<PREFIX><NUM>.(md|mdx)` — see the workspace `CLAUDE.md` for full conventions.
 
 ### Reference Documentation
 
@@ -496,7 +502,7 @@ Documentation follows workspace pattern `docs/<prefix>/<PREFIX><NUM>.(md|mdx)` �
 - [`ROADMAP.md`](ROADMAP.md) – planned milestones and long-term initiatives.
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) – design considerations for the modular
   core.
-- [`apps/clip-composer/docs/occ/`](apps/clip-composer/docs/occ/) – Orpheus Clip Composer documentation (active)
+- [Clip Composer repo](https://github.com/chrislyons/clip-composer) – Orpheus Clip Composer application + OCC documentation (external)
 - [`docs/archive/AGENTS.md`](docs/archive/AGENTS.md) – coding assistant guidelines for AI tools
 - [`CLAUDE.md`](CLAUDE.md) – Claude Code development guide
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ The Orpheus SDK provides the foundation for a family of professional audio appli
 
 **ORP Docs (SDK):**
 **PREFIX:** ORP
-**Next Doc:** ORP137
+**Next Doc:** ORP138
 **Location:** `docs/orp/`
 
 **Discovery command:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,9 @@
 # Roadmap
 
 The Orpheus roadmap captures the near-term milestones for evolving the SDK and
-its adapters. Updated October 2025 to include real-time infrastructure for
-Orpheus Clip Composer and future applications.
+its adapters. Updated 2026-07-09: M4/M6 items are now sequenced by the ORP132
+hardening program (`docs/orp/ORP132`–`ORP136`), and Clip Composer references
+point to its external repository (extracted 2026-07-09, see `docs/orp/ORP131`).
 
 ## Milestone M1 – Foundations (COMPLETE)
 
@@ -87,12 +88,9 @@ future applications requiring sample-accurate, low-latency performance.
 
 **References:**
 
-- See `docs/ORP/ORP068.md` for integration infrastructure
-- See `docs/ORP/ORP069.md` for OCC-aligned enhancements
-- See `docs/ORP/ORP070.md` for OCC MVP sprint plan (routing matrix, real audio)
-- See `apps/clip-composer/docs/OCC/OCC029.md` for detailed specifications
-- See `apps/clip-composer/docs/OCC/OCC027.md` for interface definitions
-- See `apps/clip-composer/docs/OCC/OCC030.md` for current implementation status
+- See `docs/orp/` for the ORP068/ORP069/ORP070 integration and enhancement plans
+- OCC specifications (OCC027/OCC029/OCC030) live in the external Clip Composer
+  repo (`chrislyons/clip-composer`, `docs/occ/`)
 
 ## Milestone M3 – Feature Expansion
 
@@ -101,35 +99,32 @@ future applications requiring sample-accurate, low-latency performance.
 - Add audio rendering scenarios to the minhost (streamed audio, bus routing).
 - Introduce integration tests that exercise host ↔ adapter handshakes.
 
-## Milestone M4 – Recording & DSP (Planned: Q1-Q2 2026)
+## Milestone M4 – Recording, Writer & Analysis Primitives
 
-**Purpose:** Support advanced features for Orpheus Clip Composer v1.0 and enable
-creative workflows for FX Engine.
+**Now owned by the ORP132 hardening program.** The recording/writer/analysis
+items below are scoped and sequenced in
+`docs/orp/ORP134 NEXT Sprint - Streaming Reader and Platform Primitives.md`:
 
-**Core Modules:**
+- **`IAudioFileWriter`** (WAV/AIFF/FLAC disk writer, FTR007) → ORP134 G5
+- **Input capture / recorder plumbing** (lock-free input ring,
+  `IAudioInputStream` contract; CoreAudio input capture landed as ORP130) →
+  ORP134 G7
+- **Analysis primitives** (FFT/STFT facade over the existing
+  LoudnessMeter/waveform/true-peak code) → ORP134 G6
 
-- ⏳ **Input Audio Graphs** - Planned
-  - Capture input from audio drivers (recording)
-  - Buffer management for real-time recording
-  - Disk streaming (WAV/AIFF file writer)
+Remaining M4 items not yet scheduled:
 
-- ⏳ **DSP Processing** - Planned
-  - Pluggable DSP processor interface
-  - Rubber Band integration (time-stretch, pitch-shift)
-  - Real-time parameter updates
-  - Quality vs performance profiles
-
-- ⏳ **Remote Control Protocols** - Planned
-  - WebSocket server (iOS companion app)
-  - OSC integration (Open Sound Control)
-  - MIDI control mapping
-  - Command registration API
+- ⏳ **DSP Processing** — pluggable processor interface, Rubber Band
+  integration (time-stretch/pitch-shift) → prerequisite work is the ORP134 G3
+  graph seam; processor nodes are ORP135 B4
+- ⏳ **Remote Control Protocols** — WebSocket/OSC/MIDI mapping → ORP135 B5
+  (requires the ORP133 G3 single-producer contract + an MPSC dispatcher)
 
 **Applications Enabled:**
 
-- OCC v1.0: Recording directly into buttons, DSP processing
-- FX Engine: LLM-powered effects, real-time parameter automation
-- Wave Finder: Real-time frequency analysis
+- Clip Composer: recording directly into buttons, DSP processing
+- FourTrack: SDK-backed capture → disk path (drops its local WavWriter)
+- FreqFinder: shared analysis primitives
 
 ## Milestone M5 – Production Readiness
 
@@ -138,32 +133,21 @@ creative workflows for FX Engine.
 - Expand CI with packaging, code coverage, and static analysis gates.
 - Document extension points and authoring guides for partner teams.
 
-## Milestone M6 – Advanced Features (Planned: Q3-Q4 2026)
+## Milestone M6 – Advanced Features (Speculative 2026+)
 
-**Purpose:** Enterprise capabilities and advanced workflows for Orpheus Clip
-Composer v2.0 and professional installations.
+**Re-expressed as ORP135 platform bets.** Each item below is a *candidate*
+tracked in `docs/orp/ORP135 LATER Sprint - Platform Leadership Bets.md`; a bet
+starts only when its ORP133/ORP134 dependency is stable and a concrete
+downstream consumer is asking:
 
-**Core Modules:**
-
-- ⏳ **Advanced Transport** - Planned
-  - Master/slave clip linking
-  - AutoPlay/jukebox mode with crossfades
-  - Rehearsal mode (silent playback with visual feedback)
-
-- ⏳ **Spatial Audio** (Basic VBAP) - Planned
-  - 3D positioning for clips
-  - Multi-channel speaker configurations
-  - Distance-based attenuation
-
-- ⏳ **Interaction Rules Engine** - Planned
-  - Conditional triggering (Ovation-inspired)
-  - State machines for show control
-  - External hardware integration (GPI)
-
-- ⏳ **VST3 Plugin Hosting** - Planned
-  - Plugin scanning and loading
-  - Parameter automation
-  - MIDI routing to plugins
+- **Sample-accurate automation** → ORP135 B1 (needs ORP134 identity/time)
+- **Spatial / multichannel graph readiness** (VBAP, speaker maps, ADM
+  alignment) → ORP135 B3 (needs ORP134 G3 graph seam)
+- **Plugin processor API, then optional hosting** (VST3/AU/LV2 hosting stays
+  an adapter concern, never core) → ORP135 B4 (needs B1 + graph seam)
+- **MIDI/OSC/control-surface mapping + MPSC control dispatcher** → ORP135 B5
+- **Interaction rules / show-control state machines** → app-side until the
+  automation and identity primitives exist (then reassess as an ORP135 bet)
 
 ---
 
@@ -185,8 +169,8 @@ Composer v2.0 and professional installations.
 
 **Related Documentation:**
 
-- `apps/clip-composer/docs/OCC/` - Orpheus Clip Composer design documentation
-- `apps/clip-composer/docs/OCC/OCC021` - Product vision (authoritative)
-- `apps/clip-composer/docs/OCC/OCC026` - MVP milestone definition
-- `apps/clip-composer/docs/OCC/OCC029` - SDK enhancement recommendations
-- `apps/clip-composer/docs/OCC/PROGRESS.md` - Design phase progress report
+- `docs/orp/ORP132` – SDK Hardening & Platform Roadmap master index
+  (ORP133 NOW / ORP134 NEXT / ORP135 LATER / ORP136 verification)
+- Clip Composer design documentation (OCC021/OCC026/OCC029, progress reports)
+  lives in the external Clip Composer repo (`chrislyons/clip-composer`,
+  `docs/occ/`)

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -22,6 +22,7 @@ labels.)
 | `include/orpheus/session_graph.h`              | `SessionGraph`             | In-memory session representation (tracks, clips, tempo) | v0.1.0-alpha        |
 | `include/orpheus/audio_file_reader.h`          | `IAudioFileReader`         | Audio file decoding (WAV/AIFF/FLAC via libsndfile)      | v0.1.0-alpha        |
 | `include/orpheus/audio_file_reader_extended.h` | `IAudioFileReaderExtended` | Waveform pre-processing for UI rendering                | ORP109 (unreleased) |
+| `include/orpheus/audio_file_writer.h`          | `IAudioFileWriter`         | Audio file encoding (WAV/AIFF/FLAC via libsndfile)      | ORP134 G5 (FTR007)  |
 
 ### Routing & Mixing (ORP109)
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -3,8 +3,11 @@
 This index catalogs public entry points exposed by the Orpheus SDK workspace. Update this document whenever new packages or
 notable APIs are added.
 
-**Last Updated:** 2025-11-11 (ORP109 features)
-**SDK Version:** v1.0.0-rc.2 (unreleased)
+**Last Updated:** 2026-07-09 (ORP133 truth pass)
+**SDK Version:** 0.3.0 — the authoritative version is `project(orpheus VERSION ...)`
+in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
+release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
+labels.)
 
 ---
 
@@ -104,36 +107,39 @@ notable APIs are added.
 
 ## JavaScript Packages (Archived)
 
-**Note:** TypeScript packages previously in `packages/` have been archived. See [DECISION_PACKAGES.md](DECISION_PACKAGES.md) for rationale (C++ SDK focus).
+**Note:** The former TypeScript packages have been **archived and removed from
+the tree** — nothing under `packages/` is JavaScript today. See
+[DECISION_PACKAGES.md](orp/_process/archive/DECISION_PACKAGES.md) for rationale (C++ SDK focus).
 
-| Package                  | Entry Point                   | Notes                                          | Status   |
-| ------------------------ | ----------------------------- | ---------------------------------------------- | -------- |
-| `@orpheus/shmui`         | `packages/shmui/src/index.js` | React components and UI helpers                | Archived |
-| `@orpheus/engine-native` | `packages/engine-native/`     | Node/Electron bindings wrapping the C++ engine | Archived |
-| `@orpheus/engine-wasm`   | _Planned_                     | WebAssembly bundle                             | Archived |
-| `@orpheus/client`        | _Planned_                     | Contract negotiation and command helpers       | Archived |
+| Package (archived)       | Former Role                                    | Status   |
+| ------------------------ | ---------------------------------------------- | -------- |
+| `@orpheus/shmui`         | React components and UI helpers                | Archived |
+| `@orpheus/engine-native` | Node/Electron bindings wrapping the C++ engine | Archived |
+| `@orpheus/engine-wasm`   | WebAssembly bundle (never shipped)             | Archived |
+| `@orpheus/client`        | Contract negotiation and command helpers       | Archived |
 
 ---
 
 ## C++ Components
 
-| Component   | Location    | Description                                                        |
-| ----------- | ----------- | ------------------------------------------------------------------ |
-| Core Engine | `src/`      | Primary C++ source compiled into static libraries.                 |
-| Adapters    | `adapters/` | Integration points for external hosts (minhost, REAPER).           |
-| Tests       | `tests/`    | GoogleTest-driven validation (270+ unit tests).                    |
-| Apps        | `apps/`     | Applications built on SDK (Clip Composer, Wave Finder, FX Engine). |
+| Component   | Location    | Description                                                                  |
+| ----------- | ----------- | ---------------------------------------------------------------------------- |
+| Core Engine | `src/`      | Primary C++ source compiled into static libraries.                            |
+| Adapters    | `adapters/` | Integration points for external hosts (minhost, REAPER).                      |
+| Packages    | `packages/` | Active C++/JUCE app packages (`occ-app-platform`, `shmui-juce`).               |
+| Tests       | `tests/`    | GoogleTest-driven validation (270+ unit tests).                                |
+| Apps        | `apps/`     | In-tree dev apps (wave-finder smoke shell, juce-demo-host). Production apps (Clip Composer, FourTrack, FreqFinder) are external repos. |
 
 ---
 
 ## Documentation Cross-Reference
 
 - [Architecture Overview](../ARCHITECTURE.md) – System design and threading model
-- [Migration Guide](MIGRATION_v0_to_v1.md) – v0.x → v1.0 upgrade guide (includes ORP109 features)
-- [Driver Architecture](DRIVER_ARCHITECTURE.md) – Runtime-specific integration notes
-- [Contract Guide](CONTRACT_DEVELOPMENT.md) – Command/event schemas shared across drivers
-- [ORP109 Roadmap](../docs/ORP/ORP109%20SDK%20Feature%20Roadmap%20for%20Clip%20Composer%20Integration.md) – Feature specifications
-- [ORP110 Implementation Report](../docs/ORP/ORP110%20ORP109%20Implementation%20Report.md) – Complete feature documentation
+- [Migration Guide](MIGRATION_v0_to_v1.md) – v0.x → v1.0 upgrade guide (historical; includes ORP109 features)
+- [Driver Architecture](orp/_process/archive/DRIVER_ARCHITECTURE.md) – Runtime-specific integration notes (archived)
+- [Contract Guide](orp/_process/archive/CONTRACT_DEVELOPMENT.md) – Command/event schemas shared across drivers (archived)
+- [ORP109 Roadmap](orp/ORP109%20SDK%20Feature%20Roadmap%20for%20Clip%20Composer%20Integration.md) – Feature specifications
+- [ORP110 Implementation Reports](orp/ORP110A%20App-Level%20Integration%20Report.md) – Complete feature documentation (see also ORP110B)
 
 ---
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -26,6 +26,9 @@ labels.)
 | `include/orpheus/identity.h`                   | `StrongId`, `IdAllocator`  | Stable session/track/clip/media/lane identifiers        | ORP134 G2           |
 | `include/orpheus/time_domain.h`                | `TimePoint`, `TimeRange`   | Sample-canonical time with seconds/beats/timecode views | ORP134 G2           |
 | `include/orpheus/media_model.h`                | `MediaRegion`, `Take`      | Media/region vocabulary + launcher aggregates           | ORP134 G2           |
+| `include/orpheus/audio_input.h`                | `IAudioInputStream`        | Lock-free capture ring + input-stream contract          | ORP134 G7           |
+| `include/orpheus/audio_analysis.h`             | `orpheus::analysis`        | FFT/STFT, LUFS/RMS/peak, spectral features, onsets      | ORP134 G6           |
+| `include/orpheus/audio_graph.h`                | `GraphDescription`         | Graph-neutral routing vocabulary + soundboard facade    | ORP134 G3           |
 
 ### Routing & Mixing (ORP109)
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -23,6 +23,9 @@ labels.)
 | `include/orpheus/audio_file_reader.h`          | `IAudioFileReader`         | Audio file decoding (WAV/AIFF/FLAC via libsndfile)      | v0.1.0-alpha        |
 | `include/orpheus/audio_file_reader_extended.h` | `IAudioFileReaderExtended` | Waveform pre-processing for UI rendering                | ORP109 (unreleased) |
 | `include/orpheus/audio_file_writer.h`          | `IAudioFileWriter`         | Audio file encoding (WAV/AIFF/FLAC via libsndfile)      | ORP134 G5 (FTR007)  |
+| `include/orpheus/identity.h`                   | `StrongId`, `IdAllocator`  | Stable session/track/clip/media/lane identifiers        | ORP134 G2           |
+| `include/orpheus/time_domain.h`                | `TimePoint`, `TimeRange`   | Sample-canonical time with seconds/beats/timecode views | ORP134 G2           |
+| `include/orpheus/media_model.h`                | `MediaRegion`, `Take`      | Media/region vocabulary + launcher aggregates           | ORP134 G2           |
 
 ### Routing & Mixing (ORP109)
 

--- a/docs/APP_REALTIME_DEBT_REMEDIATION.md
+++ b/docs/APP_REALTIME_DEBT_REMEDIATION.md
@@ -5,6 +5,12 @@ realtime-audit hardening branch lands. It does not require SDK code changes in
 those repos beyond consuming the public preparation/capability contracts added
 here.
 
+**Status update (2026-07-09, ORP134 G1):** the SDK-side prerequisite has
+LANDED — the transport now renders from prepared/streaming clip sources and
+`tools/realtime_audit.py --fail-known-debt` passes in-repo. The app patches
+below are now unblocked; FourTrack should adopt the SDK's prepared/streaming
+sources (and `IAudioFileWriter`, ORP134 G5) on its next submodule bump.
+
 Run from `~/dev/orpheus-sdk`:
 
 ```sh

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,68 +4,57 @@
 
 ## 🚀 Start Here
 
-**New to Orpheus SDK?** Begin with these guides:
+**New to Orpheus SDK?** Begin with these:
 
-1. **[Getting Started](orp/_process/GETTING_STARTED.md)** – Install, build, and run your first session
-2. **[Driver Architecture](orp/_process/DRIVER_ARCHITECTURE.md)** – Understand Service, WASM, and Native drivers
-3. **[Driver Integration Guide](orp/_process/DRIVER_INTEGRATION_GUIDE.md)** – Step-by-step integration with code examples
-4. **[Contract Guide](orp/_process/CONTRACT_DEVELOPMENT.md)** – Learn the command/event schema system
+1. **[Repository README](../README.md)** – Build the SDK and run the tests in minutes
+2. **[Architecture Overview](../ARCHITECTURE.md)** – Layers, transport, threading model
+3. **[Roadmap](../ROADMAP.md)** – Milestones and the ORP132 hardening program
+4. **[API Surface Index](API_SURFACE_INDEX.md)** – Catalog of public C++ headers
 
 **For specific tasks:**
 
-- Integrating drivers → [Driver Integration Guide](orp/_process/DRIVER_INTEGRATION_GUIDE.md)
-- Adding features → [Contributor Guide](orp/_process/CONTRIBUTING.md)
-- Migrating projects → [Migration Guide](MIGRATION_v0_to_v1.md)
-- API reference → [API Surface Index](API_SURFACE_INDEX.md)
-- SDK team handoff → [SDK Team Handoff](SDK_TEAM_HANDOFF.md) | [Sprint Summary](SDK_SPRINT_SUMMARY.md)
+- Realtime safety rules → [Realtime Audio Audit](REALTIME_AUDIT.md)
+- Position-tracking semantics (settled, ORP089) → [SDK Position Tracking](SDK_POSITION_TRACKING.md)
+- App-side realtime debt guidance → [App Realtime Debt Remediation](APP_REALTIME_DEBT_REMEDIATION.md)
+- Migrating old integrations → [Migration Guide](MIGRATION_v0_to_v1.md) (historical)
 
 ---
 
 ## ORP Implementation Plans & Technical Library
 
-**📘 Current Active Plans (2025):**
+**📘 Current active program (2026): SDK Hardening & Platform Roadmap**
 
-| Document                                                        | Status                        | Focus                                                         | Timeline            |
-| --------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------- | ------------------- |
-| **[ORP068 – SDK Integration Plan v2.0](ORP/ORP068.md)**         | 🟢 Active (Phase 1 Complete)  | Driver architecture, contracts, client integration            | Months 1-6          |
-| **[ORP069 – OCC-Aligned SDK Enhancements v1.0](ORP/ORP069.md)** | 🟢 Active (Planning Complete) | Platform audio drivers, routing, performance monitoring       | Months 1-6          |
-| **[ORP074 – Clip Metadata Management Sprint](ORP/ORP074.md)**   | 🟡 Ready for Implementation   | TransportController trim/fade API, audio callback integration | Week 7-8 (2.5 days) |
+| Document | Role |
+| -------- | ---- |
+| **[ORP132 – Master Sprint Index](orp/ORP132%20SDK%20Hardening%20and%20Platform%20Roadmap%20-%20Master%20Sprint%20Index.md)** | Read first: scope, sequencing, boundaries |
+| **[ORP133 – NOW Sprint](orp/ORP133%20NOW%20Sprint%20-%20Realtime%20Callback%20and%20Contract%20Truth.md)** | Realtime callback safety & contract truth |
+| **[ORP134 – NEXT Sprint](orp/ORP134%20NEXT%20Sprint%20-%20Streaming%20Reader%20and%20Platform%20Primitives.md)** | Streaming reader & platform primitives |
+| **[ORP135 – LATER Sprint](orp/ORP135%20LATER%20Sprint%20-%20Platform%20Leadership%20Bets.md)** | Speculative 2026+ platform bets |
+| **[ORP136 – Verification & CI](orp/ORP136%20Verification%20and%20CI%20Framework.md)** | Cross-cutting verification framework |
 
-**📂 [ORP Directory Index](ORP/README.md)** – Quick reference guide to all implementation plans
+**📂 [ORP Directory Index](orp/README.md)** – Guide to all implementation plans
+(ORP001–ORP136), including the completed ORP125/126/127 transport sprints and the
+historical Shmui/TypeScript-era plans (ORP060–ORP068).
 
-**Historical Context:**
+---
 
-| Document                                             | Focus                                                                                                    | Key Cross-References                                                                                                                                         |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [ORP061 – Migration Plan](ORP/ORP061.md)             | Phase-driven roadmap for merging Shmui UI into the Orpheus SDK monorepo.                                 | Establishes Phase 0 baseline that is elaborated in ORP062 (contracts) and optimized in ORP063.                                                               |
-| [ORP062 – Technical Addendum](ORP/ORP062.md)         | Normative contract, driver, and validation rules for the engine boundary.                                | Extends ORP061 Phase 0/1 requirements; informs latency and frequency limits codified in budgets.json (see orp/_process/PERFORMANCE.md) and references ORP066 refinements. |
-| [ORP063 – Technical Optimization](ORP/ORP063.md)     | Operational alignment between migration strategy and contract architecture.                              | Builds on ORP061 sequencing; cites ORP062 schemas and feeds Phase 0 CI expectations referenced in ORP066/ORP068.                                             |
-| [ORP066 – Implementation Refinements](ORP/ORP066.md) | Corrective refinements and guardrails for ORP065 execution, covering CI, packaging, and risk mitigation. | References ORP061/ORP063 for migration context; drives package naming rules summarized in orp/_process/PACKAGE_NAMING.md.                                                 |
+## Historical Records
 
-### Additional Supporting References
+These documents describe the repository as it was; paths and features they
+mention may no longer exist in the tree:
 
-- [ORP065 – Shmui Integration Plan](ORP/ORP065.md) – Historical baseline referenced by ORP066.
-- [ORP067 – Task Numbering Appendix](ORP/ORP067.md) – Crosswalk between ORP task identifiers and repo workstreams.
-- [ORP-CDX-013 – CI Revalidation](ORP-CDX-013-ci-revalidation.md) – Companion guidance for validating CI coverage post-migration.
+- [SDK Team Handoff](SDK_TEAM_HANDOFF.md) | [Sprint Summary](SDK_SPRINT_SUMMARY.md) – ORP074 trim/fade metadata sprint records
+- [Upgrading to 1.0](UPGRADING_TO_1.0.md) – TypeScript-driver-era upgrade guide
+- [Migration v0 → v1](MIGRATION_v0_to_v1.md) – v1.0.0-rc.1-era migration guide
+- [`orp/_process/archive/`](orp/_process/archive/) – archived process docs
+  (GETTING_STARTED, DRIVER_ARCHITECTURE, CONTRACT_DEVELOPMENT, DECISION_PACKAGES, ADAPTERS, …)
+- [`archive/`](archive/) – archived marketing/spec material and AGENTS.md
 
-## Migration Phase ↔ Technical Specification Map
-
-| Migration Phase                        | Core Objectives                                                            | Authoritative Specs                                                      |
-| -------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Phase 0 – Preparatory Repository Setup | Establish monorepo structure, parallel CI, package namespace baselines.    | ORP061 §Phase 0, ORP062 §§1–3, ORP063 §II, ORP066 §II (package hygiene). |
-| Phase 1 – Tooling Normalization        | Wire Orpheus engine bindings into Shmui workflows, unify tooling.          | ORP061 §Phase 1, ORP062 §§4–5, ORP063 §III, ORP068 §II.                  |
-| Phase 2 – Feature Integration          | Deliver UI experiences powered by Orpheus engine capabilities.             | ORP061 §Phase 2, ORP063 §IV, ORP068 §III.                                |
-| Phase 3+ – Expansion & Governance      | Stabilize releases, enforce performance budgets, broaden platform support. | ORP068 §§IV–V, ORP063 §V, orp/_process/PERFORMANCE.md (budgets.json).                 |
+**Clip Composer (OCC) documentation** lives in the external
+[`chrislyons/clip-composer`](https://github.com/chrislyons/clip-composer)
+repository (`docs/occ/`) — extracted 2026-07-09, see
+[ORP131](orp/ORP131%20Clip%20Composer%20Subdirectory%20Archival.md).
 
 ## Navigation
 
 - ▲ [Back to Repository Overview](../README.md)
-- 📦 [Package Naming](orp/_process/PACKAGE_NAMING.md)
-- 📈 [Performance Budgets](orp/_process/PERFORMANCE.md)
-- 🧪 [CI Validation Checklist](ORP-CDX-013-ci-revalidation.md)
-
-### Branch Protection (Manual Verification)
-
-- Ensure **main** has required status checks: `build-cpp`, `build-ui`, `lint-cpp`.
-- Require ≥1 reviewer, disallow force-push, enforce linear history.
-- Record audit date in `orp/_process/GOVERNANCE.md`.

--- a/docs/REALTIME_AUDIT.md
+++ b/docs/REALTIME_AUDIT.md
@@ -16,23 +16,39 @@ about realtime safety and architecture contracts, not micro-optimizing DSP.
 
 ## Current Gates
 
-- `ctest -R realtime_static_audit` scans driver callbacks for hard failures.
-- `tools/realtime_audit.py --include-adjacent` also reports tracked debt in
-  `~/dev/clip-composer`, `~/dev/fourtrack`, and `~/dev/freqfinder` when those
-  repos are present beside the SDK.
-- `tools/realtime_audit.py --fail-known-debt --include-adjacent` is the future
-  strict gate after the streaming-reader and app telemetry migrations land.
+- `ctest -R realtime_static_audit` runs `tools/realtime_audit.py
+  --fail-known-debt` — the STRICT in-repo gate. Since the ORP134 G1
+  streaming-reader migration, the transport render path performs no file
+  reads/seeks, so any reintroduced audio-thread read is a hard CI failure.
+- The runtime side is enforced by `realtime_harness_test` (ORP136 §2.2):
+  allocation hooks + `/proc/self/io` sampling prove zero allocations and zero
+  media I/O across multi-clip `processAudio()` stress runs, and that streaming
+  cache misses emit silence + `BufferUnderrun` instead of blocking.
+- `tools/realtime_audit.py --fail-known-debt --include-adjacent` is the
+  cross-repo strict gate. It still reports the ADJACENT-repo debt below and
+  will pass once the app-side sprints land in those repos.
+
+## Resolved Architecture Debt
+
+- **The transport render path no longer calls file readers (ORP134 G1).**
+  `prepareClipAudio()`/`startClip()` build an immutable realtime source on the
+  control thread — whole-file PCM for short clips, a worker-fed page ring for
+  long files — and `processAudio()` memcpy-reads it position-explicitly. Seek
+  became a prefetch hint (no `sf_seek` anywhere near the callback); a
+  streaming cache miss renders silence and reports `BufferUnderrun`, never
+  blocking. Parity with the old reading path is proven bit-exact by the
+  golden render-hash gate.
 
 ## Known Architecture Debt
 
-- The transport render path still calls file readers directly. `prepareClipAudio`
-  gives hosts an explicit prewarm point, but the target architecture is a
-  non-realtime streamer feeding realtime-owned clip buffers.
 - The routing matrix now carries explicit `SourceChannelPolicy` and
   `DownmixPolicy`, but transport clip rendering still uses stereo pair buffers.
 - Clip Composer still performs app-level analyzer work in its audio callback in
   the adjacent repo. The SDK-side target is decimated telemetry copied out of
-  callback buffers and consumed by UI/message-thread code.
+  callback buffers and consumed by UI/message-thread code. **→ OCC sprint.**
+- FourTrack's engine still calls `readSamples` in its own callback in the
+  adjacent repo; it should adopt the SDK's prepared/streaming sources.
+  **→ FourTrack sprint.**
 - See `docs/APP_REALTIME_DEBT_REMEDIATION.md` for Clip Composer and FourTrack
   patch guidance.
 

--- a/docs/orp/ORP137 Hardening Program Completion and Downstream Follow-ups.md
+++ b/docs/orp/ORP137 Hardening Program Completion and Downstream Follow-ups.md
@@ -1,0 +1,59 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP137 — Hardening Program Completion & Downstream Follow-ups
+
+**Document type:** Completion record + follow-on sprint scaffold
+**Status:** ORP133 + ORP136 bootstrap + ORP134 EXECUTED (2026-07-09); follow-ups proposed
+**Parent:** [[ORP132]] · **Executed plans:** [[ORP133]], [[ORP134]], [[ORP136]] (§5 items 1–2 + §2.1–2.3 gates)
+**Deferred by design:** [[ORP135]] (directional bets — none implemented, per plan)
+
+---
+
+## 1. What landed (single branch, sequenced commits)
+
+| Sprint | Delivered | Defining proof |
+|--------|-----------|----------------|
+| **ORP133 NOW** | POD `TransportEvent` ring (G1); `stopAllInGroup` deprecated → `NotSupported`, dead `StopGroup` arm deleted (G2); single-producer command contract documented + debug-asserted, all producers funneled through `postCommand()` (G3); version truth = **0.3.0** from CMake (G4); docs truth pass (G5); `tools/docs_path_audit.py` + ctest/CI gate (G6) | No `std::function` on any audio path; event-ordering test; producer death test green under TSAN |
+| **ORP136 bootstrap** | Runtime realtime harness (`rt_guard.hpp` alloc hooks + `/proc/self/io`); golden transport render-hash gate; offline dither-seed determinism gate | Harness red/greens (detector self-test); render bit-identical across block sizes 256–2048 |
+| **ORP134 NEXT** | **G1 streaming migration** (`clip_source.{h,cpp}`: `PreparedClipSource` + `StreamingClipSource` + `MediaStreamWorker`); G2 identity/time (`identity.h`, `time_domain.h`, `media_model.h`); G3 graph seam (`audio_graph.h`); G4 render-job determinism; G5 `IAudioFileWriter` (FTR007); G6 analysis facade (`audio_analysis.h`); G7 recorder plumbing (`audio_input.h`); G8 `ISceneManager::setRoutingMatrix` wiring + launcher-scale tests | `realtime_audit.py --fail-known-debt` **passes** (strict in CI); render-hash parity **bit-exact** vs the old reading path; file-backed callback: ~2,400 read syscalls → ~0 |
+
+Full verification matrix: 132/132 ctest green (Debug + ASan/UBSan), transport/new suites green under ThreadSanitizer, clang-format-14 clean, docs-path gate green.
+
+## 2. Reconciliation on record (ORP132 §3 rule)
+
+[[ORP134]] names `--fail-known-debt --include-adjacent` as the finish line;
+`REALTIME_AUDIT.md` (authoritative for contract facts) scopes the strict
+cross-repo gate to "after the streaming-reader **and app telemetry**
+migrations land". The SDK-side migration landed here and the SDK contributes
+**zero** findings to the cross-repo run; the remaining `--include-adjacent`
+findings are the two app repos' own debt (below). The in-repo strict gate
+(`--fail-known-debt`) is CI-enforced now.
+
+## 3. Downstream follow-up sprints (OUT of this repo — file in the app repos)
+
+- **FourTrack (`~/dev/fourtrack`):** adopt SDK prepared/streaming sources in
+  `Engine::processAudio()` (clears its two `readSamples` audit findings);
+  delete local `WavWriter` for `IAudioFileWriter` (closes FTR007/FTR019);
+  adopt `IAudioInputStream`/`AudioInputRing` for capture. Bump submodule pin.
+- **Clip Composer (`~/dev/clip-composer`):** move in-callback analyzer work to
+  a telemetry ring (clears its audit finding); wire
+  `ISceneManager::setRoutingMatrix()` (now public) for tab/scene recall.
+  Bump submodule pin.
+- **FreqFinder (`~/dev/freqfinder`):** adopt `orpheus::analysis` (FFT/STFT,
+  spectral features, onsets) and the graph `Tap` vocabulary.
+- After both app realtime migrations land: run
+  `realtime_audit.py --fail-known-debt --include-adjacent` as the standing
+  cross-repo gate.
+
+## 4. ORP135 bets — status of gating dependencies (nothing implemented)
+
+- **B1 automation** — unblocked by G2 (`AutomationLaneId`, `TimePoint`); needs its own ORP doc.
+- **B2 take/comping** — unblocked by G2 (`Take`, `MediaRegion`) + G5 + G7.
+- **B3 spatial** — G3 seam exists; channel-layout governance still required.
+- **B4 plugin processor API** — blocked on B1; `NodeKind::Processor` is reserved in the seam.
+- **B5 MIDI/OSC + MPSC dispatcher** — G3 contract in place; dispatcher still future work.
+- **B6/B7 ABI facades + migration tooling** — contracts newly settled; let them soak first.
+- **B8/B9** — unchanged, dependency-gated.
+
+Per [[ORP135]] §5, each bet still requires a concrete downstream pull and its
+own ORP1NN doc before code starts. **Next free doc number: ORP138.**

--- a/docs/orp/README.md
+++ b/docs/orp/README.md
@@ -11,7 +11,7 @@ This directory contains authoritative implementation plans for the Orpheus SDK e
 
 ---
 
-## SDK Hardening & Platform Roadmap (ORP132–ORP136) — Proposed
+## SDK Hardening & Platform Roadmap (ORP132–ORP137) — ORP133/ORP134/ORP136 EXECUTED (2026-07-09)
 
 A five-document program (2026-07-09) turning the strategic architecture review into
 executable, verified sprints. **Start with ORP132.** All work is confirmed local to
@@ -26,6 +26,10 @@ executable, verified sprints. **Start with ORP132.** All work is confirmed local
   `IAudioFileWriter` (FTR007), analysis & recorder primitives.
 - **ORP135** — LATER: speculative 2026+ bets (automation, spatial, plugin API, MIDI/OSC,
   ABI facades, migration tooling). Directional.
+- **ORP137** — Completion record: what landed, the on-record reconciliation of
+  the cross-repo audit gate, downstream follow-up sprints (FourTrack /
+  Clip Composer / FreqFinder), and ORP135 bet-dependency status. Next free
+  doc number: ORP138.
 - **ORP136** — Verification & CI framework spanning all sprints (realtime gates,
   determinism hashes, TSAN, fuzzing, benchmark budgets, downstream conformance).
 

--- a/include/orpheus/audio_analysis.h
+++ b/include/orpheus/audio_analysis.h
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G6: unified offline analysis facade.
+//
+// One entry point for the analysis primitives downstream apps kept
+// re-implementing (FreqFinder is the primary consumer; Clip Composer and
+// FourTrack reuse the metering/waveform pieces):
+//
+//  * FFT / STFT           — new in the SDK (iterative radix-2, power-of-two)
+//  * RMS / peak           — buffer statistics
+//  * Integrated LUFS      — WRAPS the existing LoudnessMeter (BS.1770-style
+//                           K-weighting); the facade does not re-implement it
+//  * Spectral centroid / rolloff — derived from the magnitude spectrum
+//  * Onset detection      — spectral-flux peak picking over the STFT
+//  * Waveform proxy       — min/max peaks for an IN-MEMORY buffer. For
+//                           file-backed proxies keep using
+//                           IAudioFileReaderExtended::getWaveformData()
+//                           (waveform_processor.cpp) — NOT duplicated here.
+//
+// All functions are OFFLINE/background-thread utilities: they allocate and
+// are NOT realtime-safe. Determinism: within one platform+toolchain results
+// are bit-stable (fixed iteration order, no wall clock, no RNG); the window/
+// twiddle tables use libm (std::sin/std::cos), so cross-platform bit
+// identity follows the same policy as the transport fade math (ORP136 §2.3 —
+// pinning libm is future work; drift is a bug to file, not mask).
+
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace orpheus::analysis {
+
+/// Analysis window applied before the FFT.
+enum class WindowType : uint8_t {
+  Rectangular = 0,
+  Hann = 1,
+};
+
+/// Single-frame magnitude spectrum.
+struct Spectrum {
+  std::vector<float> magnitudes; ///< fftSize/2 + 1 bins (DC .. Nyquist)
+  float binHz = 0.0f;            ///< Frequency step between bins
+  uint32_t sampleRate = 0;       ///< Rate the source samples were in
+  size_t fftSize = 0;            ///< Transform length actually used (power of two)
+};
+
+/// Short-time Fourier transform result: one Spectrum-shaped magnitude row per
+/// hop, plus the geometry needed to map rows back to sample positions.
+struct StftResult {
+  std::vector<std::vector<float>> frames; ///< [numFrames][fftSize/2+1]
+  size_t frameSize = 0;                   ///< Analysis frame length (power of two)
+  size_t hopSize = 0;                     ///< Samples advanced per row
+  float binHz = 0.0f;
+  uint32_t sampleRate = 0;
+};
+
+/// Min/max waveform proxy for an in-memory buffer (one entry per pixel).
+struct WaveformPeaks {
+  std::vector<float> minPeaks;
+  std::vector<float> maxPeaks;
+};
+
+/// Smallest power of two >= value (>= 1).
+size_t nextPowerOfTwo(size_t value);
+
+/// In-place iterative radix-2 FFT. data.size() must be a power of two.
+void fftInPlace(std::vector<std::complex<float>>& data);
+
+/// Magnitude spectrum of a mono buffer. The input is windowed and zero-padded
+/// up to the next power of two (or `fftSize` if nonzero — must be pow2 and
+/// >= count).
+Spectrum magnitudeSpectrum(const float* samples, size_t count, uint32_t sampleRate,
+                           WindowType window = WindowType::Hann, size_t fftSize = 0);
+
+/// STFT over a mono buffer. frameSize must be a power of two; hopSize >= 1.
+StftResult stft(const float* samples, size_t count, uint32_t sampleRate, size_t frameSize = 1024,
+                size_t hopSize = 512, WindowType window = WindowType::Hann);
+
+/// Root-mean-square of a buffer (interleaved or mono — plain sample RMS).
+float rms(const float* samples, size_t count);
+
+/// Absolute peak of a buffer.
+float peak(const float* samples, size_t count);
+
+/// Integrated loudness (LUFS) of an interleaved buffer. Wraps the existing
+/// LoudnessMeter (K-weighted); channels beyond the first two are ignored,
+/// matching the meter's stereo model. Returns LoudnessMeter::kSilenceLufs
+/// for empty/silent input.
+float integratedLufs(const float* interleaved, size_t frames, uint16_t numChannels,
+                     double sampleRate);
+
+/// Amplitude-weighted mean frequency of a spectrum (Hz); 0 for silence.
+float spectralCentroidHz(const Spectrum& spectrum);
+
+/// Frequency below which `fraction` of the spectral energy lies (Hz).
+float spectralRolloffHz(const Spectrum& spectrum, float fraction = 0.85f);
+
+/// Spectral-flux onset detection over a mono buffer. Returns onset positions
+/// in SAMPLES (frame-quantized to hopSize). `sensitivity` scales the adaptive
+/// threshold: lower = more onsets (typical range 1.0 .. 3.0).
+std::vector<int64_t> detectOnsets(const float* samples, size_t count, uint32_t sampleRate,
+                                  size_t frameSize = 1024, size_t hopSize = 512,
+                                  float sensitivity = 1.5f);
+
+/// Min/max waveform proxy for an in-memory interleaved buffer (channel 0).
+/// For FILE-backed proxies use IAudioFileReaderExtended::getWaveformData().
+WaveformPeaks waveformPeaks(const float* interleaved, size_t frames, uint16_t numChannels,
+                            uint32_t pixelWidth);
+
+} // namespace orpheus::analysis

--- a/include/orpheus/audio_file_writer.h
+++ b/include/orpheus/audio_file_writer.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <orpheus/audio_file_reader.h> // AudioFileFormat, AudioFileMetadata
+#include <orpheus/errors.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace orpheus {
+
+/// Sample encoding for written audio files (ORP134 G5 / FTR007).
+enum class AudioSampleFormat : uint8_t {
+  Int16 = 0,  ///< 16-bit signed PCM
+  Int24 = 1,  ///< 24-bit signed PCM
+  Float32 = 2 ///< 32-bit IEEE float (not valid for FLAC)
+};
+
+/// Configuration for a file to be written.
+struct AudioFileWriterConfig {
+  AudioFileFormat format = AudioFileFormat::WAV;                ///< Container (WAV/AIFF/FLAC)
+  uint32_t sample_rate = 48000;                                 ///< Sample rate in Hz
+  uint16_t num_channels = 2;                                    ///< Channel count (interleaved)
+  AudioSampleFormat sample_format = AudioSampleFormat::Float32; ///< Sample encoding
+};
+
+/// Audio file writer interface (ORP134 G5 — requested by FourTrack as FTR007).
+///
+/// Mirrors IAudioFileReader's shape and error model: open/write/close with
+/// Result<> returns. Streams interleaved float32 frames to disk, encoding to
+/// the configured container/sample format.
+///
+/// Thread Safety (same contract as IAudioFileReader):
+/// - open(), close(): background/UI thread only (NOT the audio thread)
+/// - writeSamples(): background thread only — writing performs blocking file
+///   I/O and must NEVER be called from an audio callback. Real-time capture
+///   feeds a lock-free ring buffer that a background writer thread drains
+///   into this interface (see the ORP134 G7 recorder primitives).
+/// - getFramesWritten(), isOpen(): thread-safe queries
+///
+/// Format support (libsndfile-backed):
+/// - WAV:  Int16 / Int24 / Float32
+/// - AIFF: Int16 / Int24 / Float32
+/// - FLAC: Int16 / Int24 (Float32 is rejected — FLAC is integer-only)
+/// - Other formats (MP3/OGG) are not supported yet and are rejected at open.
+class IAudioFileWriter {
+public:
+  virtual ~IAudioFileWriter() = default;
+
+  /// Create/overwrite the target file and write its header.
+  ///
+  /// @param file_path Destination path (parent directory must exist)
+  /// @param config Container format, sample rate, channels, sample encoding
+  /// @return SessionGraphError::OK on success;
+  ///         InvalidParameter for a bad config (e.g. FLAC + Float32,
+  ///         zero channels/rate); NotSupported for unsupported containers;
+  ///         InternalError when the file cannot be created.
+  virtual SessionGraphError open(const std::string& file_path,
+                                 const AudioFileWriterConfig& config) = 0;
+
+  /// Append interleaved float32 frames.
+  ///
+  /// Samples are expected in [-1.0, 1.0]; integer encodings clip beyond that
+  /// (libsndfile clipping is enabled so out-of-range floats saturate instead
+  /// of wrapping).
+  ///
+  /// @param buffer Interleaved samples (num_frames * num_channels floats)
+  /// @param num_frames Number of sample frames to write
+  /// @return Result containing frames actually written, or an error
+  virtual Result<size_t> writeSamples(const float* buffer, size_t num_frames) = 0;
+
+  /// Finalize the file (flush + header fixup) and release resources.
+  ///
+  /// @return SessionGraphError::OK on success (also when already closed)
+  virtual SessionGraphError close() = 0;
+
+  /// Total frames written since open().
+  virtual int64_t getFramesWritten() const = 0;
+
+  /// True while a file is open for writing.
+  virtual bool isOpen() const = 0;
+
+  /// Metadata describing the file being written (format, rate, channels,
+  /// frames written so far). Valid while open and after close().
+  virtual AudioFileMetadata metadata() const = 0;
+};
+
+/// Create an audio file writer instance.
+///
+/// Uses libsndfile for encoding (WAV/AIFF/FLAC). Returns nullptr when the
+/// SDK was built without libsndfile — callers must check.
+std::unique_ptr<IAudioFileWriter> createAudioFileWriter();
+
+} // namespace orpheus

--- a/include/orpheus/audio_graph.h
+++ b/include/orpheus/audio_graph.h
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G3: graph-neutral routing seam.
+//
+// A descriptive vocabulary — sources, processors, buses, sinks, sends, taps,
+// channel layouts — layered BENEATH the existing routing matrix, which is
+// deliberately NOT replaced (ORP134 §7 "Do Not Touch Yet"; the full graph
+// engine is an ORP135 candidate). The deliverable is the SEAM:
+//
+//  * GraphDescription — a validated, serializable description of an audio
+//    topology, neutral to any app's mental model.
+//  * makeSoundboardGraph() — the soundboard FACADE: expresses the transport's
+//    current hard-wired topology (N stereo clip sources → group buses →
+//    master bus → stereo sink) as one instance of the neutral vocabulary.
+//  * toRoutingConfig() — maps a soundboard-shaped description onto the
+//    existing IRoutingMatrix configuration, proving the seam is real: the
+//    facade's translation must equal the config the transport builds today
+//    (asserted by tests/routing/audio_graph_test.cpp).
+//
+// Downstream payoff: FourTrack expresses track/input/monitor/export buses,
+// FreqFinder attaches analysis TAPS, and Clip Composer keeps its cue/master/
+// group facade — all in one vocabulary, without touching the matrix engine.
+//
+// Everything here is descriptive data (control-thread, allocating); nothing
+// executes on the audio thread.
+
+#include <orpheus/routing_matrix.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace orpheus::graph {
+
+/// Node identifier within one GraphDescription (0 = invalid).
+using NodeId = uint32_t;
+
+/// What a node does.
+enum class NodeKind : uint8_t {
+  Source = 0,    ///< Produces audio (clip voice, live input, generator)
+  Processor = 1, ///< Transforms audio in place (FX; ORP135 B4 territory)
+  Bus = 2,       ///< Sums inputs (group, master, cue, monitor)
+  Sink = 3,      ///< Consumes audio (device output, file writer, analyzer)
+};
+
+/// Channel layout carried by a node's output.
+enum class ChannelLayout : uint8_t {
+  Mono = 1,
+  Stereo = 2,
+  Quad = 4,
+  FiveOne = 6,
+  SevenOne = 8,
+};
+
+constexpr uint16_t channelCount(ChannelLayout layout) {
+  return static_cast<uint16_t>(layout);
+}
+
+/// How a connection carries audio.
+enum class ConnectionKind : uint8_t {
+  Direct = 0, ///< Primary signal path (source→bus, bus→bus, bus→sink)
+  Send = 1,   ///< Post-node auxiliary feed at send gain (cue/FX sends)
+  Tap = 2,    ///< Unity-gain observation point (metering/analysis; FreqFinder)
+};
+
+/// One node in the description.
+struct NodeDesc {
+  NodeId id = 0;
+  NodeKind kind = NodeKind::Bus;
+  ChannelLayout layout = ChannelLayout::Stereo;
+  std::string name;
+};
+
+/// One edge in the description.
+struct Connection {
+  NodeId from = 0;
+  NodeId to = 0;
+  ConnectionKind kind = ConnectionKind::Direct;
+  float gainDb = 0.0f; ///< Send gain (Direct/Tap connections leave this at 0)
+};
+
+/// A validated, serializable audio topology.
+struct GraphDescription {
+  std::vector<NodeDesc> nodes;
+  std::vector<Connection> connections;
+
+  /// Structural validation: unique nonzero node ids; every connection joins
+  /// existing nodes; sources have no inputs; sinks have no outputs; taps
+  /// originate only from buses or sources.
+  /// @return true when structurally sound (error, if any, in outError)
+  bool validate(std::string* outError = nullptr) const;
+
+  const NodeDesc* findNode(NodeId id) const;
+};
+
+/// The soundboard facade's shape parameters — mirrors the topology the
+/// transport hard-wires today (transport_controller.cpp routing setup).
+struct SoundboardTopology {
+  size_t numClipSources = 32; ///< Stereo clip voices (transport MAX_ACTIVE_CLIPS)
+  uint8_t numGroups = 4;      ///< Group buses (soundboard default)
+  uint8_t numOutputs = 2;     ///< Device sink channels (stereo master out)
+};
+
+/// Build the soundboard topology as a neutral graph: numClipSources stereo
+/// Sources → group Buses (all sources default to group 0, matching the
+/// transport) → master Bus → device Sink.
+GraphDescription makeSoundboardGraph(const SoundboardTopology& topology);
+
+/// Map a soundboard-shaped graph onto the existing routing matrix
+/// configuration. Channels = stereo pairs per Source (the matrix's
+/// SourceChannelPolicy::StereoPairs model); groups = non-master Buses;
+/// outputs = Sink channel count.
+RoutingConfig toRoutingConfig(const GraphDescription& graph);
+
+} // namespace orpheus::graph

--- a/include/orpheus/audio_input.h
+++ b/include/orpheus/audio_input.h
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G7: host-neutral recorder plumbing.
+//
+// FourTrack (and future recording hosts) currently hook the raw driver input
+// callback and hand-roll a ring buffer + async disk writer. The SDK now
+// provides the reusable, non-opinionated pieces:
+//
+//  * AudioInputRing — a lock-free SPSC ring of interleaved float frames.
+//    The AUDIO thread produces (write: memcpy + atomic index, never blocks,
+//    drops whole buffers on overflow and counts them); ONE background thread
+//    consumes (read) and feeds e.g. IAudioFileWriter (ORP134 G5) — making
+//    "capture → disk" an SDK-supported path.
+//  * IAudioInputStream — the capture contract hosts consume instead of the
+//    raw driver callback: the driver-facing side pushes captured frames on
+//    the audio thread; the host-facing side drains them on a background
+//    thread. createAudioInputStream() returns the SDK's ring-backed
+//    implementation.
+//
+// Deliberately NOT here (host policy, per ORP134 G7): take management,
+// punch in/out, latency compensation, arming semantics, file naming.
+
+#include <orpheus/errors.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace orpheus {
+
+/// Lock-free single-producer/single-consumer ring of interleaved audio
+/// frames.
+///
+/// Threading contract:
+/// - write(): exactly ONE producer thread (the audio/driver callback).
+///   Realtime-safe: memcpy + relaxed/acquire/release atomics; no locks, no
+///   allocation, never blocks. When the ring lacks space for the WHOLE
+///   buffer, the write is dropped atomically (no partial frames) and
+///   overflowCount() increments — matching the transport's event-ring
+///   drop-don't-block policy.
+/// - read(): exactly ONE consumer thread (a background writer/analysis
+///   thread). Returns however many frames are available, up to maxFrames.
+/// - framesAvailable()/overflowCount(): safe from any thread (diagnostics).
+class AudioInputRing {
+public:
+  /// @param numChannels Interleaved channel count (>= 1)
+  /// @param capacityFrames Ring capacity; rounded UP to a power of two
+  ///        (allocation happens here, never on the audio thread)
+  AudioInputRing(uint16_t numChannels, size_t capacityFrames);
+
+  uint16_t numChannels() const {
+    return m_numChannels;
+  }
+
+  /// Usable capacity in frames (power of two minus one slot semantics are
+  /// handled internally; this is the real writable capacity).
+  size_t capacityFrames() const {
+    return m_capacityFrames;
+  }
+
+  /// AUDIO THREAD (single producer): append `frames` interleaved frames.
+  /// @return frames written — either `frames` (all) or 0 (dropped: ring full)
+  size_t write(const float* interleaved, size_t frames);
+
+  /// BACKGROUND THREAD (single consumer): pop up to `maxFrames` frames.
+  /// @return frames actually copied into `dest`
+  size_t read(float* dest, size_t maxFrames);
+
+  /// Frames currently queued (approximate under concurrency; exact when one
+  /// side is idle).
+  size_t framesAvailable() const;
+
+  /// Number of write() calls dropped because the ring was full.
+  uint64_t overflowCount() const {
+    return m_overflows.load(std::memory_order_relaxed);
+  }
+
+private:
+  const uint16_t m_numChannels;
+  size_t m_capacityFrames; // power of two
+  std::vector<float> m_data;
+  std::atomic<size_t> m_writeIndex{0}; // in frames, monotonically wrapping
+  std::atomic<size_t> m_readIndex{0};
+  std::atomic<uint64_t> m_overflows{0};
+};
+
+/// Capture-stream configuration.
+struct AudioInputStreamConfig {
+  uint16_t num_channels = 2;    ///< Interleaved input channel count
+  uint32_t sample_rate = 48000; ///< Capture sample rate (informational)
+  /// Ring depth. Default 65536 frames ≈ 1.37 s @ 48 kHz — generous headroom
+  /// for a background writer that flushes every few hundred ms.
+  size_t ring_capacity_frames = 65536;
+};
+
+/// The capture contract between a driver input callback and a host's
+/// background consumer (ORP134 G7).
+///
+/// Threading:
+/// - capture(): AUDIO THREAD only (single producer). Realtime-safe;
+///   never blocks; drops + counts on overflow.
+/// - drain(): ONE background thread (single consumer).
+/// - Queries: any thread.
+class IAudioInputStream {
+public:
+  virtual ~IAudioInputStream() = default;
+
+  virtual uint16_t numChannels() const = 0;
+  virtual uint32_t sampleRate() const = 0;
+
+  /// AUDIO THREAD: push captured interleaved frames into the stream.
+  /// @return frames accepted (all or nothing; 0 == dropped, overflow counted)
+  virtual size_t capture(const float* interleaved, size_t frames) = 0;
+
+  /// BACKGROUND THREAD: pop up to maxFrames captured frames.
+  /// @return frames copied into dest
+  virtual size_t drain(float* dest, size_t maxFrames) = 0;
+
+  /// Frames waiting to be drained.
+  virtual size_t framesPending() const = 0;
+
+  /// Capture buffers dropped because the consumer fell behind.
+  virtual uint64_t overflowCount() const = 0;
+};
+
+/// Create the SDK's ring-backed input stream.
+std::unique_ptr<IAudioInputStream> createAudioInputStream(const AudioInputStreamConfig& config);
+
+} // namespace orpheus

--- a/include/orpheus/errors.h
+++ b/include/orpheus/errors.h
@@ -43,9 +43,9 @@ ORPHEUS_API void orpheus_set_telemetry_callback(orpheus_telemetry_callback callb
 #endif
 
 #ifdef __cplusplus
-#include <string_view>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace orpheus {
 

--- a/include/orpheus/identity.h
+++ b/include/orpheus/identity.h
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G2: stable identity primitives.
+//
+// The existing session graph identifies Clip/Track objects by POINTER
+// (session_graph.h) — fine in-memory, but useless for serialization, undo,
+// cross-process references, or takes/comping (ORP135 B2). These strong ID
+// types are ADDITIVE: they live alongside the pointer-based graph (which is
+// deliberately NOT rewritten — see ORP134 §7 "Do Not Touch Yet"); new code
+// and serialization should prefer IDs.
+//
+// Properties:
+//  * Opaque strong typedefs over uint64_t — SessionId and ClipId do not
+//    convert to each other or to integers implicitly.
+//  * 0 is the universal "invalid" value; valid IDs start at 1.
+//  * Trivially copyable, hashable, ordered, constexpr-friendly — usable as
+//    map keys and POD message payloads (safe on realtime paths).
+//  * Deterministic allocation: IdAllocator hands out monotonically increasing
+//    values from an explicit seed. No wall clock, no global RNG — the same
+//    session build replays to the same IDs (SDK determinism rule).
+
+#include <cstdint>
+#include <functional>
+
+namespace orpheus {
+
+/// Opaque, stable, serializable identifier. Tag makes each instantiation a
+/// distinct type: StrongId<ClipIdTag> never mixes with StrongId<TrackIdTag>.
+template <typename Tag> class StrongId {
+public:
+  /// Default-constructed IDs are invalid (raw value 0).
+  constexpr StrongId() = default;
+
+  /// Rehydrate an ID from its serialized raw value.
+  static constexpr StrongId fromRaw(uint64_t raw) {
+    return StrongId(raw);
+  }
+
+  /// The invalid sentinel (raw value 0).
+  static constexpr StrongId invalid() {
+    return StrongId(0);
+  }
+
+  /// Serialized representation (stable across processes and sessions).
+  constexpr uint64_t raw() const {
+    return m_value;
+  }
+
+  constexpr bool isValid() const {
+    return m_value != 0;
+  }
+
+  friend constexpr bool operator==(StrongId a, StrongId b) {
+    return a.m_value == b.m_value;
+  }
+  friend constexpr bool operator!=(StrongId a, StrongId b) {
+    return a.m_value != b.m_value;
+  }
+  friend constexpr bool operator<(StrongId a, StrongId b) {
+    return a.m_value < b.m_value;
+  }
+  friend constexpr bool operator>(StrongId a, StrongId b) {
+    return a.m_value > b.m_value;
+  }
+  friend constexpr bool operator<=(StrongId a, StrongId b) {
+    return a.m_value <= b.m_value;
+  }
+  friend constexpr bool operator>=(StrongId a, StrongId b) {
+    return a.m_value >= b.m_value;
+  }
+
+private:
+  constexpr explicit StrongId(uint64_t value) : m_value(value) {}
+  uint64_t m_value = 0;
+};
+
+// The identity vocabulary (ORP134 G2). AutomationLaneId is forward-provisioned
+// for sample-accurate automation (ORP135 B1).
+using SessionId = StrongId<struct SessionIdTag>;
+using TrackId = StrongId<struct TrackIdTag>;
+using ClipId = StrongId<struct ClipIdTag>;
+using MediaId = StrongId<struct MediaIdTag>;
+using AutomationLaneId = StrongId<struct AutomationLaneIdTag>;
+
+/// Deterministic, monotonic ID source. One allocator per ID space (typically
+/// per session document). Not thread-safe by design — allocate on the
+/// document/control thread; IDs are immutable values once handed out.
+template <typename Id> class IdAllocator {
+public:
+  /// @param nextRaw First raw value to hand out (>= 1). Serialize this
+  ///        watermark with the document so reloads keep allocating above
+  ///        every existing ID.
+  constexpr explicit IdAllocator(uint64_t nextRaw = 1) : m_next(nextRaw == 0 ? 1 : nextRaw) {}
+
+  Id allocate() {
+    return Id::fromRaw(m_next++);
+  }
+
+  /// Watermark to persist: the next raw value that would be handed out.
+  constexpr uint64_t nextRaw() const {
+    return m_next;
+  }
+
+  /// Bump the watermark above an ID observed during deserialization.
+  void reserveThrough(Id id) {
+    if (id.raw() >= m_next) {
+      m_next = id.raw() + 1;
+    }
+  }
+
+private:
+  uint64_t m_next;
+};
+
+} // namespace orpheus
+
+// Hash support so IDs work as unordered_map keys out of the box.
+template <typename Tag> struct std::hash<orpheus::StrongId<Tag>> {
+  size_t operator()(orpheus::StrongId<Tag> id) const noexcept {
+    return std::hash<uint64_t>{}(id.raw());
+  }
+};

--- a/include/orpheus/loudness_meter.h
+++ b/include/orpheus/loudness_meter.h
@@ -26,7 +26,8 @@ public:
 
   void setSampleRate(double sample_rate) {
     sampleRate_ = std::max(8000.0, sample_rate);
-    segmentTargetSamples_ = std::max<std::size_t>(1, static_cast<std::size_t>(std::llround(sampleRate_ * 0.1)));
+    segmentTargetSamples_ =
+        std::max<std::size_t>(1, static_cast<std::size_t>(std::llround(sampleRate_ * 0.1)));
     for (auto& filter : filters_) {
       filter.configure(sampleRate_);
     }
@@ -63,8 +64,8 @@ public:
       const float weightedLeft = filters_[0].process(leftSample);
       const float weightedRight = filters_[1].process(rightSample);
 
-      segmentEnergy_ += static_cast<double>(weightedLeft) * static_cast<double>(weightedLeft)
-                      + static_cast<double>(weightedRight) * static_cast<double>(weightedRight);
+      segmentEnergy_ += static_cast<double>(weightedLeft) * static_cast<double>(weightedLeft) +
+                        static_cast<double>(weightedRight) * static_cast<double>(weightedRight);
       ++segmentSamples_;
 
       if (segmentSamples_ >= segmentTargetSamples_) {
@@ -73,8 +74,12 @@ public:
     }
   }
 
-  [[nodiscard]] float shortTermLufs() const { return shortTermLufs_; }
-  [[nodiscard]] float integratedLufs() const { return integratedLufs_; }
+  [[nodiscard]] float shortTermLufs() const {
+    return shortTermLufs_;
+  }
+  [[nodiscard]] float integratedLufs() const {
+    return integratedLufs_;
+  }
 
 private:
   struct Biquad {
@@ -96,8 +101,8 @@ private:
       return static_cast<float>(output);
     }
 
-    std::array<double, 3> b { 1.0, 0.0, 0.0 };
-    std::array<double, 3> a { 1.0, 0.0, 0.0 };
+    std::array<double, 3> b{1.0, 0.0, 0.0};
+    std::array<double, 3> a{1.0, 0.0, 0.0};
     double z1 = 0.0;
     double z2 = 0.0;
   };
@@ -121,22 +126,16 @@ private:
       return highPass.process(highShelf.process(sample));
     }
 
-    static void normalize(std::array<double, 3>& b,
-                          std::array<double, 3>& a,
-                          double a0,
-                          double a1,
+    static void normalize(std::array<double, 3>& b, std::array<double, 3>& a, double a0, double a1,
                           double a2) {
       b[0] /= a0;
       b[1] /= a0;
       b[2] /= a0;
-      a = { 1.0, a1 / a0, a2 / a0 };
+      a = {1.0, a1 / a0, a2 / a0};
     }
 
-    static void configureShelfCoefficients(std::array<double, 3>& b,
-                                           std::array<double, 3>& a,
-                                           double sample_rate,
-                                           double frequency_hz,
-                                           double gain_db,
+    static void configureShelfCoefficients(std::array<double, 3>& b, std::array<double, 3>& a,
+                                           double sample_rate, double frequency_hz, double gain_db,
                                            double slope) {
       constexpr double pi = 3.14159265358979323846;
 
@@ -144,28 +143,21 @@ private:
       const double omega = 2.0 * pi * frequency_hz / sample_rate;
       const double sine = std::sin(omega);
       const double cosine = std::cos(omega);
-      const double alpha = sine / 2.0
-          * std::sqrt((A + 1.0 / A) * (1.0 / slope - 1.0) + 2.0);
+      const double alpha = sine / 2.0 * std::sqrt((A + 1.0 / A) * (1.0 / slope - 1.0) + 2.0);
       const double beta = 2.0 * std::sqrt(A) * alpha;
 
       b = {
-        A * ((A + 1.0) + (A - 1.0) * cosine + beta),
-        -2.0 * A * ((A - 1.0) + (A + 1.0) * cosine),
-        A * ((A + 1.0) + (A - 1.0) * cosine - beta),
+          A * ((A + 1.0) + (A - 1.0) * cosine + beta),
+          -2.0 * A * ((A - 1.0) + (A + 1.0) * cosine),
+          A * ((A + 1.0) + (A - 1.0) * cosine - beta),
       };
 
-      normalize(b,
-                a,
-                (A + 1.0) - (A - 1.0) * cosine + beta,
-                2.0 * ((A - 1.0) - (A + 1.0) * cosine),
+      normalize(b, a, (A + 1.0) - (A - 1.0) * cosine + beta, 2.0 * ((A - 1.0) - (A + 1.0) * cosine),
                 (A + 1.0) - (A - 1.0) * cosine - beta);
     }
 
-    static void configureHighPassCoefficients(std::array<double, 3>& b,
-                                              std::array<double, 3>& a,
-                                              double sample_rate,
-                                              double frequency_hz,
-                                              double q) {
+    static void configureHighPassCoefficients(std::array<double, 3>& b, std::array<double, 3>& a,
+                                              double sample_rate, double frequency_hz, double q) {
       constexpr double pi = 3.14159265358979323846;
 
       const double omega = 2.0 * pi * frequency_hz / sample_rate;
@@ -174,31 +166,28 @@ private:
       const double alpha = sine / (2.0 * q);
 
       b = {
-        (1.0 + cosine) / 2.0,
-        -(1.0 + cosine),
-        (1.0 + cosine) / 2.0,
+          (1.0 + cosine) / 2.0,
+          -(1.0 + cosine),
+          (1.0 + cosine) / 2.0,
       };
 
       normalize(b, a, 1.0 + alpha, -2.0 * cosine, 1.0 - alpha);
     }
 
-    static std::array<std::array<double, 3>, 2> designHighShelf(double sample_rate,
-                                                                 double frequency_hz,
-                                                                 double gain_db,
-                                                                 double slope) {
-      std::array<double, 3> b {};
-      std::array<double, 3> a {};
+    static std::array<std::array<double, 3>, 2>
+    designHighShelf(double sample_rate, double frequency_hz, double gain_db, double slope) {
+      std::array<double, 3> b{};
+      std::array<double, 3> a{};
       configureShelfCoefficients(b, a, sample_rate, frequency_hz, gain_db, slope);
-      return { b, a };
+      return {b, a};
     }
 
     static std::array<std::array<double, 3>, 2> designHighPass(double sample_rate,
-                                                                double frequency_hz,
-                                                                double q) {
-      std::array<double, 3> b {};
-      std::array<double, 3> a {};
+                                                               double frequency_hz, double q) {
+      std::array<double, 3> b{};
+      std::array<double, 3> a{};
       configureHighPassCoefficients(b, a, sample_rate, frequency_hz, q);
-      return { b, a };
+      return {b, a};
     }
 
     static constexpr double kHighShelfFrequencyHz = 1681.974450955533;
@@ -244,7 +233,8 @@ private:
       energy += value;
     }
 
-    shortTermLufs_ = lufsFromMeanSquare(energy / static_cast<double>(recentShortTermSegments_.size()));
+    shortTermLufs_ =
+        lufsFromMeanSquare(energy / static_cast<double>(recentShortTermSegments_.size()));
   }
 
   void updateIntegrated() {
@@ -292,9 +282,10 @@ private:
       }
     }
 
-    integratedLufs_ = integratedCount > 0
-        ? lufsFromMeanSquare(integratedEnergy / static_cast<double>(integratedCount))
-        : kSilenceLufs;
+    integratedLufs_ =
+        integratedCount > 0
+            ? lufsFromMeanSquare(integratedEnergy / static_cast<double>(integratedCount))
+            : kSilenceLufs;
   }
 
   [[nodiscard]] static float lufsFromMeanSquare(double mean_square) {
@@ -311,7 +302,7 @@ private:
 
   double sampleRate_ = 48000.0;
   std::size_t segmentTargetSamples_ = 4800;
-  std::array<ChannelFilter, 2> filters_ {};
+  std::array<ChannelFilter, 2> filters_{};
   double segmentEnergy_ = 0.0;
   std::size_t segmentSamples_ = 0;
   std::deque<double> recentSegments_;

--- a/include/orpheus/media_model.h
+++ b/include/orpheus/media_model.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G2: media/region vocabulary and app-shaped aggregates.
+//
+// Thin value structs over the identity (identity.h) and time (time_domain.h)
+// primitives. They give the downstream apps a shared, serializable shape for
+// "a piece of media placed in time" without prescribing an engine model:
+//
+//  * MediaRegion — a window into a media file (FreqFinder analysis regions,
+//    FourTrack punch ranges, Clip Composer trims).
+//  * Take — one recorded pass targeting a track (FourTrack; ORP135 B2
+//    take/comping builds on this).
+//  * ClipSlot / LauncherScene — launcher-grid vocabulary (Clip Composer's
+//    tabs/buttons; scene_manager.h remains the session-level snapshot API).
+//
+// Everything here is additive; the pointer-based SessionGraph is untouched
+// (ORP134 §7 "Do Not Touch Yet").
+
+#include <orpheus/identity.h>
+#include <orpheus/time_domain.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace orpheus {
+
+/// A region within a media item, in the MEDIA file's own sample timeline.
+struct MediaRegion {
+  MediaId media;         ///< Which media item (invalid() = unresolved)
+  TimeRange sourceRange; ///< Window into that media, media-rate samples
+
+  friend bool operator==(const MediaRegion& a, const MediaRegion& b) {
+    return a.media == b.media && a.sourceRange == b.sourceRange;
+  }
+  friend bool operator!=(const MediaRegion& a, const MediaRegion& b) {
+    return !(a == b);
+  }
+};
+
+/// One recorded pass. Policy (comping, crossfades, latency compensation)
+/// stays host-side; this is just the stable, serializable record of what was
+/// captured where.
+struct Take {
+  ClipId id;          ///< Stable identity of this take
+  TrackId track;      ///< Track the take targets
+  MediaRegion region; ///< Captured media + usable window
+  TimePoint placedAt; ///< Timeline position (session-rate samples)
+  uint32_t index = 0; ///< Take number within its lane (1-based; 0 = unset)
+  std::string name;   ///< Host-facing label
+};
+
+/// One cell in a launcher grid (page/tab, row, column) holding a clip.
+struct ClipSlot {
+  ClipId clip;         ///< Occupant (invalid() = empty slot)
+  uint16_t page = 0;   ///< Tab/page index
+  uint16_t row = 0;    ///< Grid row
+  uint16_t column = 0; ///< Grid column
+};
+
+/// A named arrangement of launcher slots (a "scene" in launcher terms).
+/// Complements ISceneManager: SceneSnapshot captures live session state,
+/// LauncherScene is the serializable document-model shape.
+struct LauncherScene {
+  std::string name;
+  std::vector<ClipSlot> slots;
+};
+
+} // namespace orpheus

--- a/include/orpheus/scene_manager.h
+++ b/include/orpheus/scene_manager.h
@@ -33,7 +33,12 @@ struct SceneSnapshot {
   std::string name;    ///< User-friendly name (e.g., "Act 1", "Intro Music")
   uint64_t timestamp;  ///< Creation time (Unix epoch in seconds)
 
-  // Clip assignments (which clips loaded on which buttons)
+  // Clip assignments (which clips loaded on which buttons).
+  // ORP134 G8 design note: captureScene() does NOT populate this — button/
+  // grid layout is host presentation state the SDK cannot derive (the
+  // transport's ClipHandles carry no grid geometry). Hosts persist their grid
+  // with the document-model shapes in <orpheus/media_model.h> (ClipSlot /
+  // LauncherScene) or fill this vector themselves before exportScene().
   std::vector<ClipHandle> assignedClips; ///< Clip handles per button/position
 
   // Routing configuration (from Feature 1: Routing Matrix)
@@ -84,6 +89,26 @@ struct SceneSnapshot {
 class ISceneManager {
 public:
   virtual ~ISceneManager() = default;
+
+  // ========================================================================
+  // Wiring (UI Thread)
+  // ========================================================================
+
+  /// Attach the routing matrix whose state captureScene()/recallScene()
+  /// snapshot and restore (ORP134 G8).
+  ///
+  /// Without this call scenes still capture/restore names and metadata, but
+  /// clip-group assignments and group gains are skipped — the routing state
+  /// was previously impossible to wire through the public interface at all.
+  ///
+  /// @param routingMatrix Matrix to snapshot/restore (nullptr to detach).
+  ///        Not owned; must outlive the scene manager or be detached first.
+  ///
+  /// @note Default implementation is a no-op so existing ISceneManager
+  ///       implementations keep compiling (additive, ORP134).
+  virtual void setRoutingMatrix(IRoutingMatrix* routingMatrix) {
+    (void)routingMatrix;
+  }
 
   // ========================================================================
   // Scene Capture & Recall (UI Thread)

--- a/include/orpheus/time_domain.h
+++ b/include/orpheus/time_domain.h
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G2: time-domain primitives.
+//
+// The sample count is CANONICAL (the SDK rule: "64-bit sample counts, never
+// float seconds"). Seconds, beats, and timecode are derived views computed on
+// demand from an explicit sample rate / tempo — they are never stored, so a
+// TimePoint cannot drift or double-round. The existing session graph's
+// beats-only fields (start_beats/length_beats) stay untouched; these types
+// are the additive sample-domain vocabulary new code should build on.
+//
+// All types are trivially copyable PODs, safe to embed in realtime messages.
+
+#include <cstdint>
+
+namespace orpheus {
+
+/// Integer timecode (non-drop-frame). Derived view only.
+struct Timecode {
+  int32_t hours = 0;
+  int32_t minutes = 0;
+  int32_t seconds = 0;
+  int32_t frames = 0; ///< At the fps supplied to TimePoint::toTimecode()
+
+  friend constexpr bool operator==(const Timecode& a, const Timecode& b) {
+    return a.hours == b.hours && a.minutes == b.minutes && a.seconds == b.seconds &&
+           a.frames == b.frames;
+  }
+  friend constexpr bool operator!=(const Timecode& a, const Timecode& b) {
+    return !(a == b);
+  }
+};
+
+/// A point on a sample timeline. Canonical representation: int64 samples.
+class TimePoint {
+public:
+  constexpr TimePoint() = default;
+
+  // ---- construction ------------------------------------------------------
+
+  static constexpr TimePoint fromSamples(int64_t samples) {
+    return TimePoint(samples);
+  }
+
+  /// Derived-domain constructor; rounds to the nearest sample.
+  static constexpr TimePoint fromSeconds(double seconds, uint32_t sampleRate) {
+    return TimePoint(roundToSamples(seconds * static_cast<double>(sampleRate)));
+  }
+
+  /// Derived-domain constructor; rounds to the nearest sample.
+  /// @param tempoBpm Beats per minute (> 0)
+  static constexpr TimePoint fromBeats(double beats, double tempoBpm, uint32_t sampleRate) {
+    const double seconds = tempoBpm > 0.0 ? (beats * 60.0 / tempoBpm) : 0.0;
+    return fromSeconds(seconds, sampleRate);
+  }
+
+  // ---- canonical value ---------------------------------------------------
+
+  constexpr int64_t samples() const {
+    return m_samples;
+  }
+
+  // ---- derived views -----------------------------------------------------
+
+  constexpr double toSeconds(uint32_t sampleRate) const {
+    return sampleRate == 0 ? 0.0 : static_cast<double>(m_samples) / static_cast<double>(sampleRate);
+  }
+
+  constexpr double toBeats(double tempoBpm, uint32_t sampleRate) const {
+    return toSeconds(sampleRate) * tempoBpm / 60.0;
+  }
+
+  /// Non-drop-frame timecode at an integer frame rate (24/25/30...).
+  /// Integer math throughout; truncates within the final frame.
+  constexpr Timecode toTimecode(uint32_t sampleRate, uint32_t framesPerSecond) const {
+    Timecode tc;
+    if (sampleRate == 0 || framesPerSecond == 0) {
+      return tc;
+    }
+    const int64_t clamped = m_samples < 0 ? 0 : m_samples;
+    const int64_t totalSeconds = clamped / static_cast<int64_t>(sampleRate);
+    const int64_t remainderSamples = clamped % static_cast<int64_t>(sampleRate);
+    tc.hours = static_cast<int32_t>(totalSeconds / 3600);
+    tc.minutes = static_cast<int32_t>((totalSeconds / 60) % 60);
+    tc.seconds = static_cast<int32_t>(totalSeconds % 60);
+    tc.frames = static_cast<int32_t>((remainderSamples * static_cast<int64_t>(framesPerSecond)) /
+                                     static_cast<int64_t>(sampleRate));
+    return tc;
+  }
+
+  // ---- arithmetic / ordering --------------------------------------------
+
+  friend constexpr TimePoint operator+(TimePoint p, int64_t deltaSamples) {
+    return TimePoint(p.m_samples + deltaSamples);
+  }
+  friend constexpr TimePoint operator-(TimePoint p, int64_t deltaSamples) {
+    return TimePoint(p.m_samples - deltaSamples);
+  }
+  /// Distance in samples.
+  friend constexpr int64_t operator-(TimePoint a, TimePoint b) {
+    return a.m_samples - b.m_samples;
+  }
+
+  friend constexpr bool operator==(TimePoint a, TimePoint b) {
+    return a.m_samples == b.m_samples;
+  }
+  friend constexpr bool operator!=(TimePoint a, TimePoint b) {
+    return a.m_samples != b.m_samples;
+  }
+  friend constexpr bool operator<(TimePoint a, TimePoint b) {
+    return a.m_samples < b.m_samples;
+  }
+  friend constexpr bool operator>(TimePoint a, TimePoint b) {
+    return a.m_samples > b.m_samples;
+  }
+  friend constexpr bool operator<=(TimePoint a, TimePoint b) {
+    return a.m_samples <= b.m_samples;
+  }
+  friend constexpr bool operator>=(TimePoint a, TimePoint b) {
+    return a.m_samples >= b.m_samples;
+  }
+
+private:
+  constexpr explicit TimePoint(int64_t samples) : m_samples(samples) {}
+
+  static constexpr int64_t roundToSamples(double value) {
+    // constexpr-friendly round-half-away-from-zero (std::llround isn't
+    // constexpr in C++20).
+    return value >= 0.0 ? static_cast<int64_t>(value + 0.5) : -static_cast<int64_t>(-value + 0.5);
+  }
+
+  int64_t m_samples = 0;
+};
+
+/// Half-open sample range [start, end). Length is canonical alongside start;
+/// end() is derived. Empty ranges (length 0) are valid.
+class TimeRange {
+public:
+  constexpr TimeRange() = default;
+
+  static constexpr TimeRange fromStartLength(TimePoint start, int64_t lengthSamples) {
+    return TimeRange(start, lengthSamples < 0 ? 0 : lengthSamples);
+  }
+
+  static constexpr TimeRange fromStartEnd(TimePoint start, TimePoint end) {
+    return fromStartLength(start, end - start);
+  }
+
+  constexpr TimePoint start() const {
+    return m_start;
+  }
+  constexpr TimePoint end() const {
+    return m_start + m_length;
+  }
+  constexpr int64_t length() const {
+    return m_length;
+  }
+  constexpr bool empty() const {
+    return m_length == 0;
+  }
+
+  /// Half-open containment: start() <= p < end().
+  constexpr bool contains(TimePoint p) const {
+    return p >= m_start && p < end();
+  }
+
+  constexpr bool overlaps(const TimeRange& other) const {
+    return m_start < other.end() && other.m_start < end();
+  }
+
+  /// Intersection (empty range at the later start when disjoint).
+  constexpr TimeRange intersect(const TimeRange& other) const {
+    const TimePoint s = m_start > other.m_start ? m_start : other.m_start;
+    const TimePoint e = end() < other.end() ? end() : other.end();
+    return e > s ? fromStartEnd(s, e) : fromStartLength(s, 0);
+  }
+
+  friend constexpr bool operator==(const TimeRange& a, const TimeRange& b) {
+    return a.m_start == b.m_start && a.m_length == b.m_length;
+  }
+  friend constexpr bool operator!=(const TimeRange& a, const TimeRange& b) {
+    return !(a == b);
+  }
+
+private:
+  constexpr TimeRange(TimePoint start, int64_t length) : m_start(start), m_length(length) {}
+
+  TimePoint m_start;
+  int64_t m_length = 0;
+};
+
+} // namespace orpheus

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -4,10 +4,10 @@
 #include <orpheus/errors.h>
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace orpheus {
 
@@ -151,15 +151,32 @@ public:
 /// This interface provides real-time control over clip playback with
 /// sample-accurate timing and thread-safe operation.
 ///
-/// Thread Safety:
-/// - startClip(), stopClip(), stopAllClips(), stopAllInGroup(): Thread-safe, callable from UI
-/// thread
-/// - getClipState(), isClipPlaying(), getCurrentPosition(): Thread-safe, callable from any thread
-/// - setCallback(): UI thread only
+/// Threading contract (ORP133 G3 — this is the real, enforced contract):
+///
+/// - **Control-mutating methods are single-producer.** startClip(), stopClip(),
+///   stopAllClips(), stopOtherClips(), restartClip(), seekClip(), and every
+///   updateClip*/setClip* method post commands onto a lock-free
+///   single-producer/single-consumer (SPSC) queue drained by the audio thread.
+///   Exactly ONE control thread may call them — typically the host's UI/message
+///   thread. They are NOT safe to call concurrently from multiple threads: the
+///   SPSC producer side is unsynchronized by design. Hosts with multiple
+///   control sources (UI + MIDI + OSC + network remote) must funnel them
+///   through a single dispatcher thread before they reach this interface.
+///   (A first-class SDK multi-producer dispatcher is future work — ORP135.)
+///   Debug builds assert if commands are posted from more than one thread.
+/// - **Queries are lock-free readers of a published snapshot.** getClipState(),
+///   isClipPlaying(), getCurrentPosition(), getClipPosition(),
+///   getActiveVoiceCount(), isClipLooping(), and the getClip* metadata queries
+///   are safe from any thread, including concurrently with the control thread.
+/// - **setCallback(): control thread only**, and not concurrently with
+///   callback dispatch. Callbacks are invoked on the host's UI thread (from
+///   processCallbacks()), never the audio thread.
 ///
 /// Audio Thread Guarantees:
 /// - No allocations in audio callback
 /// - Lock-free command processing
+/// - POD event queue for audio→UI notifications (no std::function on the
+///   audio thread — ORP133 G1)
 /// - Sample-accurate timing (±1 sample tolerance)
 class ITransportController {
 public:
@@ -198,11 +215,17 @@ public:
 
   /// Stop all clips in a specific routing group
   ///
-  /// This is useful for "FIFO choke" behavior where only one clip
-  /// in a group can play at a time.
+  /// @deprecated ORP133 G2: NOT SUPPORTED — always returns
+  /// SessionGraphError::NotSupported. This method was a silent no-op in every
+  /// SDK release (the transport has no clip→group mapping; grouping is a host
+  /// concern), and it now reports that truthfully instead. Hosts that need
+  /// scoped group-stop should implement it with their own group model on top
+  /// of stopOtherClips() (host-neutral choke, ORP127 G7) and/or stopClip().
+  /// The method is retained only for source compatibility and may be removed
+  /// in a future major version.
   ///
-  /// @param groupIndex Routing group index (0-3)
-  /// @return SessionGraphError::OK on success, or error code on failure
+  /// @param groupIndex Ignored
+  /// @return SessionGraphError::NotSupported, always
   virtual SessionGraphError stopAllInGroup(uint8_t groupIndex) = 0;
 
   /// Stop every playing clip EXCEPT the given one (ORP127 G7 choke primitive)

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -36,14 +36,16 @@ list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES scrub_resampler.cpp)
 
 if(SNDFILE_FOUND)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader_libsndfile.cpp)
+    list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_writer_libsndfile.cpp) # ORP134 G5 / FTR007
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES resampling_audio_file_reader.cpp)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES waveform_processor.cpp)
-    message(STATUS "✓ libsndfile FOUND - audio file reading enabled (with waveform processing)")
+    message(STATUS "✓ libsndfile FOUND - audio file reading/writing enabled (with waveform processing)")
 else()
-    # Provide stub implementation when libsndfile is not available
-    # This ensures createAudioFileReader() symbol exists for linking
+    # Provide stub implementations when libsndfile is not available
+    # This ensures the factory symbols exist for linking
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES create_audio_file_reader_stub.cpp)
-    message(STATUS "✗ libsndfile NOT FOUND - using stub implementation (audio file reading disabled)")
+    list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES create_audio_file_writer_stub.cpp)
+    message(STATUS "✗ libsndfile NOT FOUND - using stub implementation (audio file I/O disabled)")
 endif()
 
 add_library(orpheus_audio_utils STATIC

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -34,6 +34,14 @@ list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader.cpp)
 # dependency-free — always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES scrub_resampler.cpp)
 
+# ORP134 G7: lock-free input ring + capture-stream contract. Host-neutral,
+# dependency-free — always built.
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_input.cpp)
+
+# ORP134 G6: offline analysis facade (FFT/STFT + wrappers over LoudnessMeter
+# and buffer statistics). Host-neutral, dependency-free — always built.
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_analysis.cpp)
+
 if(SNDFILE_FOUND)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader_libsndfile.cpp)
     list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_writer_libsndfile.cpp) # ORP134 G5 / FTR007

--- a/src/core/audio_io/audio_analysis.cpp
+++ b/src/core/audio_io/audio_analysis.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/audio_analysis.h>
+#include <orpheus/loudness_meter.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace orpheus::analysis {
+
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+void applyWindow(std::vector<std::complex<float>>& data, size_t count, WindowType window) {
+  if (window != WindowType::Hann || count < 2) {
+    return;
+  }
+  for (size_t i = 0; i < count; ++i) {
+    const float w =
+        0.5f *
+        (1.0f - std::cos(2.0f * kPi * static_cast<float>(i) / static_cast<float>(count - 1)));
+    data[i] *= w;
+  }
+}
+
+std::vector<float> magnitudesFromComplex(const std::vector<std::complex<float>>& data) {
+  const size_t bins = data.size() / 2 + 1;
+  std::vector<float> magnitudes(bins, 0.0f);
+  for (size_t i = 0; i < bins; ++i) {
+    magnitudes[i] = std::abs(data[i]);
+  }
+  return magnitudes;
+}
+
+} // namespace
+
+size_t nextPowerOfTwo(size_t value) {
+  size_t result = 1;
+  while (result < value) {
+    result <<= 1;
+  }
+  return result;
+}
+
+void fftInPlace(std::vector<std::complex<float>>& data) {
+  const size_t n = data.size();
+  if (n < 2 || (n & (n - 1)) != 0) {
+    return; // power-of-two only; callers guarantee this
+  }
+
+  // Bit-reversal permutation.
+  for (size_t i = 1, j = 0; i < n; ++i) {
+    size_t bit = n >> 1;
+    for (; j & bit; bit >>= 1) {
+      j ^= bit;
+    }
+    j ^= bit;
+    if (i < j) {
+      std::swap(data[i], data[j]);
+    }
+  }
+
+  // Iterative Danielson-Lanczos butterflies.
+  for (size_t len = 2; len <= n; len <<= 1) {
+    const float angle = -2.0f * kPi / static_cast<float>(len);
+    const std::complex<float> wlen(std::cos(angle), std::sin(angle));
+    for (size_t i = 0; i < n; i += len) {
+      std::complex<float> w(1.0f, 0.0f);
+      for (size_t k = 0; k < len / 2; ++k) {
+        const std::complex<float> u = data[i + k];
+        const std::complex<float> v = data[i + k + len / 2] * w;
+        data[i + k] = u + v;
+        data[i + k + len / 2] = u - v;
+        w *= wlen;
+      }
+    }
+  }
+}
+
+Spectrum magnitudeSpectrum(const float* samples, size_t count, uint32_t sampleRate,
+                           WindowType window, size_t fftSize) {
+  Spectrum result;
+  result.sampleRate = sampleRate;
+  if (samples == nullptr || count == 0 || sampleRate == 0) {
+    return result;
+  }
+
+  size_t n = fftSize != 0 ? fftSize : nextPowerOfTwo(count);
+  n = std::max<size_t>(n, 2);
+  if ((n & (n - 1)) != 0 || n < count) {
+    n = nextPowerOfTwo(std::max(n, count));
+  }
+
+  std::vector<std::complex<float>> data(n, std::complex<float>(0.0f, 0.0f));
+  for (size_t i = 0; i < count; ++i) {
+    data[i] = std::complex<float>(samples[i], 0.0f);
+  }
+  applyWindow(data, count, window);
+  fftInPlace(data);
+
+  result.magnitudes = magnitudesFromComplex(data);
+  result.fftSize = n;
+  result.binHz = static_cast<float>(sampleRate) / static_cast<float>(n);
+  return result;
+}
+
+StftResult stft(const float* samples, size_t count, uint32_t sampleRate, size_t frameSize,
+                size_t hopSize, WindowType window) {
+  StftResult result;
+  result.sampleRate = sampleRate;
+  if (samples == nullptr || count == 0 || sampleRate == 0 || frameSize < 2 || hopSize == 0) {
+    return result;
+  }
+  if ((frameSize & (frameSize - 1)) != 0) {
+    frameSize = nextPowerOfTwo(frameSize);
+  }
+  result.frameSize = frameSize;
+  result.hopSize = hopSize;
+  result.binHz = static_cast<float>(sampleRate) / static_cast<float>(frameSize);
+
+  std::vector<std::complex<float>> data(frameSize);
+  for (size_t start = 0; start + 1 <= count; start += hopSize) {
+    const size_t remaining = count - start;
+    const size_t take = std::min(frameSize, remaining);
+    for (size_t i = 0; i < take; ++i) {
+      data[i] = std::complex<float>(samples[start + i], 0.0f);
+    }
+    for (size_t i = take; i < frameSize; ++i) {
+      data[i] = std::complex<float>(0.0f, 0.0f);
+    }
+    applyWindow(data, frameSize, window);
+    fftInPlace(data);
+    result.frames.push_back(magnitudesFromComplex(data));
+    if (remaining <= frameSize) {
+      break; // last (possibly zero-padded) frame emitted
+    }
+  }
+  return result;
+}
+
+float rms(const float* samples, size_t count) {
+  if (samples == nullptr || count == 0) {
+    return 0.0f;
+  }
+  double sum = 0.0;
+  for (size_t i = 0; i < count; ++i) {
+    sum += static_cast<double>(samples[i]) * static_cast<double>(samples[i]);
+  }
+  return static_cast<float>(std::sqrt(sum / static_cast<double>(count)));
+}
+
+float peak(const float* samples, size_t count) {
+  float maxAbs = 0.0f;
+  for (size_t i = 0; i < count; ++i) {
+    maxAbs = std::max(maxAbs, std::abs(samples[i]));
+  }
+  return maxAbs;
+}
+
+float integratedLufs(const float* interleaved, size_t frames, uint16_t numChannels,
+                     double sampleRate) {
+  if (interleaved == nullptr || frames == 0 || numChannels == 0) {
+    return LoudnessMeter::kSilenceLufs;
+  }
+
+  // De-interleave into the meter's mono/stereo model (extra channels ignored,
+  // matching LoudnessMeter's two-filter design).
+  std::vector<float> left(frames, 0.0f);
+  std::vector<float> right(frames, 0.0f);
+  const bool stereo = numChannels >= 2;
+  for (size_t i = 0; i < frames; ++i) {
+    left[i] = interleaved[i * numChannels];
+    right[i] = stereo ? interleaved[i * numChannels + 1] : 0.0f;
+  }
+
+  LoudnessMeter meter(sampleRate);
+  meter.processBuffer(left.data(), stereo ? right.data() : nullptr, frames);
+  return meter.integratedLufs();
+}
+
+float spectralCentroidHz(const Spectrum& spectrum) {
+  double weighted = 0.0;
+  double total = 0.0;
+  for (size_t i = 0; i < spectrum.magnitudes.size(); ++i) {
+    const double magnitude = spectrum.magnitudes[i];
+    weighted += magnitude * static_cast<double>(i) * spectrum.binHz;
+    total += magnitude;
+  }
+  return total > 0.0 ? static_cast<float>(weighted / total) : 0.0f;
+}
+
+float spectralRolloffHz(const Spectrum& spectrum, float fraction) {
+  fraction = std::clamp(fraction, 0.0f, 1.0f);
+  double total = 0.0;
+  for (float magnitude : spectrum.magnitudes) {
+    total += static_cast<double>(magnitude) * magnitude;
+  }
+  if (total <= 0.0) {
+    return 0.0f;
+  }
+  const double target = total * fraction;
+  double running = 0.0;
+  for (size_t i = 0; i < spectrum.magnitudes.size(); ++i) {
+    running += static_cast<double>(spectrum.magnitudes[i]) * spectrum.magnitudes[i];
+    if (running >= target) {
+      return static_cast<float>(i) * spectrum.binHz;
+    }
+  }
+  return static_cast<float>(spectrum.magnitudes.size() - 1) * spectrum.binHz;
+}
+
+std::vector<int64_t> detectOnsets(const float* samples, size_t count, uint32_t sampleRate,
+                                  size_t frameSize, size_t hopSize, float sensitivity) {
+  std::vector<int64_t> onsets;
+  const StftResult analysis = stft(samples, count, sampleRate, frameSize, hopSize);
+  if (analysis.frames.size() < 3) {
+    return onsets;
+  }
+
+  // Spectral flux: positive magnitude increases per frame.
+  std::vector<double> flux(analysis.frames.size(), 0.0);
+  for (size_t frame = 1; frame < analysis.frames.size(); ++frame) {
+    double sum = 0.0;
+    const auto& current = analysis.frames[frame];
+    const auto& previous = analysis.frames[frame - 1];
+    for (size_t bin = 0; bin < current.size(); ++bin) {
+      const double diff = static_cast<double>(current[bin]) - previous[bin];
+      if (diff > 0.0) {
+        sum += diff;
+      }
+    }
+    flux[frame] = sum;
+  }
+
+  const double mean = [&]() {
+    double sum = 0.0;
+    for (double f : flux) {
+      sum += f;
+    }
+    return sum / static_cast<double>(flux.size());
+  }();
+  const double threshold = mean * static_cast<double>(std::max(0.1f, sensitivity));
+
+  // Local-maximum peak picking above the adaptive threshold.
+  for (size_t frame = 1; frame + 1 < flux.size(); ++frame) {
+    if (flux[frame] > threshold && flux[frame] > flux[frame - 1] &&
+        flux[frame] >= flux[frame + 1]) {
+      onsets.push_back(static_cast<int64_t>(frame * analysis.hopSize));
+    }
+  }
+  return onsets;
+}
+
+WaveformPeaks waveformPeaks(const float* interleaved, size_t frames, uint16_t numChannels,
+                            uint32_t pixelWidth) {
+  WaveformPeaks result;
+  if (interleaved == nullptr || frames == 0 || numChannels == 0 || pixelWidth == 0) {
+    return result;
+  }
+  result.minPeaks.assign(pixelWidth, 0.0f);
+  result.maxPeaks.assign(pixelWidth, 0.0f);
+
+  const double framesPerPixel = static_cast<double>(frames) / static_cast<double>(pixelWidth);
+  for (uint32_t pixel = 0; pixel < pixelWidth; ++pixel) {
+    const size_t begin = static_cast<size_t>(static_cast<double>(pixel) * framesPerPixel);
+    size_t end = static_cast<size_t>(static_cast<double>(pixel + 1) * framesPerPixel);
+    end = std::min(std::max(end, begin + 1), frames);
+    float lo = interleaved[begin * numChannels];
+    float hi = lo;
+    for (size_t frame = begin; frame < end; ++frame) {
+      const float sample = interleaved[frame * numChannels];
+      lo = std::min(lo, sample);
+      hi = std::max(hi, sample);
+    }
+    result.minPeaks[pixel] = lo;
+    result.maxPeaks[pixel] = hi;
+  }
+  return result;
+}
+
+} // namespace orpheus::analysis

--- a/src/core/audio_io/audio_file_writer_libsndfile.cpp
+++ b/src/core/audio_io/audio_file_writer_libsndfile.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+#include "audio_file_writer_libsndfile.h"
+
+#include <cstring>
+
+namespace orpheus {
+
+AudioFileWriterLibsndfile::AudioFileWriterLibsndfile() : m_file(nullptr) {
+  std::memset(&m_info, 0, sizeof(m_info));
+}
+
+AudioFileWriterLibsndfile::~AudioFileWriterLibsndfile() {
+  close();
+}
+
+int AudioFileWriterLibsndfile::sndfileFormatFor(AudioFileFormat format,
+                                                AudioSampleFormat sampleFormat) {
+  int major = 0;
+  switch (format) {
+  case AudioFileFormat::WAV:
+    major = SF_FORMAT_WAV;
+    break;
+  case AudioFileFormat::AIFF:
+    major = SF_FORMAT_AIFF;
+    break;
+  case AudioFileFormat::FLAC:
+    major = SF_FORMAT_FLAC;
+    break;
+  default:
+    return 0; // Unsupported container
+  }
+
+  int sub = 0;
+  switch (sampleFormat) {
+  case AudioSampleFormat::Int16:
+    sub = SF_FORMAT_PCM_16;
+    break;
+  case AudioSampleFormat::Int24:
+    sub = SF_FORMAT_PCM_24;
+    break;
+  case AudioSampleFormat::Float32:
+    // FLAC is integer-only; float subformat is invalid there.
+    if (format == AudioFileFormat::FLAC) {
+      return 0;
+    }
+    sub = SF_FORMAT_FLOAT;
+    break;
+  default:
+    return 0;
+  }
+
+  return major | sub;
+}
+
+SessionGraphError AudioFileWriterLibsndfile::open(const std::string& file_path,
+                                                  const AudioFileWriterConfig& config) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  // Close any previously open file first.
+  if (m_file) {
+    sf_close(m_file);
+    m_file = nullptr;
+    m_is_open.store(false, std::memory_order_release);
+  }
+
+  if (file_path.empty() || config.sample_rate == 0 || config.num_channels == 0) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  // Distinguish "unsupported container" from "invalid combination".
+  const bool containerSupported = config.format == AudioFileFormat::WAV ||
+                                  config.format == AudioFileFormat::AIFF ||
+                                  config.format == AudioFileFormat::FLAC;
+  if (!containerSupported) {
+    return SessionGraphError::NotSupported;
+  }
+
+  const int sfFormat = sndfileFormatFor(config.format, config.sample_format);
+  if (sfFormat == 0) {
+    return SessionGraphError::InvalidParameter; // e.g. FLAC + Float32
+  }
+
+  std::memset(&m_info, 0, sizeof(m_info));
+  m_info.samplerate = static_cast<int>(config.sample_rate);
+  m_info.channels = static_cast<int>(config.num_channels);
+  m_info.format = sfFormat;
+
+  if (!sf_format_check(&m_info)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  m_file = sf_open(file_path.c_str(), SFM_WRITE, &m_info);
+  if (!m_file) {
+    return SessionGraphError::InternalError;
+  }
+
+  // Saturate out-of-range floats when encoding to integer PCM instead of
+  // letting them wrap (libsndfile default float->int conversion can wrap).
+  sf_command(m_file, SFC_SET_CLIPPING, nullptr, SF_TRUE);
+
+  m_file_path = file_path;
+  m_frames_written.store(0, std::memory_order_release);
+
+  m_metadata = AudioFileMetadata{};
+  m_metadata.format = config.format;
+  m_metadata.sample_rate = config.sample_rate;
+  m_metadata.num_channels = config.num_channels;
+  m_metadata.duration_samples = 0;
+  switch (config.sample_format) {
+  case AudioSampleFormat::Int16:
+    m_metadata.bit_depth = 16;
+    m_metadata.codec = "PCM";
+    break;
+  case AudioSampleFormat::Int24:
+    m_metadata.bit_depth = 24;
+    m_metadata.codec = "PCM";
+    break;
+  case AudioSampleFormat::Float32:
+    m_metadata.bit_depth = 32;
+    m_metadata.codec = "Float";
+    break;
+  }
+  if (config.format == AudioFileFormat::FLAC) {
+    m_metadata.codec = "FLAC";
+  }
+
+  m_is_open.store(true, std::memory_order_release);
+  return SessionGraphError::OK;
+}
+
+Result<size_t> AudioFileWriterLibsndfile::writeSamples(const float* buffer, size_t num_frames) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  Result<size_t> result;
+  if (!m_file || !m_is_open.load(std::memory_order_acquire)) {
+    result.error = SessionGraphError::NotReady;
+    result.errorMessage = "Writer is not open";
+    result.value = 0;
+    return result;
+  }
+  if (buffer == nullptr && num_frames > 0) {
+    result.error = SessionGraphError::InvalidParameter;
+    result.errorMessage = "Null buffer";
+    result.value = 0;
+    return result;
+  }
+
+  const sf_count_t written = sf_writef_float(m_file, buffer, static_cast<sf_count_t>(num_frames));
+  if (written < 0 || (static_cast<size_t>(written) != num_frames)) {
+    result.error = SessionGraphError::InternalError;
+    result.errorMessage = "Short write: " + std::string(sf_strerror(m_file));
+    result.value = written > 0 ? static_cast<size_t>(written) : 0;
+    return result;
+  }
+
+  const int64_t total = m_frames_written.fetch_add(written, std::memory_order_acq_rel) + written;
+  m_metadata.duration_samples = total;
+
+  result.error = SessionGraphError::OK;
+  result.value = static_cast<size_t>(written);
+  return result;
+}
+
+SessionGraphError AudioFileWriterLibsndfile::close() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (!m_file) {
+    return SessionGraphError::OK; // Already closed — idempotent
+  }
+
+  sf_write_sync(m_file);
+  const int err = sf_close(m_file);
+  m_file = nullptr;
+  m_is_open.store(false, std::memory_order_release);
+
+  return err == 0 ? SessionGraphError::OK : SessionGraphError::InternalError;
+}
+
+int64_t AudioFileWriterLibsndfile::getFramesWritten() const {
+  return m_frames_written.load(std::memory_order_acquire);
+}
+
+bool AudioFileWriterLibsndfile::isOpen() const {
+  return m_is_open.load(std::memory_order_acquire);
+}
+
+AudioFileMetadata AudioFileWriterLibsndfile::metadata() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  AudioFileMetadata meta = m_metadata;
+  meta.duration_samples = m_frames_written.load(std::memory_order_acquire);
+  return meta;
+}
+
+// Factory function (libsndfile build)
+std::unique_ptr<IAudioFileWriter> createAudioFileWriter() {
+  return std::make_unique<AudioFileWriterLibsndfile>();
+}
+
+} // namespace orpheus

--- a/src/core/audio_io/audio_file_writer_libsndfile.h
+++ b/src/core/audio_io/audio_file_writer_libsndfile.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <orpheus/audio_file_writer.h>
+
+#include <atomic>
+#include <mutex>
+#include <sndfile.h>
+#include <string>
+
+namespace orpheus {
+
+/// Audio file writer implementation using libsndfile (ORP134 G5 / FTR007).
+///
+/// Supports WAV, AIFF (Int16/Int24/Float32) and FLAC (Int16/Int24).
+class AudioFileWriterLibsndfile : public IAudioFileWriter {
+public:
+  AudioFileWriterLibsndfile();
+  ~AudioFileWriterLibsndfile() override;
+
+  // IAudioFileWriter interface
+  SessionGraphError open(const std::string& file_path,
+                         const AudioFileWriterConfig& config) override;
+  Result<size_t> writeSamples(const float* buffer, size_t num_frames) override;
+  SessionGraphError close() override;
+  int64_t getFramesWritten() const override;
+  bool isOpen() const override;
+  AudioFileMetadata metadata() const override;
+
+private:
+  /// Map (container, sample format) to a libsndfile format word.
+  /// Returns 0 for unsupported combinations.
+  static int sndfileFormatFor(AudioFileFormat format, AudioSampleFormat sampleFormat);
+
+  // File state
+  SNDFILE* m_file;
+  SF_INFO m_info;
+  AudioFileMetadata m_metadata;
+  std::string m_file_path;
+
+  // Thread safety (open/write/close serialized; queries lock-free)
+  mutable std::mutex m_mutex;
+  std::atomic<int64_t> m_frames_written{0};
+  std::atomic<bool> m_is_open{false};
+};
+
+} // namespace orpheus

--- a/src/core/audio_io/audio_input.cpp
+++ b/src/core/audio_io/audio_input.cpp
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/audio_input.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace orpheus {
+
+namespace {
+
+size_t roundUpPowerOfTwo(size_t value) {
+  size_t result = 1;
+  while (result < value) {
+    result <<= 1;
+  }
+  return result;
+}
+
+} // namespace
+
+// ============================================================================
+// AudioInputRing
+// ============================================================================
+
+AudioInputRing::AudioInputRing(uint16_t numChannels, size_t capacityFrames)
+    : m_numChannels(numChannels == 0 ? 1 : numChannels),
+      m_capacityFrames(roundUpPowerOfTwo(std::max<size_t>(2, capacityFrames))) {
+  m_data.assign(m_capacityFrames * m_numChannels, 0.0f);
+}
+
+size_t AudioInputRing::write(const float* interleaved, size_t frames) {
+  if (interleaved == nullptr || frames == 0) {
+    return 0;
+  }
+
+  const size_t writeIndex = m_writeIndex.load(std::memory_order_relaxed);
+  const size_t readIndex = m_readIndex.load(std::memory_order_acquire);
+  const size_t used = writeIndex - readIndex; // wraps correctly (unsigned)
+  const size_t freeFrames = m_capacityFrames - used;
+
+  if (frames > freeFrames) {
+    // All-or-nothing: dropping the whole buffer keeps frames contiguous and
+    // never blocks the audio thread.
+    m_overflows.fetch_add(1, std::memory_order_relaxed);
+    return 0;
+  }
+
+  const size_t mask = m_capacityFrames - 1;
+  size_t written = 0;
+  while (written < frames) {
+    const size_t slot = (writeIndex + written) & mask;
+    const size_t contiguous = std::min(frames - written, m_capacityFrames - slot);
+    std::memcpy(m_data.data() + slot * m_numChannels, interleaved + written * m_numChannels,
+                contiguous * m_numChannels * sizeof(float));
+    written += contiguous;
+  }
+
+  m_writeIndex.store(writeIndex + frames, std::memory_order_release);
+  return frames;
+}
+
+size_t AudioInputRing::read(float* dest, size_t maxFrames) {
+  if (dest == nullptr || maxFrames == 0) {
+    return 0;
+  }
+
+  const size_t readIndex = m_readIndex.load(std::memory_order_relaxed);
+  const size_t writeIndex = m_writeIndex.load(std::memory_order_acquire);
+  const size_t available = writeIndex - readIndex;
+  const size_t toRead = std::min(maxFrames, available);
+  if (toRead == 0) {
+    return 0;
+  }
+
+  const size_t mask = m_capacityFrames - 1;
+  size_t done = 0;
+  while (done < toRead) {
+    const size_t slot = (readIndex + done) & mask;
+    const size_t contiguous = std::min(toRead - done, m_capacityFrames - slot);
+    std::memcpy(dest + done * m_numChannels, m_data.data() + slot * m_numChannels,
+                contiguous * m_numChannels * sizeof(float));
+    done += contiguous;
+  }
+
+  m_readIndex.store(readIndex + toRead, std::memory_order_release);
+  return toRead;
+}
+
+size_t AudioInputRing::framesAvailable() const {
+  return m_writeIndex.load(std::memory_order_acquire) - m_readIndex.load(std::memory_order_acquire);
+}
+
+// ============================================================================
+// Ring-backed IAudioInputStream
+// ============================================================================
+
+namespace {
+
+class RingAudioInputStream : public IAudioInputStream {
+public:
+  explicit RingAudioInputStream(const AudioInputStreamConfig& config)
+      : m_config(config), m_ring(config.num_channels, config.ring_capacity_frames) {}
+
+  uint16_t numChannels() const override {
+    return m_ring.numChannels();
+  }
+  uint32_t sampleRate() const override {
+    return m_config.sample_rate;
+  }
+  size_t capture(const float* interleaved, size_t frames) override {
+    return m_ring.write(interleaved, frames);
+  }
+  size_t drain(float* dest, size_t maxFrames) override {
+    return m_ring.read(dest, maxFrames);
+  }
+  size_t framesPending() const override {
+    return m_ring.framesAvailable();
+  }
+  uint64_t overflowCount() const override {
+    return m_ring.overflowCount();
+  }
+
+private:
+  AudioInputStreamConfig m_config;
+  AudioInputRing m_ring;
+};
+
+} // namespace
+
+std::unique_ptr<IAudioInputStream> createAudioInputStream(const AudioInputStreamConfig& config) {
+  return std::make_unique<RingAudioInputStream>(config);
+}
+
+} // namespace orpheus

--- a/src/core/audio_io/create_audio_file_writer_stub.cpp
+++ b/src/core/audio_io/create_audio_file_writer_stub.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/audio_file_writer.h>
+
+namespace orpheus {
+
+// Fallback factory implementation when libsndfile is not available.
+// Mirrors create_audio_file_reader_stub.cpp: the symbol must exist for
+// linking; callers must check for nullptr.
+std::unique_ptr<IAudioFileWriter> createAudioFileWriter() {
+  return nullptr;
+}
+
+} // namespace orpheus

--- a/src/core/audio_io/waveform_processor.cpp
+++ b/src/core/audio_io/waveform_processor.cpp
@@ -229,7 +229,7 @@ private:
         result.maxPeaks[pixelIndex] = std::max(result.maxPeaks[pixelIndex], sample);
       }
 
-      samplesProcessed += framesRead;
+      samplesProcessed += static_cast<int64_t>(framesRead);
     }
 
     // Handle pixels that had no samples (edge case)
@@ -278,7 +278,7 @@ private:
         peak = std::max(peak, std::abs(sample));
       }
 
-      totalSamplesProcessed += framesRead;
+      totalSamplesProcessed += static_cast<int64_t>(framesRead);
     }
 
     // Restore original position

--- a/src/core/routing/CMakeLists.txt
+++ b/src/core/routing/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 add_library(orpheus_routing STATIC
+    audio_graph.cpp # ORP134 G3: graph-neutral routing seam
     routing_matrix.cpp
     gain_smoother.cpp
     clip_routing.cpp

--- a/src/core/routing/audio_graph.cpp
+++ b/src/core/routing/audio_graph.cpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/audio_graph.h>
+
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace orpheus::graph {
+
+const NodeDesc* GraphDescription::findNode(NodeId id) const {
+  for (const auto& node : nodes) {
+    if (node.id == id) {
+      return &node;
+    }
+  }
+  return nullptr;
+}
+
+bool GraphDescription::validate(std::string* outError) const {
+  auto fail = [&](const std::string& message) {
+    if (outError != nullptr) {
+      *outError = message;
+    }
+    return false;
+  };
+
+  std::unordered_set<NodeId> ids;
+  for (const auto& node : nodes) {
+    if (node.id == 0) {
+      return fail("node id 0 is reserved as invalid");
+    }
+    if (!ids.insert(node.id).second) {
+      return fail("duplicate node id " + std::to_string(node.id));
+    }
+  }
+
+  for (const auto& connection : connections) {
+    const NodeDesc* from = findNode(connection.from);
+    const NodeDesc* to = findNode(connection.to);
+    if (from == nullptr || to == nullptr) {
+      return fail("connection references unknown node");
+    }
+    if (to->kind == NodeKind::Source) {
+      return fail("source node " + std::to_string(to->id) + " cannot have inputs");
+    }
+    if (from->kind == NodeKind::Sink) {
+      return fail("sink node " + std::to_string(from->id) + " cannot have outputs");
+    }
+    if (connection.kind == ConnectionKind::Tap && from->kind == NodeKind::Processor) {
+      return fail("taps observe sources or buses, not processors");
+    }
+  }
+
+  return true;
+}
+
+GraphDescription makeSoundboardGraph(const SoundboardTopology& topology) {
+  GraphDescription graph;
+  NodeId nextId = 1;
+
+  // Group buses first so sources can connect to group 0.
+  std::vector<NodeId> groupIds;
+  for (uint8_t group = 0; group < topology.numGroups; ++group) {
+    NodeDesc bus;
+    bus.id = nextId++;
+    bus.kind = NodeKind::Bus;
+    bus.layout = ChannelLayout::Stereo;
+    bus.name = "group " + std::to_string(group);
+    groupIds.push_back(bus.id);
+    graph.nodes.push_back(std::move(bus));
+  }
+
+  NodeDesc master;
+  master.id = nextId++;
+  master.kind = NodeKind::Bus;
+  master.layout = ChannelLayout::Stereo;
+  master.name = "master";
+  const NodeId masterId = master.id;
+  graph.nodes.push_back(std::move(master));
+
+  NodeDesc sink;
+  sink.id = nextId++;
+  sink.kind = NodeKind::Sink;
+  sink.layout = topology.numOutputs >= 2 ? ChannelLayout::Stereo : ChannelLayout::Mono;
+  sink.name = "device out";
+  const NodeId sinkId = sink.id;
+  graph.nodes.push_back(std::move(sink));
+
+  // Clip sources — all default-routed to group 0, exactly like the
+  // transport's constructor (setChannelGroup(ch, 0) for every clip pair).
+  for (size_t clip = 0; clip < topology.numClipSources; ++clip) {
+    NodeDesc source;
+    source.id = nextId++;
+    source.kind = NodeKind::Source;
+    source.layout = ChannelLayout::Stereo;
+    source.name = "clip " + std::to_string(clip);
+    graph.nodes.push_back(source);
+    if (!groupIds.empty()) {
+      graph.connections.push_back({source.id, groupIds.front(), ConnectionKind::Direct, 0.0f});
+    }
+  }
+
+  for (NodeId groupId : groupIds) {
+    graph.connections.push_back({groupId, masterId, ConnectionKind::Direct, 0.0f});
+  }
+  graph.connections.push_back({masterId, sinkId, ConnectionKind::Direct, 0.0f});
+
+  return graph;
+}
+
+RoutingConfig toRoutingConfig(const GraphDescription& graph) {
+  RoutingConfig config;
+
+  size_t sourceCount = 0;
+  size_t groupBusCount = 0;
+  uint16_t sinkChannels = 0;
+  for (const auto& node : graph.nodes) {
+    switch (node.kind) {
+    case NodeKind::Source:
+      ++sourceCount;
+      break;
+    case NodeKind::Bus:
+      // The master bus is the matrix's implicit mix stage, not a group.
+      if (node.name != "master") {
+        ++groupBusCount;
+      }
+      break;
+    case NodeKind::Sink:
+      sinkChannels = std::max(sinkChannels, channelCount(node.layout));
+      break;
+    case NodeKind::Processor:
+      break; // Processor nodes await the graph engine (ORP135 B4)
+    }
+  }
+
+  // Stereo pair per source — the matrix's SourceChannelPolicy::StereoPairs
+  // model the transport uses today (2 routing channels per clip voice).
+  config.num_channels = static_cast<uint8_t>(std::min<size_t>(sourceCount * 2, 255));
+  config.num_groups = static_cast<uint8_t>(std::min<size_t>(groupBusCount, 255));
+  config.num_outputs = static_cast<uint8_t>(std::min<uint16_t>(sinkChannels, 255));
+  return config;
+}
+
+} // namespace orpheus::graph

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -636,8 +636,8 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
     // output_bus 1 = channels 2-3 (stereo pair 2)
     // etc.
     uint8_t output_bus = group.config.output_bus;
-    uint8_t out_L = output_bus * 2;
-    uint8_t out_R = output_bus * 2 + 1;
+    uint8_t out_L = static_cast<uint8_t>(output_bus * 2);
+    uint8_t out_R = static_cast<uint8_t>(output_bus * 2 + 1);
 
     // Validate output channels exist
     if (out_R >= config.num_outputs) {

--- a/src/core/session/scene_manager.cpp
+++ b/src/core/session/scene_manager.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <map>
 #include <mutex>

--- a/src/core/session/scene_manager.cpp
+++ b/src/core/session/scene_manager.cpp
@@ -206,8 +206,10 @@ public:
 
   ~SceneManager() override = default;
 
-  // Set routing matrix (optional, used for capturing/restoring routing state)
-  void setRoutingMatrix(IRoutingMatrix* routingMatrix) {
+  // ORP134 G8: now part of ISceneManager — previously this existed only on
+  // the hidden concrete class, so no consumer could ever wire routing
+  // capture/recall through the public factory.
+  void setRoutingMatrix(IRoutingMatrix* routingMatrix) override {
     std::lock_guard<std::mutex> lock(mutex_);
     routingMatrix_ = routingMatrix;
   }

--- a/src/core/transport/CMakeLists.txt
+++ b/src/core/transport/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 add_library(orpheus_transport STATIC
+    clip_source.cpp # ORP134 G1: prepared/streaming realtime clip sources
     transport_controller.cpp
 )
 

--- a/src/core/transport/clip_source.cpp
+++ b/src/core/transport/clip_source.cpp
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+#include "clip_source.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+namespace orpheus {
+
+// ============================================================================
+// PreparedClipSource
+// ============================================================================
+
+PreparedClipSource::PreparedClipSource(std::vector<float> pcm, uint16_t numChannels,
+                                       int64_t lengthFrames)
+    : m_pcm(std::move(pcm)), m_numChannels(numChannels), m_lengthFrames(lengthFrames) {}
+
+std::shared_ptr<PreparedClipSource>
+PreparedClipSource::decode(IAudioFileReader& reader, uint16_t numChannels, int64_t lengthFrames) {
+  if (numChannels == 0 || lengthFrames < 0) {
+    return nullptr;
+  }
+
+  std::vector<float> pcm(static_cast<size_t>(lengthFrames) * numChannels, 0.0f);
+
+  if (reader.seek(0) != SessionGraphError::OK) {
+    return nullptr;
+  }
+
+  // Chunked sequential decode (background thread; blocking I/O is fine here).
+  constexpr size_t kChunkFrames = 65536;
+  int64_t framesDecoded = 0;
+  while (framesDecoded < lengthFrames) {
+    const size_t want = static_cast<size_t>(
+        std::min<int64_t>(static_cast<int64_t>(kChunkFrames), lengthFrames - framesDecoded));
+    float* dest = pcm.data() + static_cast<size_t>(framesDecoded) * numChannels;
+    auto result = reader.readSamples(dest, want);
+    if (!result.isOk()) {
+      return nullptr;
+    }
+    if (result.value == 0) {
+      break; // EOF earlier than metadata promised — keep zero padding
+    }
+    framesDecoded += static_cast<int64_t>(result.value);
+  }
+
+  return std::shared_ptr<PreparedClipSource>(
+      new PreparedClipSource(std::move(pcm), numChannels, lengthFrames));
+}
+
+bool PreparedClipSource::read(int64_t pos, float* dest, size_t frames, size_t& framesRead) {
+  framesRead = 0;
+  if (pos < 0 || pos >= m_lengthFrames) {
+    return true; // valid read of zero frames (EOF / out of range)
+  }
+  const int64_t available = m_lengthFrames - pos;
+  const size_t toCopy =
+      static_cast<size_t>(std::min<int64_t>(static_cast<int64_t>(frames), available));
+  std::memcpy(dest, m_pcm.data() + static_cast<size_t>(pos) * m_numChannels,
+              toCopy * m_numChannels * sizeof(float));
+  framesRead = toCopy;
+  return true;
+}
+
+// ============================================================================
+// StreamingClipSource
+// ============================================================================
+
+StreamingClipSource::StreamingClipSource(std::shared_ptr<IAudioFileReader> reader,
+                                         uint16_t numChannels, int64_t lengthFrames)
+    : m_reader(std::move(reader)), m_numChannels(numChannels), m_lengthFrames(lengthFrames) {
+  for (auto& page : m_pages) {
+    page.data.assign(kPageFrames * m_numChannels, 0.0f);
+  }
+}
+
+bool StreamingClipSource::copyFromResidentPage(int64_t pos, float* dest, size_t frames) {
+  const int64_t pageStart = alignDown(pos);
+  for (auto& page : m_pages) {
+    if (page.start.load(std::memory_order_acquire) == pageStart) {
+      const size_t offset = static_cast<size_t>(pos - pageStart);
+      std::memcpy(dest, page.data.data() + offset * m_numChannels,
+                  frames * m_numChannels * sizeof(float));
+      return true;
+    }
+  }
+  return false;
+}
+
+bool StreamingClipSource::read(int64_t pos, float* dest, size_t frames, size_t& framesRead) {
+  framesRead = 0;
+  if (pos < 0 || pos >= m_lengthFrames) {
+    return true; // valid read of zero frames
+  }
+  const int64_t available = m_lengthFrames - pos;
+  size_t toCopy = static_cast<size_t>(std::min<int64_t>(static_cast<int64_t>(frames), available));
+
+  // Publish the demand position and retire every READY page outside the
+  // demand window [alignDown(pos), +kNumPages pages). Retirement here — on
+  // the audio thread, the pages' owner — is what hands FREE pages back to the
+  // worker after seeks/loops; without it the ring would pin stale pages
+  // forever. (Release store; the worker acquires before writing.)
+  m_demand.store(pos, std::memory_order_relaxed);
+  const int64_t windowBase = alignDown(pos);
+  const int64_t windowEnd =
+      windowBase + static_cast<int64_t>(kNumPages) * static_cast<int64_t>(kPageFrames);
+  for (auto& page : m_pages) {
+    const int64_t start = page.start.load(std::memory_order_acquire);
+    if (start >= 0 && (start < windowBase || start >= windowEnd)) {
+      page.start.store(-1, std::memory_order_release);
+    }
+  }
+
+  // A transport buffer (<= 2048 frames) spans at most two 64k pages.
+  size_t copied = 0;
+  while (copied < toCopy) {
+    const int64_t subPos = pos + static_cast<int64_t>(copied);
+    const int64_t pageEnd = alignDown(subPos) + static_cast<int64_t>(kPageFrames);
+    const size_t subFrames = static_cast<size_t>(
+        std::min<int64_t>(static_cast<int64_t>(toCopy - copied), pageEnd - subPos));
+    if (!copyFromResidentPage(subPos, dest + copied * m_numChannels, subFrames)) {
+      return false; // miss → caller emits silence + BufferUnderrun
+    }
+    copied += subFrames;
+  }
+
+  framesRead = toCopy;
+  return true;
+}
+
+bool StreamingClipSource::fillPage(int64_t alignedStart) {
+  // Find a FREE page (worker-owned).
+  Page* target = nullptr;
+  for (auto& page : m_pages) {
+    if (page.start.load(std::memory_order_acquire) == -1) {
+      target = &page;
+      break;
+    }
+  }
+  if (target == nullptr) {
+    return false; // nothing FREE yet — audio thread will retire on its next read
+  }
+
+  const int64_t framesLeft = m_lengthFrames - alignedStart;
+  const size_t want = static_cast<size_t>(
+      std::min<int64_t>(static_cast<int64_t>(kPageFrames), std::max<int64_t>(0, framesLeft)));
+  if (want == 0) {
+    return false;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_readerMutex);
+    if (!m_reader || m_reader->seek(alignedStart) != SessionGraphError::OK) {
+      return false;
+    }
+    auto result = m_reader->readSamples(target->data.data(), want);
+    if (!result.isOk()) {
+      return false;
+    }
+    // Zero-pad a short tail (EOF) so the whole page is defined.
+    const size_t got = result.value;
+    if (got < kPageFrames) {
+      std::fill(target->data.begin() + static_cast<ptrdiff_t>(got * m_numChannels),
+                target->data.end(), 0.0f);
+    }
+  }
+
+  target->start.store(alignedStart, std::memory_order_release);
+  return true;
+}
+
+void StreamingClipSource::prefill(int64_t pos) {
+  const int64_t base = alignDown(std::max<int64_t>(0, pos));
+  for (size_t i = 0; i < kNumPages; ++i) {
+    const int64_t start = base + static_cast<int64_t>(i) * static_cast<int64_t>(kPageFrames);
+    if (start >= m_lengthFrames) {
+      break;
+    }
+    bool resident = false;
+    for (auto& page : m_pages) {
+      if (page.start.load(std::memory_order_acquire) == start) {
+        resident = true;
+        break;
+      }
+    }
+    if (!resident) {
+      fillPage(start);
+    }
+  }
+}
+
+void StreamingClipSource::service() {
+  prefill(m_demand.load(std::memory_order_relaxed));
+}
+
+// ============================================================================
+// MediaStreamWorker
+// ============================================================================
+
+MediaStreamWorker::MediaStreamWorker() : m_thread([this]() { run(); }) {}
+
+MediaStreamWorker::~MediaStreamWorker() {
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_stop = true;
+  }
+  m_wake.notify_all();
+  if (m_thread.joinable()) {
+    m_thread.join();
+  }
+}
+
+void MediaStreamWorker::attach(const std::shared_ptr<StreamingClipSource>& source) {
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_sources.push_back(source);
+  }
+  m_wake.notify_all();
+}
+
+void MediaStreamWorker::run() {
+  std::unique_lock<std::mutex> lock(m_mutex);
+  while (!m_stop) {
+    // Snapshot live sources, then service them without holding the lock so
+    // attach() never blocks behind file I/O.
+    std::vector<std::shared_ptr<StreamingClipSource>> live;
+    live.reserve(m_sources.size());
+    for (auto it = m_sources.begin(); it != m_sources.end();) {
+      if (auto strong = it->lock()) {
+        live.push_back(std::move(strong));
+        ++it;
+      } else {
+        it = m_sources.erase(it);
+      }
+    }
+
+    lock.unlock();
+    for (auto& source : live) {
+      source->service();
+    }
+    live.clear();
+    lock.lock();
+
+    // The audio thread cannot notify (no locks there); poll. 10ms against a
+    // multi-second resident window keeps refill latency negligible.
+    m_wake.wait_for(lock, std::chrono::milliseconds(10), [this]() { return m_stop; });
+  }
+}
+
+} // namespace orpheus

--- a/src/core/transport/clip_source.h
+++ b/src/core/transport/clip_source.h
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP134 G1: realtime clip playback sources.
+//
+// The transport's audio callback used to call IAudioFileReader::readSamples()
+// / seek() directly — blocking libsndfile decode on the audio thread (the
+// KNOWN_DEBT the realtime audit tracked since ORP121). These classes are the
+// replacement contract: an IClipSource is an immutable, position-explicit,
+// audio-thread-only VIEW of decoded engine-rate PCM. All decode, resample,
+// and file I/O happens off the audio thread:
+//
+//  * PreparedClipSource — whole file decoded to memory during
+//    prepareClipAudio()/startClip() (background/control thread). The common
+//    short-clip case (soundboards, stingers, beds). Never misses.
+//  * StreamingClipSource — fixed ring of PCM pages filled by a background
+//    MediaStreamWorker for long files. The audio thread reads resident pages
+//    (memcpy) and NEVER blocks: a cache miss returns false and the transport
+//    emits silence + a BufferUnderrun event while the worker catches up.
+//
+// Threading model (strict ownership handoff — no locks on the audio thread,
+// TSAN-clean by construction):
+//  * A page is either FREE (start == -1, worker-owned, writable) or READY
+//    (start >= 0, audio-owned, readable). The worker fills a FREE page then
+//    publishes it with a release store of its aligned start frame; the audio
+//    thread acquires it before reading. Only the AUDIO thread retires READY
+//    pages (release store of -1) — it does so for any page outside its
+//    current demand window, so the worker always regains pages to refill.
+//  * The audio thread communicates its read position via a relaxed atomic
+//    (setDemand); the worker polls it. After a large reposition the next
+//    audio read retires stale pages and reports a miss (one silent buffer)
+//    while the worker refills — streaming sources trade seek latency for
+//    bounded memory; hosts needing instant random access use prepared
+//    sources.
+//
+// Reads are position-explicit (no shared file cursor), which also makes
+// multi-voice playback of one clip correct by construction — voices no
+// longer fight over a single reader's seek position.
+
+#include <orpheus/audio_file_reader.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace orpheus {
+
+/// Audio-thread-safe random-access view of a clip's engine-rate PCM.
+class IClipSource {
+public:
+  virtual ~IClipSource() = default;
+
+  virtual uint16_t numChannels() const = 0;
+
+  /// Total engine-rate frames available.
+  virtual int64_t lengthFrames() const = 0;
+
+  /// Copy up to `frames` interleaved frames starting at absolute frame `pos`
+  /// into `dest`. AUDIO THREAD SAFE: no locks, no allocation, no I/O.
+  ///
+  /// @return true on success (framesRead = frames actually copied, capped at
+  ///         EOF); false on a streaming cache miss (framesRead == 0, dest
+  ///         untouched) — the caller renders silence and reports an underrun.
+  virtual bool read(int64_t pos, float* dest, size_t frames, size_t& framesRead) = 0;
+
+  /// Audio-thread hint: playback continues from `pos` (streaming prefetch
+  /// target). Relaxed atomic store; no-op for prepared sources.
+  virtual void setDemand(int64_t /*pos*/) {}
+
+  /// True when the whole clip is memory-resident (read() can never miss).
+  virtual bool isFullyResident() const = 0;
+};
+
+/// Whole-file PCM in memory. Immutable after construction.
+class PreparedClipSource : public IClipSource {
+public:
+  /// Decode the reader's full content (engine-rate frames) into memory.
+  /// BACKGROUND/CONTROL THREAD ONLY. Returns nullptr on decode failure.
+  static std::shared_ptr<PreparedClipSource> decode(IAudioFileReader& reader, uint16_t numChannels,
+                                                    int64_t lengthFrames);
+
+  uint16_t numChannels() const override {
+    return m_numChannels;
+  }
+  int64_t lengthFrames() const override {
+    return m_lengthFrames;
+  }
+  bool read(int64_t pos, float* dest, size_t frames, size_t& framesRead) override;
+  bool isFullyResident() const override {
+    return true;
+  }
+
+private:
+  PreparedClipSource(std::vector<float> pcm, uint16_t numChannels, int64_t lengthFrames);
+
+  std::vector<float> m_pcm; // interleaved engine-rate PCM
+  uint16_t m_numChannels;
+  int64_t m_lengthFrames;
+};
+
+/// Fixed-page streaming source for long files.
+class StreamingClipSource : public IClipSource {
+public:
+  static constexpr size_t kPageFrames = 65536; ///< frames per page (~1.4s @ 48k)
+  static constexpr size_t kNumPages = 4;       ///< resident window ≈ 5.5s @ 48k
+
+  /// BACKGROUND/CONTROL THREAD. The reader is retained and used exclusively
+  /// from worker/control threads (guarded by an internal mutex).
+  StreamingClipSource(std::shared_ptr<IAudioFileReader> reader, uint16_t numChannels,
+                      int64_t lengthFrames);
+
+  uint16_t numChannels() const override {
+    return m_numChannels;
+  }
+  int64_t lengthFrames() const override {
+    return m_lengthFrames;
+  }
+  bool read(int64_t pos, float* dest, size_t frames, size_t& framesRead) override;
+  void setDemand(int64_t pos) override {
+    m_demand.store(pos, std::memory_order_relaxed);
+  }
+  bool isFullyResident() const override {
+    return false;
+  }
+
+  /// Fill every page of the window starting at `pos` synchronously.
+  /// CONTROL/WORKER THREAD. Called by prepareClipAudio so playback from the
+  /// trim-in point starts without an initial underrun.
+  void prefill(int64_t pos);
+
+  /// One worker pass: refill FREE pages inside the current demand window.
+  /// WORKER THREAD ONLY.
+  void service();
+
+private:
+  struct Page {
+    // -1 == FREE (worker-owned, writable); >= 0 == READY at that aligned
+    // start frame (audio-owned, readable until the audio thread retires it).
+    std::atomic<int64_t> start{-1};
+    std::vector<float> data; // kPageFrames * numChannels, pre-allocated
+  };
+
+  static int64_t alignDown(int64_t pos) {
+    return (pos / static_cast<int64_t>(kPageFrames)) * static_cast<int64_t>(kPageFrames);
+  }
+
+  /// Copy the subrange [pos, pos+frames) from a READY page covering it.
+  /// Returns false when no resident page covers pos.
+  bool copyFromResidentPage(int64_t pos, float* dest, size_t frames);
+
+  /// Fill one FREE page with content starting at alignedStart and publish it.
+  /// Worker/control thread. Returns false when no FREE page is available or
+  /// the read fails.
+  bool fillPage(int64_t alignedStart);
+
+  std::shared_ptr<IAudioFileReader> m_reader; // worker/control threads only
+  std::mutex m_readerMutex;                   // serializes prefill vs service
+  std::atomic<int64_t> m_demand{0};
+  uint16_t m_numChannels;
+  int64_t m_lengthFrames;
+  Page m_pages[kNumPages];
+};
+
+/// Background thread servicing every StreamingClipSource of a transport.
+/// Owns no source (weak references); prunes dead sources automatically.
+class MediaStreamWorker {
+public:
+  MediaStreamWorker();
+  ~MediaStreamWorker();
+
+  /// CONTROL THREAD: register a source for periodic servicing.
+  void attach(const std::shared_ptr<StreamingClipSource>& source);
+
+private:
+  void run();
+
+  std::mutex m_mutex;
+  std::condition_variable m_wake;
+  std::vector<std::weak_ptr<StreamingClipSource>> m_sources;
+  bool m_stop = false;
+  std::thread m_thread;
+};
+
+} // namespace orpheus

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -126,8 +126,12 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
     std::lock_guard<std::mutex> lock(m_audioFilesMutex);
     auto it = m_audioFiles.find(handle);
     if (it != m_audioFiles.end()) {
-      const auto& entry = it->second;
-      context->reader = entry.reader;
+      auto& entry = it->second;
+      // ORP134 G1: lazy preparation for hosts that never call
+      // prepareClipAudio() — decode/stream setup happens HERE on the control
+      // thread, never on the audio thread.
+      ensurePreparedSourceLocked(entry);
+      context->source = entry.source;
       context->numChannels = entry.metadata.num_channels;
       context->trimInSamples = entry.trimInSamples;
       context->fileLengthSamples = entry.metadata.duration_samples; // ORP127 G3
@@ -147,7 +151,7 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
       context->voiceMode = entry.voiceMode; // ORP127 G5
     } else {
       // Clip not registered - use defaults for testing
-      context->reader = nullptr;
+      context->source = nullptr;
       context->numChannels = 2;
       context->trimInSamples = 0;
       context->trimOutSamples = 48000 * 60;    // Default 60s
@@ -315,8 +319,8 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
   for (size_t i = 0; i < m_activeClipCount; ++i) {
     ActiveClip& clip = m_activeClips[i];
 
-    // Skip if no audio file registered
-    if (!clip.reader || !clip.reader->isOpen()) {
+    // Skip if no audio source prepared (unregistered/test clips)
+    if (!clip.source) {
       continue;
     }
 
@@ -332,20 +336,18 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
     // CRITICAL: Clamp position to [trimIn, trimOut) range to maintain edit laws
     // This ensures getClipPosition() never returns values outside user-defined boundaries
     if (clip.currentSample < trimIn) {
-      // Position below IN point - clamp to IN (enforce Edit Law #1)
+      // Position below IN point - clamp to IN (enforce Edit Law #1).
+      // ORP134 G1: sources are position-explicit — no reader seek; just hint
+      // the streaming prefetcher.
       clip.currentSample = trimIn;
-      if (clip.reader) {
-        clip.reader->seek(trimIn);
-      }
+      clip.source->setDemand(trimIn);
     } else if (clip.currentSample >= trimOut) {
       // Position at or past OUT point - handle loop or stop
       bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
       if (shouldLoop) {
         // Loop mode: restart from IN point
         clip.currentSample = trimIn;
-        if (clip.reader) {
-          clip.reader->seek(trimIn);
-        }
+        clip.source->setDemand(trimIn);
 
         // ORP097 Bug 7 Fix: Mark that clip has looped
         clip.hasLoopedOnce = true;
@@ -408,10 +410,10 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
     size_t framesToRead =
         static_cast<size_t>(std::min(static_cast<int64_t>(numFrames), framesUntilEnd));
 
-    // Note: We don't seek on every callback - the reader maintains its position
-    // The initial seek to trimInSamples happens in addActiveClip()
-
-    // Read audio from file
+    // ORP134 G1: reads are position-explicit against the prepared/streamed
+    // source — the audio thread never touches a file reader or a shared
+    // cursor. (This also makes multi-voice playback of one clip correct:
+    // every voice reads at its own currentSample.)
     size_t numFileChannels = clip.numChannels;
 
     // Use this clip's dedicated read buffer (no shared buffer conflicts!)
@@ -425,15 +427,32 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
       continue;
     }
 
-    // Read samples from audio file into THIS clip's buffer
-    // Use captured shared_ptr reader (thread-safe, no map lookup needed)
-    auto readResult = clip.reader->readSamples(clipReadBuffer, framesToRead);
+    // Copy decoded PCM from this clip's source into THIS clip's buffer.
+    // A streaming cache miss NEVER blocks: the clip renders silence for this
+    // buffer, the transport reports a BufferUnderrun, and the position still
+    // advances so the timeline keeps moving while the worker catches up.
+    size_t framesRead = 0;
+    if (!clip.source->read(clip.currentSample, clipReadBuffer, framesToRead, framesRead)) {
+      TransportEvent event{};
+      event.type = TransportEventType::BufferUnderrun;
+      event.handle = clip.handle;
+      event.voiceId = clip.voiceId;
+      event.position = getCurrentPosition();
+      postTransportEvent(event);
 
-    if (!readResult.isOk()) {
+      clip.source->setDemand(clip.currentSample);
+      clip.currentSample += static_cast<int64_t>(framesToRead);
       continue;
     }
 
-    size_t framesRead = readResult.value;
+    if (framesRead == 0) {
+      // Past EOF (e.g. OUT-tail horizon beyond the file). Advance so stop
+      // fades can complete, mirroring the source-less advance path.
+      if (clip.isStopping) {
+        clip.currentSample += static_cast<int64_t>(numFrames);
+      }
+      continue;
+    }
 
     // ORP121 A-01: Stereo output to L/R channel buffers (indices i*2 and i*2+1)
     // No mono sum - preserves source channel separation per ST2110-30
@@ -555,12 +574,12 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
     clip.currentSample += static_cast<int64_t>(framesRead);
   }
 
-  // Multi-voice fix: Advance position for clips WITHOUT readers (test clips, stopped clips)
+  // Multi-voice fix: Advance position for clips WITHOUT sources (test clips)
   // This ensures fade-outs complete properly even when no audio is being rendered
   for (size_t i = 0; i < m_activeClipCount; ++i) {
     ActiveClip& clip = m_activeClips[i];
-    if (!clip.reader || !clip.reader->isOpen()) {
-      // Clip has no reader - advance position by buffer size so fades can complete
+    if (!clip.source) {
+      // Clip has no source - advance position by buffer size so fades can complete
       clip.currentSample += static_cast<int64_t>(numFrames);
     }
   }
@@ -606,10 +625,10 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
       bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
 
       if (shouldLoop) {
-        // Loop: seek back to trim IN point (works even without reader)
+        // Loop: jump back to trim IN point (works even without a source)
         int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
-        if (clip.reader) {
-          clip.reader->seek(trimIn);
+        if (clip.source) {
+          clip.source->setDemand(trimIn);
         }
         clip.currentSample = trimIn;
 
@@ -721,16 +740,12 @@ void TransportController::processCommands() {
           // This prevents fade calculation overflow in processAudio()
           if (m_activeClips[i].currentSample < trimIn) {
             m_activeClips[i].currentSample = trimIn;
-            if (m_activeClips[i].reader) {
-              m_activeClips[i].reader->seek(trimIn);
+            if (m_activeClips[i].source) {
+              m_activeClips[i].source->setDemand(trimIn);
             }
           } else if (m_activeClips[i].currentSample >= trimOut) {
             m_activeClips[i].currentSample = trimOut;
-            // Don't seek to trimOut (EOF), just let it stop naturally in processAudio logic
-            // But ensure reader is consistent if we needed to read
-            if (m_activeClips[i].reader) {
-              m_activeClips[i].reader->seek(trimOut);
-            }
+            // Position clamps to OUT; playback stops naturally in processAudio.
           }
         }
       }
@@ -792,8 +807,8 @@ void TransportController::processCommands() {
 
           trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
           clip.currentSample = trimIn;
-          if (clip.reader) {
-            clip.reader->seek(trimIn);
+          if (clip.source) {
+            clip.source->setDemand(trimIn);
           }
 
           // Cancel any fade-out in progress.
@@ -831,8 +846,8 @@ void TransportController::processCommands() {
           foundAnyVoice = true;
           ActiveClip& clip = m_activeClips[i];
           clip.currentSample = position;
-          if (clip.reader) {
-            clip.reader->seek(position);
+          if (clip.source) {
+            clip.source->setDemand(position);
           }
         }
       }
@@ -932,8 +947,8 @@ void TransportController::restartVoiceInPlace(ActiveClip& clip) {
   // ORP127 G5: reset a live voice to its trim IN for an in-place restart.
   int64_t trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
   clip.currentSample = trimIn;
-  if (clip.reader) {
-    clip.reader->seek(trimIn);
+  if (clip.source) {
+    clip.source->setDemand(trimIn);
   }
   clip.isStopping = false;
   clip.fadeOutGain = 1.0f;
@@ -997,8 +1012,8 @@ void TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
       // still applies via hasLoopedOnce=false.
       int64_t trimIn = primary->trimInSamples.load(std::memory_order_relaxed);
       primary->currentSample = trimIn;
-      if (primary->reader) {
-        primary->reader->seek(trimIn);
+      if (primary->source) {
+        primary->source->setDemand(trimIn);
       }
       primary->isStopping = false;
       primary->fadeOutGain = 1.0f;
@@ -1107,7 +1122,7 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   // Initialize loop mode
   clip.loopEnabled.store(context->loopEnabled, std::memory_order_release);
 
-  clip.reader = context->reader; // Store shared_ptr (maintains reference count)
+  clip.source = context->source; // Store shared_ptr (maintains reference count)
   clip.numChannels = context->numChannels;
   clip.fileLengthSamples = context->fileLengthSamples; // ORP127 G3
   clip.voiceMode = context->voiceMode;                 // ORP127 G5
@@ -1122,9 +1137,10 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   // ORP097 Bug 7 Fix: Initialize loop state
   clip.hasLoopedOnce = false;
 
-  // Seek to trim IN point once when starting
-  if (clip.reader) {
-    clip.reader->seek(context->trimInSamples);
+  // Prime the streaming prefetcher at the trim IN point (no-op for prepared
+  // sources; sources are position-explicit so there is nothing to seek).
+  if (clip.source) {
+    clip.source->setDemand(context->trimInSamples);
   }
 }
 
@@ -1172,7 +1188,7 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
         dest.isRestarting = src.isRestarting;
         dest.restartFadeFramesRemaining = src.restartFadeFramesRemaining;
         dest.hasLoopedOnce = src.hasLoopedOnce;
-        dest.reader = src.reader;
+        dest.source = src.source;
         dest.numChannels = src.numChannels;
         dest.fileLengthSamples = src.fileLengthSamples; // ORP127 G3
         dest.voiceMode = src.voiceMode;                 // ORP127 G5
@@ -1228,7 +1244,7 @@ void TransportController::removeActiveClip(ClipHandle handle) {
         dest.isRestarting = src.isRestarting;
         dest.restartFadeFramesRemaining = src.restartFadeFramesRemaining;
         dest.hasLoopedOnce = src.hasLoopedOnce; // ORP097 Bug 7 Fix
-        dest.reader = src.reader;               // Copy shared_ptr (atomic refcount increment)
+        dest.source = src.source;               // Copy shared_ptr (atomic refcount increment)
         dest.numChannels = src.numChannels;
       }
       --m_activeClipCount;
@@ -1442,42 +1458,59 @@ SessionGraphError TransportController::prepareClipAudio(ClipHandle handle) {
     return SessionGraphError::InvalidHandle;
   }
 
-  // Do not seek/read a shared reader while an active voice may be using it on
-  // the audio thread. Future streaming readers should remove this limitation.
+  // Preserved contract: preparation is a pre-playback operation. (With
+  // ORP134 G1 sources a re-preparation while playing would actually be safe -
+  // active voices hold their own reference - but the historical NotReady
+  // keeps host behavior unchanged.)
   if (isClipPlaying(handle)) {
     return SessionGraphError::NotReady;
   }
 
-  std::shared_ptr<IAudioFileReader> reader;
-  uint16_t numChannels = 0;
-  int64_t trimIn = 0;
-  {
-    std::lock_guard<std::mutex> lock(m_audioFilesMutex);
-    auto it = m_audioFiles.find(handle);
-    if (it == m_audioFiles.end()) {
-      return SessionGraphError::ClipNotRegistered;
-    }
-    reader = it->second.reader;
-    numChannels = it->second.metadata.num_channels;
-    trimIn = it->second.trimInSamples;
+  std::lock_guard<std::mutex> lock(m_audioFilesMutex);
+  auto it = m_audioFiles.find(handle);
+  if (it == m_audioFiles.end()) {
+    return SessionGraphError::ClipNotRegistered;
+  }
+  return ensurePreparedSourceLocked(it->second);
+}
+
+SessionGraphError TransportController::ensurePreparedSourceLocked(AudioFileEntry& entry) {
+  // ORP134 G1: build the realtime playback source on the CONTROL thread. All
+  // decode/resample/file I/O happens here (or on the stream worker) - the
+  // audio thread only ever memcpy-reads the published source.
+  if (entry.source) {
+    return SessionGraphError::OK;
   }
 
-  if (!reader || !reader->isOpen() || numChannels == 0 || numChannels > MAX_FILE_CHANNELS) {
+  const uint16_t numChannels = entry.metadata.num_channels;
+  if (!entry.reader || !entry.reader->isOpen() || numChannels == 0 ||
+      numChannels > MAX_FILE_CHANNELS) {
     return SessionGraphError::NotReady;
   }
 
-  SessionGraphError seekResult = reader->seek(trimIn);
-  if (seekResult != SessionGraphError::OK) {
-    return seekResult;
+  const int64_t lengthFrames = entry.metadata.duration_samples;
+  if (lengthFrames <= m_preparedSourceMaxFrames) {
+    // Short clip: decode the whole file (engine-rate; entry.reader is already
+    // wrapped in the ORP127 G6 resampler when rates differ).
+    auto prepared = PreparedClipSource::decode(*entry.reader, numChannels, lengthFrames);
+    if (!prepared) {
+      return SessionGraphError::InternalError;
+    }
+    entry.source = prepared;
+    return SessionGraphError::OK;
   }
 
-  float scratch[MAX_FILE_CHANNELS] = {};
-  auto readResult = reader->readSamples(scratch, 1);
-  if (!readResult.isOk()) {
-    return readResult.error;
+  // Long file: stream through a fixed page ring. Prefill the window at the
+  // trim IN synchronously so playback starts without an initial underrun,
+  // then hand the source to the background worker for steady-state refills.
+  auto streaming = std::make_shared<StreamingClipSource>(entry.reader, numChannels, lengthFrames);
+  streaming->prefill(entry.trimInSamples);
+  if (!m_streamWorker) {
+    m_streamWorker = std::make_unique<MediaStreamWorker>();
   }
-
-  return reader->seek(trimIn);
+  m_streamWorker->attach(streaming);
+  entry.source = streaming;
+  return SessionGraphError::OK;
 }
 
 SessionGraphError TransportController::updateClipTrimPoints(ClipHandle handle,

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -4,6 +4,7 @@
 #include "audio_io/resampling_audio_file_reader.h" // ORP127 G6: SRC decorator
 #include "session/session_graph.h"                 // For SessionGraph
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstring>
 
@@ -181,22 +182,11 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
   }
 
   // Post Start command to audio thread
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  // Check if queue is full
-  if (nextIndex == m_commandReadIndex.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  TransportCommand& cmd = m_commands[writeIndex];
+  TransportCommand cmd{};
   cmd.type = TransportCommand::Type::Start;
   cmd.handle = handle;
-  cmd.startContext = context; // Move shared_ptr into command
-
-  m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-
-  return SessionGraphError::OK;
+  cmd.startContext = context;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::stopClip(ClipHandle handle) {
@@ -205,68 +195,31 @@ SessionGraphError TransportController::stopClip(ClipHandle handle) {
     return SessionGraphError::InvalidHandle;
   }
 
-  // Post command to audio thread
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  // Check if queue is full
-  if (nextIndex == m_commandReadIndex.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  TransportCommand& cmd = m_commands[writeIndex];
+  TransportCommand cmd{};
   cmd.type = TransportCommand::Type::Stop;
   cmd.handle = handle;
-  cmd.startContext = nullptr;
-  cmd.data.groupIndex = 0;
-  m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-
-  return SessionGraphError::OK;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::stopAllClips() {
-  // Post command to audio thread
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  // Check if queue is full
-  if (nextIndex == m_commandReadIndex.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  TransportCommand& cmd = m_commands[writeIndex];
+  TransportCommand cmd{};
   cmd.type = TransportCommand::Type::StopAll;
   cmd.handle = 0;
-  cmd.startContext = nullptr;
-  cmd.data.groupIndex = 0;
-  m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-
-  return SessionGraphError::OK;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::stopAllInGroup(uint8_t groupIndex) {
-  // Validate group index (0-3 for 4 Clip Groups)
-  if (groupIndex >= 4) {
-    return SessionGraphError::InvalidParameter;
-  }
-
-  // Post command to audio thread
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  // Check if queue is full
-  if (nextIndex == m_commandReadIndex.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  TransportCommand& cmd = m_commands[writeIndex];
-  cmd.type = TransportCommand::Type::StopGroup;
-  cmd.handle = 0;
-  cmd.startContext = nullptr;
-  cmd.data.groupIndex = groupIndex;
-  m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-
-  return SessionGraphError::OK;
+  // ORP133 G2: Deprecated — group-stop is a host concern, not a transport one.
+  //
+  // The transport has never had a clip→group mapping (the former StopGroup
+  // command arm was a silent no-op blocked on "get clip group assignments from
+  // SessionGraph"). Grouping lives with the host: Clip Composer models its own
+  // playgroups and scopes chokes with stopOtherClips() (the ORP127 G7
+  // host-neutral primitive), and the routing matrix's channel groups are a
+  // mixing topology, not a playback-control one. Rather than keep a public
+  // method that silently does nothing, this now reports the truth.
+  (void)groupIndex;
+  return SessionGraphError::NotSupported;
 }
 
 SessionGraphError TransportController::stopOtherClips(ClipHandle exceptHandle) {
@@ -634,11 +587,12 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
 
       if (fadeProgress >= fadeOutSampleCount) {
         // Fade-out complete, remove clip
-        postCallback([this, handle = clip.handle, pos = getCurrentPosition()]() {
-          if (m_callback) {
-            m_callback->onClipStopped(handle, pos);
-          }
-        });
+        TransportEvent event{};
+        event.type = TransportEventType::ClipStopped;
+        event.handle = clip.handle;
+        event.voiceId = clip.voiceId;
+        event.position = getCurrentPosition();
+        postTransportEvent(event);
 
         removeActiveClip(clip.handle);
         continue; // Don't increment i, we just removed this clip
@@ -662,12 +616,13 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
         // ORP097 Bug 7 Fix: Mark that clip has looped (prevents fade-in/out on subsequent loops)
         clip.hasLoopedOnce = true;
 
-        // Post loop callback
-        postCallback([this, handle = clip.handle, pos = getCurrentPosition()]() {
-          if (m_callback) {
-            m_callback->onClipLooped(handle, pos);
-          }
-        });
+        // Post loop event
+        TransportEvent event{};
+        event.type = TransportEventType::ClipLooped;
+        event.handle = clip.handle;
+        event.voiceId = clip.voiceId;
+        event.position = getCurrentPosition();
+        postTransportEvent(event);
 
         // Continue playback (don't remove clip, don't increment i)
         ++i;
@@ -712,11 +667,11 @@ void TransportController::processCommands() {
       // ORP127 G5: honor the clip's voice policy when firing.
       if (cmd.startContext) {
         startVoiceWithMode(cmd.startContext);
-        postCallback([this, handle = cmd.handle, pos = getCurrentPosition()]() {
-          if (m_callback) {
-            m_callback->onClipStarted(handle, pos);
-          }
-        });
+        TransportEvent event{};
+        event.type = TransportEventType::ClipStarted;
+        event.handle = cmd.handle;
+        event.position = getCurrentPosition();
+        postTransportEvent(event);
       }
     } break;
 
@@ -750,11 +705,6 @@ void TransportController::processCommands() {
           m_activeClips[i].fadeOutStartPos = m_activeClips[i].currentSample;
         }
       }
-      break;
-
-    case TransportCommand::Type::StopGroup:
-      // TODO: Get clip group assignments from SessionGraph
-      // For now, this is a no-op
       break;
 
     case TransportCommand::Type::UpdateTrim:
@@ -861,15 +811,13 @@ void TransportController::processCommands() {
       }
 
       if (foundAnyVoice) {
-        postCallback([this, handle = cmd.handle, trimIn]() {
-          if (m_callback) {
-            TransportPosition pos;
-            pos.samples = trimIn;
-            pos.seconds = static_cast<double>(trimIn) / static_cast<double>(m_sampleRate);
-            pos.beats = 0.0;
-            m_callback->onClipRestarted(handle, pos);
-          }
-        });
+        TransportEvent event{};
+        event.type = TransportEventType::ClipRestarted;
+        event.handle = cmd.handle;
+        event.position.samples = trimIn;
+        event.position.seconds = static_cast<double>(trimIn) / static_cast<double>(m_sampleRate);
+        event.position.beats = 0.0;
+        postTransportEvent(event);
       }
     } break;
 
@@ -890,15 +838,13 @@ void TransportController::processCommands() {
       }
 
       if (foundAnyVoice) {
-        postCallback([this, handle = cmd.handle, position]() {
-          if (m_callback) {
-            TransportPosition pos;
-            pos.samples = position;
-            pos.seconds = static_cast<double>(position) / static_cast<double>(m_sampleRate);
-            pos.beats = 0.0;
-            m_callback->onClipSeeked(handle, pos);
-          }
-        });
+        TransportEvent event{};
+        event.type = TransportEventType::ClipSeeked;
+        event.handle = cmd.handle;
+        event.position.samples = position;
+        event.position.seconds = static_cast<double>(position) / static_cast<double>(m_sampleRate);
+        event.position.beats = 0.0;
+        postTransportEvent(event);
       }
     } break;
 
@@ -1108,13 +1054,14 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
     if (oldest) {
       uint32_t oldestVoiceId = oldest->voiceId;
 
-      // Post callback that voice was stopped (for UI tracking)
+      // Post event that voice was stopped (for UI tracking)
       // Note: Callback reports handle, not specific voiceId (UI tracks per-handle, not per-voice)
-      postCallback([this, handle, pos = getCurrentPosition()]() {
-        if (m_callback) {
-          m_callback->onClipStopped(handle, pos);
-        }
-      });
+      TransportEvent event{};
+      event.type = TransportEventType::ClipStopped;
+      event.handle = handle;
+      event.voiceId = oldestVoiceId;
+      event.position = getCurrentPosition();
+      postTransportEvent(event);
 
       removeActiveVoice(oldestVoiceId);
     }
@@ -1292,7 +1239,27 @@ void TransportController::removeActiveClip(ClipHandle handle) {
 
 SessionGraphError TransportController::postCommand(const TransportCommand& command) {
   // ORP127 G1: Single choke point for UI → audio-thread commands. SPSC ring;
-  // UI thread is the sole producer, audio thread the sole consumer.
+  // ONE control thread is the sole producer, the audio thread the sole
+  // consumer. Every control-mutating entry point funnels through here (ORP133
+  // G3), so the debug producer check below covers the whole mutation surface.
+#ifndef NDEBUG
+  {
+    // ORP133 G3: enforce the single-producer contract in debug builds. The
+    // first producer thread claims the queue; any later post from a different
+    // thread is a contract violation (hosts with multiple control sources must
+    // funnel through a single dispatcher — see ITransportController docs).
+    std::thread::id expected{};
+    const std::thread::id self = std::this_thread::get_id();
+    if (!m_commandProducerThread.compare_exchange_strong(expected, self,
+                                                         std::memory_order_relaxed) &&
+        expected != self) {
+      assert(false &&
+             "TransportController: control-mutating methods must be called from a single "
+             "control thread (SPSC command queue). Funnel UI/MIDI/OSC through one dispatcher.");
+    }
+  }
+#endif
+
   size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
   size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
 
@@ -1331,47 +1298,68 @@ void TransportController::publishVoiceSnapshot() {
   m_snapshotIndex.store(back, std::memory_order_release);
 }
 
-void TransportController::postCallback(std::function<void()> callback) {
-  // ORP121 C-03: Lock-free SPSC callback queue
-  // Audio thread writes to ring buffer (no mutex, no blocking)
+void TransportController::postTransportEvent(const TransportEvent& event) {
+  // ORP121 C-03 / ORP133 G1: Lock-free SPSC event queue
+  // Audio thread writes POD events to the ring buffer (no mutex, no blocking,
+  // no std::function construction/destruction on the audio thread)
   //
   // Memory ordering rationale:
-  // - relaxed for same-thread reads (writeIdx in postCallback)
+  // - relaxed for same-thread reads (writeIdx in postTransportEvent)
   // - acquire for cross-thread reads (readIdx check for full detection)
-  // - release for writes (ensures callback data visible before index update)
+  // - release for writes (ensures event data visible before index update)
 
   size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_relaxed);
   size_t nextIdx = (writeIdx + 1) & (CALLBACK_QUEUE_SIZE - 1); // Mask for wrap (power of 2)
 
   // Check if queue full (read index caught up)
   if (nextIdx == m_callbackReadIndex.load(std::memory_order_acquire)) {
-    // Queue full - drop callback (better than blocking audio thread)
+    // Queue full - drop event (better than blocking audio thread)
     // Increment dropped callback counter for diagnostics
     m_droppedCallbackCount.fetch_add(1, std::memory_order_relaxed);
     return;
   }
 
-  m_callbackRing[writeIdx] = std::move(callback);
+  m_eventRing[writeIdx] = event;
   m_callbackWriteIndex.store(nextIdx, std::memory_order_release);
 }
 
 void TransportController::processCallbacks() {
-  // ORP121 C-03: Lock-free SPSC callback queue
-  // UI thread reads from ring buffer (no mutex, no blocking)
+  // ORP121 C-03 / ORP133 G1: Lock-free SPSC event queue
+  // UI thread reads POD events from the ring buffer (no mutex, no blocking)
+  // and translates them into the host's ITransportCallback virtuals. Events
+  // are dispatched strictly in ring (emission) order.
   //
   // Memory ordering rationale:
   // - relaxed for same-thread reads (readIdx in processCallbacks)
-  // - acquire for cross-thread reads (writeIdx to see all pending callbacks)
-  // - release for writes (ensures slot cleared before index update)
+  // - acquire for cross-thread reads (writeIdx to see all pending events)
+  // - release for the read-index update (frees the slots for the producer)
 
   size_t readIdx = m_callbackReadIndex.load(std::memory_order_relaxed);
   size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_acquire);
 
   while (readIdx != writeIdx) {
-    auto& callback = m_callbackRing[readIdx];
-    if (callback) {
-      callback();
-      callback = nullptr; // Clear slot to release captured resources
+    const TransportEvent& event = m_eventRing[readIdx];
+    if (m_callback) {
+      switch (event.type) {
+      case TransportEventType::ClipStarted:
+        m_callback->onClipStarted(event.handle, event.position);
+        break;
+      case TransportEventType::ClipStopped:
+        m_callback->onClipStopped(event.handle, event.position);
+        break;
+      case TransportEventType::ClipLooped:
+        m_callback->onClipLooped(event.handle, event.position);
+        break;
+      case TransportEventType::ClipRestarted:
+        m_callback->onClipRestarted(event.handle, event.position);
+        break;
+      case TransportEventType::ClipSeeked:
+        m_callback->onClipSeeked(event.handle, event.position);
+        break;
+      case TransportEventType::BufferUnderrun:
+        m_callback->onBufferUnderrun(event.position);
+        break;
+      }
     }
     readIdx = (readIdx + 1) & (CALLBACK_QUEUE_SIZE - 1);
   }
@@ -1530,21 +1518,12 @@ SessionGraphError TransportController::updateClipTrimPoints(ClipHandle handle,
   }
 
   // Post command to audio thread for thread-safe update (ORP115)
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  if (nextIndex != m_commandReadIndex.load(std::memory_order_acquire)) {
-    TransportCommand& cmd = m_commands[writeIndex];
-    cmd.type = TransportCommand::Type::UpdateTrim;
-    cmd.handle = handle;
-    cmd.data.trim.in = trimInSamples;
-    cmd.data.trim.out = trimOutSamples;
-    m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-  } else {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  return SessionGraphError::OK;
+  TransportCommand cmd{};
+  cmd.type = TransportCommand::Type::UpdateTrim;
+  cmd.handle = handle;
+  cmd.data.trim.in = trimInSamples;
+  cmd.data.trim.out = trimOutSamples;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::updateClipFades(ClipHandle handle, double fadeInSeconds,
@@ -1614,23 +1593,14 @@ SessionGraphError TransportController::updateClipFades(ClipHandle handle, double
   }
 
   // Post command to audio thread for thread-safe update (ORP115)
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  if (nextIndex != m_commandReadIndex.load(std::memory_order_acquire)) {
-    TransportCommand& cmd = m_commands[writeIndex];
-    cmd.type = TransportCommand::Type::UpdateFade;
-    cmd.handle = handle;
-    cmd.data.fade.inSeconds = fadeInSeconds;
-    cmd.data.fade.outSeconds = fadeOutSeconds;
-    cmd.data.fade.inCurve = fadeInCurve;
-    cmd.data.fade.outCurve = fadeOutCurve;
-    m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-  } else {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  return SessionGraphError::OK;
+  TransportCommand cmd{};
+  cmd.type = TransportCommand::Type::UpdateFade;
+  cmd.handle = handle;
+  cmd.data.fade.inSeconds = fadeInSeconds;
+  cmd.data.fade.outSeconds = fadeOutSeconds;
+  cmd.data.fade.inCurve = fadeInCurve;
+  cmd.data.fade.outCurve = fadeOutCurve;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::getClipTrimPoints(ClipHandle handle, int64_t& trimInSamples,
@@ -1696,20 +1666,11 @@ SessionGraphError TransportController::updateClipGain(ClipHandle handle, float g
   }
 
   // Post command to audio thread for thread-safe update (ORP115)
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  if (nextIndex != m_commandReadIndex.load(std::memory_order_acquire)) {
-    TransportCommand& cmd = m_commands[writeIndex];
-    cmd.type = TransportCommand::Type::UpdateGain;
-    cmd.handle = handle;
-    cmd.data.gainDb = gainDb;
-    m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-  } else {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  return SessionGraphError::OK;
+  TransportCommand cmd{};
+  cmd.type = TransportCommand::Type::UpdateGain;
+  cmd.handle = handle;
+  cmd.data.gainDb = gainDb;
+  return postCommand(cmd);
 }
 
 SessionGraphError TransportController::setClipLoopMode(ClipHandle handle, bool shouldLoop) {
@@ -1728,20 +1689,11 @@ SessionGraphError TransportController::setClipLoopMode(ClipHandle handle, bool s
   }
 
   // Post command to audio thread for thread-safe update (ORP115)
-  size_t writeIndex = m_commandWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIndex = (writeIndex + 1) % MAX_COMMANDS;
-
-  if (nextIndex != m_commandReadIndex.load(std::memory_order_acquire)) {
-    TransportCommand& cmd = m_commands[writeIndex];
-    cmd.type = TransportCommand::Type::UpdateLoop;
-    cmd.handle = handle;
-    cmd.data.booleanValue = shouldLoop;
-    m_commandWriteIndex.store(nextIndex, std::memory_order_release);
-  } else {
-    return SessionGraphError::InternalError; // Queue full
-  }
-
-  return SessionGraphError::OK;
+  TransportCommand cmd{};
+  cmd.type = TransportCommand::Type::UpdateLoop;
+  cmd.handle = handle;
+  cmd.data.booleanValue = shouldLoop;
+  return postCommand(cmd);
 }
 
 int64_t TransportController::getClipPosition(ClipHandle handle) const {

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "clip_source.h" // ORP134 G1: prepared/streaming realtime sources
+
 #include <orpheus/audio_file_reader.h>
 #include <orpheus/routing_matrix.h>
 #include <orpheus/transport_controller.h>
@@ -24,7 +26,9 @@ class SessionGraph;
 /// Contains all immutable state required to start a clip
 struct ClipPlaybackContext {
   ClipHandle handle;
-  std::shared_ptr<IAudioFileReader> reader;
+  // ORP134 G1: the audio thread reads decoded PCM through an IClipSource
+  // (prepared memory or streaming pages) — never through an IAudioFileReader.
+  std::shared_ptr<IClipSource> source;
 
   // Metadata snapshot at start time
   int64_t trimInSamples;
@@ -162,12 +166,14 @@ struct ActiveClip {
 
   uint16_t numChannels; // Number of channels in audio file
 
-  // Thread-safe reader reference (captured from AudioFileEntry when clip starts)
-  // Using shared_ptr provides reference-counted lifetime management:
-  // - Audio thread holds reference until clip stops
-  // - Reader can't be destroyed while audio thread is still using it
+  // ORP134 G1: thread-safe clip-source reference (captured from AudioFileEntry
+  // when the clip starts). shared_ptr gives reference-counted lifetime:
+  // - Audio thread holds a reference until the voice is removed
+  // - The source can't be destroyed while the audio thread still reads it
   // - Atomic refcount increment/decrement (lock-free, broadcast-safe)
-  std::shared_ptr<IAudioFileReader> reader;
+  // Reads are position-explicit (source->read(currentSample, ...)), so
+  // multiple voices of one clip no longer contend over a shared file cursor.
+  std::shared_ptr<IClipSource> source;
 
   // ORP127 G5: per-voice policy (copied from the clip's configured VoiceMode at
   // Start). Governs how a fresh fire interacts with this voice.
@@ -284,8 +290,19 @@ public:
   /// @return Error code
   SessionGraphError registerClipAudio(ClipHandle handle, const std::string& file_path) override;
 
-  /// Prewarm clip reader outside the audio callback.
+  /// ORP134 G1: Build the clip's realtime playback source outside the audio
+  /// callback — whole-file PCM in memory for short clips, a worker-fed page
+  /// ring for long ones. Hosts should call this after registration/metadata
+  /// changes and before latency-critical playback; startClip() prepares
+  /// lazily (on the control thread) when it wasn't called.
   SessionGraphError prepareClipAudio(ClipHandle handle) override;
+
+  /// ORP134 G1 test hook: clips whose engine-rate length exceeds this many
+  /// frames stream from a page ring instead of being fully decoded to memory.
+  /// Control thread only; affects sources prepared after the call.
+  void setPreparedSourceMaxFrames(int64_t maxFrames) {
+    m_preparedSourceMaxFrames = maxFrames;
+  }
 
 private:
   /// Process pending commands from UI thread
@@ -448,14 +465,32 @@ private:
     // SDK's historical polyphonic behavior).
     VoiceMode voiceMode = VoiceMode::Polyphonic;
 
+    // ORP134 G1: the realtime playback source built by prepareClipAudio()
+    // (or lazily by startClip). The reader above remains the background
+    // decode/metadata handle; the audio thread only ever touches `source`.
+    std::shared_ptr<IClipSource> source;
+
     // Cue points (stored sorted by position)
     std::vector<CuePoint> cuePoints;
   };
   std::mutex m_audioFilesMutex;
   std::unordered_map<ClipHandle, AudioFileEntry> m_audioFiles;
 
+  /// ORP134 G1: Ensure entry.source exists (decode-to-memory or streaming
+  /// ring). Control thread only; caller holds m_audioFilesMutex.
+  SessionGraphError ensurePreparedSourceLocked(AudioFileEntry& entry);
+
   // Routing matrix for final mix (audio thread processes, UI thread configures)
   std::unique_ptr<IRoutingMatrix> m_routingMatrix;
+
+  // ORP134 G1: streaming-source machinery. The worker thread is created
+  // lazily when the first streaming source is prepared (short-clip-only hosts
+  // never spawn it). DEFAULT_PREPARED_SOURCE_MAX_FRAMES ≈ 30s @ 48k: below
+  // it, clips decode fully to memory (soundboard case, ~11.5 MB stereo max);
+  // above it, they stream through a fixed page ring (long beds, songs).
+  static constexpr int64_t DEFAULT_PREPARED_SOURCE_MAX_FRAMES = 48000ll * 30;
+  int64_t m_preparedSourceMaxFrames{DEFAULT_PREPARED_SOURCE_MAX_FRAMES};
+  std::unique_ptr<MediaStreamWorker> m_streamWorker; // guarded by m_audioFilesMutex
 
   // Per-clip buffers (audio thread only, pre-allocated)
   static constexpr size_t MAX_BUFFER_FRAMES = 2048;

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -9,6 +9,8 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <thread>
+#include <type_traits>
 #include <unordered_map>
 
 namespace orpheus {
@@ -45,7 +47,8 @@ struct TransportCommand {
     Start,
     Stop,
     StopAll,
-    StopGroup,
+    // ORP133 G2: StopGroup removed — the transport has no clip→group mapping;
+    // hosts implement scoped group-stop with stopOtherClips() + host grouping.
     UpdateTrim,
     UpdateFade,
     UpdateGain,
@@ -68,8 +71,6 @@ struct TransportCommand {
   std::shared_ptr<ClipPlaybackContext> startContext;
 
   union {
-    uint8_t groupIndex; // For StopGroup command
-
     struct {
       int64_t in;
       int64_t out;
@@ -172,6 +173,37 @@ struct ActiveClip {
   // Start). Governs how a fresh fire interacts with this voice.
   VoiceMode voiceMode{VoiceMode::Polyphonic};
 };
+
+/// ORP133 G1: Transport event kinds posted from the audio thread.
+///
+/// The audio→UI callback ring used to carry std::function<void()> payloads,
+/// which violates the callback rule in docs/REALTIME_AUDIT.md ("no
+/// std::function ownership changes on realtime callbacks") — small-object
+/// optimization may hide the allocation today, but it is not a portable
+/// guarantee. The ring now carries these fixed POD events; processCallbacks()
+/// translates them into the host's ITransportCallback virtuals on the UI
+/// thread. Event emission points map 1:1 to the old postCallback sites, so
+/// callback ordering and timing are unchanged.
+enum class TransportEventType : uint8_t {
+  ClipStarted = 0,
+  ClipStopped,
+  ClipLooped,
+  ClipRestarted,
+  ClipSeeked,
+  BufferUnderrun
+};
+
+/// ORP133 G1: Trivially-copyable event payload for the audio→UI SPSC ring.
+struct TransportEvent {
+  TransportEventType type;
+  ClipHandle handle;          ///< Subject clip (0 for transport-wide events)
+  uint32_t voiceId;           ///< Voice instance when known, 0 otherwise (diagnostic)
+  TransportPosition position; ///< Position payload delivered to the callback
+};
+
+static_assert(std::is_trivially_copyable_v<TransportEvent>,
+              "TransportEvent must stay POD: it is copied through the audio->UI ring "
+              "with no construction/destruction on the audio thread");
 
 /// ORP127 G1: Immutable per-voice snapshot published by the audio thread for
 /// lock-free UI-thread queries. Plain-old-data so it can be copied wholesale
@@ -301,8 +333,10 @@ private:
   /// @note Deprecated: Use removeActiveVoice() for multi-voice
   void removeActiveClip(ClipHandle handle);
 
-  /// Post callback to UI thread
-  void postCallback(std::function<void()> callback);
+  /// ORP133 G1: Post a POD transport event to the UI thread (audio thread only).
+  /// Drops the event (and bumps m_droppedCallbackCount) if the ring is full —
+  /// never blocks the audio thread.
+  void postTransportEvent(const TransportEvent& event);
 
   /// Calculate fade gain based on curve type
   /// @param normalizedPosition Position in fade (0.0 to 1.0)
@@ -361,16 +395,25 @@ private:
   // Transport position (audio thread writes, UI thread reads)
   std::atomic<int64_t> m_currentSample{0};
 
-  // ORP121 C-03: Lock-free callback queue (Audio → UI thread)
+  // ORP121 C-03 / ORP133 G1: Lock-free event queue (Audio → UI thread)
   // SPSC ring buffer: Audio thread writes, UI thread reads - no contention
-  // Power of 2 size for efficient modulo via bitwise AND
+  // Power of 2 size for efficient modulo via bitwise AND. Payload is the POD
+  // TransportEvent (no std::function on the audio thread).
   static constexpr size_t CALLBACK_QUEUE_SIZE = 256;
-  std::array<std::function<void()>, CALLBACK_QUEUE_SIZE> m_callbackRing;
+  std::array<TransportEvent, CALLBACK_QUEUE_SIZE> m_eventRing{};
   std::atomic<size_t> m_callbackWriteIndex{0};
   std::atomic<size_t> m_callbackReadIndex{0};
 
   // Diagnostic counter for dropped callbacks (queue overflow)
   std::atomic<uint32_t> m_droppedCallbackCount{0};
+
+#ifndef NDEBUG
+  // ORP133 G3: Debug-only enforcement of the command queue's single-producer
+  // contract. The first thread to post a command is captured; any command
+  // posted from a different thread afterwards trips an assert. Compiled out in
+  // release builds (zero cost on the fast path).
+  mutable std::atomic<std::thread::id> m_commandProducerThread{};
+#endif
 
   // ORP127 G4: default clip-gain smoothing time. 5ms is a broadcast-console
   // norm (Yamaha CL/QL fader smoothing sits ~10ms); short enough to feel

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,13 @@ if(Python3_Interpreter_FOUND)
     COMMAND ${Python3_EXECUTABLE}
       ${CMAKE_SOURCE_DIR}/tools/realtime_audit.py
       --root ${CMAKE_SOURCE_DIR})
+
+  # ORP133 G6: docs-path validation (broken internal links, references to the
+  # extracted apps/clip-composer subdir, removed CMake options).
+  add_test(NAME docs_path_audit
+    COMMAND ${Python3_EXECUTABLE}
+      ${CMAKE_SOURCE_DIR}/tools/docs_path_audit.py
+      --root ${CMAKE_SOURCE_DIR})
 endif()
 
 # Session tests (including Scene Manager)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,10 +108,14 @@ endif()
 
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
+  # ORP134 G1: the streaming-reader migration landed, so the audit runs as the
+  # STRICT gate (ORP136 §2.1 / §4 "fail closed on realtime"): a reintroduced
+  # audio-thread read is a hard failure, not a tracked-debt report.
   add_test(NAME realtime_static_audit
     COMMAND ${Python3_EXECUTABLE}
       ${CMAKE_SOURCE_DIR}/tools/realtime_audit.py
-      --root ${CMAKE_SOURCE_DIR})
+      --root ${CMAKE_SOURCE_DIR}
+      --fail-known-debt)
 
   # ORP133 G6: docs-path validation (broken internal links, references to the
   # extracted apps/clip-composer subdir, removed CMake options).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,27 @@ if(NOT ORP_BUILD_SHARED_CORE)
   set_tests_properties(abi_link PROPERTIES DISABLED ON)
 endif()
 
+# On Linux with GCC + ASan, dlopen-ing sanitized shared libraries from the
+# (unsanitized) abi_link host aborts with "ASan runtime does not come first in
+# initial library list" unless the runtime is preloaded. Mirror of the macOS
+# DYLD_INSERT_LIBRARIES block below.
+if(UNIX
+   AND NOT APPLE
+   AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+   AND CMAKE_BUILD_TYPE MATCHES "Debug"
+   AND ORP_ENABLE_ASAN)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libasan.so
+    OUTPUT_VARIABLE ASAN_SO_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(EXISTS "${ASAN_SO_PATH}")
+    set_tests_properties(abi_link PROPERTIES
+      ENVIRONMENT "LD_PRELOAD=${ASAN_SO_PATH}"
+    )
+  endif()
+endif()
+
 # On macOS with ASan + dlopen, interceptors fail unless the ASan dylib is
 # preloaded via DYLD_INSERT_LIBRARIES. Detect the runtime path from the
 # compiler and set it for the abi_link test (which uses dlopen internally).

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -40,6 +40,47 @@ target_include_directories(scrub_resampler_test
 
 add_test(NAME scrub_resampler_test COMMAND scrub_resampler_test)
 
+# ORP134 G7: lock-free input ring + capture-stream contract. Links audio_io
+# so the capture->disk pairing test can use the reader/writer when available.
+add_executable(audio_input_test
+    audio_input_test.cpp
+)
+
+target_link_libraries(audio_input_test
+    PRIVATE
+        orpheus_audio_io
+        orpheus_session
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(audio_input_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+add_test(NAME audio_input_test COMMAND audio_input_test)
+
+# ORP134 G6: analysis facade (standalone; links audio_utils only)
+add_executable(audio_analysis_test
+    audio_analysis_test.cpp
+)
+
+target_link_libraries(audio_analysis_test
+    PRIVATE
+        orpheus_audio_utils
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(audio_analysis_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/tests
+)
+
+add_test(NAME audio_analysis_test COMMAND audio_analysis_test)
+
 # Find libsndfile (needed because orpheus_audio_io is static)
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -112,6 +112,33 @@ if(SNDFILE_FOUND)
 
     add_test(NAME audio_file_reader_test COMMAND audio_file_reader_test)
 
+    # ORP134 G5 / FTR007: IAudioFileWriter round-trip tests (requires libsndfile)
+    add_executable(audio_file_writer_test
+        audio_file_writer_test.cpp
+    )
+
+    target_link_libraries(audio_file_writer_test
+        PRIVATE
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+            ${SNDFILE_LIBRARIES}
+    )
+
+    if(SNDFILE_LIBRARY_DIRS)
+        target_link_directories(audio_file_writer_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+    endif()
+
+    target_include_directories(audio_file_writer_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+            ${CMAKE_SOURCE_DIR}/tests
+    )
+
+    add_test(NAME audio_file_writer_test COMMAND audio_file_writer_test)
+
     # Waveform processor tests (requires libsndfile)
     add_executable(waveform_processor_test
         waveform_processor_test.cpp

--- a/tests/audio_io/audio_analysis_test.cpp
+++ b/tests/audio_io/audio_analysis_test.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G6: analysis facade tests — FFT/STFT correctness on known signals,
+// LUFS parity with the wrapped LoudnessMeter (facade must not diverge from
+// the primitive it wraps), spectral features, onsets, and waveform proxy.
+
+#include <orpheus/audio_analysis.h>
+#include <orpheus/loudness_meter.h>
+
+#include "../support/synth.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace orpheus;
+using namespace orpheus::analysis;
+using orpheus::tests::support::GenerateSine;
+
+namespace {
+constexpr uint32_t kRate = 48000;
+}
+
+TEST(AnalysisFftTest, SinePeaksAtItsFrequencyBin) {
+  // 750 Hz = bin 64 exactly at fftSize 4096 @ 48k (48000/4096 = 11.71875 Hz;
+  // 750 / 11.71875 = 64) — no spectral leakage even rectangular.
+  auto sine = GenerateSine(4096, kRate, 750, 0.5f);
+  Spectrum spectrum =
+      magnitudeSpectrum(sine.data(), sine.size(), kRate, WindowType::Rectangular, 4096);
+
+  ASSERT_EQ(spectrum.fftSize, 4096u);
+  ASSERT_EQ(spectrum.magnitudes.size(), 2049u);
+  size_t peakBin = 0;
+  for (size_t i = 1; i < spectrum.magnitudes.size(); ++i) {
+    if (spectrum.magnitudes[i] > spectrum.magnitudes[peakBin]) {
+      peakBin = i;
+    }
+  }
+  EXPECT_EQ(peakBin, 64u);
+  EXPECT_NEAR(static_cast<float>(peakBin) * spectrum.binHz, 750.0f, spectrum.binHz);
+}
+
+TEST(AnalysisFftTest, ZeroPadsNonPowerOfTwoInput) {
+  auto sine = GenerateSine(3000, kRate, 750, 0.5f);
+  Spectrum spectrum = magnitudeSpectrum(sine.data(), sine.size(), kRate);
+  EXPECT_EQ(spectrum.fftSize, 4096u); // next power of two
+  EXPECT_GT(spectrum.magnitudes[64], 0.0f);
+}
+
+TEST(AnalysisFftTest, DcSignalConcentratesInBinZero) {
+  std::vector<float> dc(1024, 0.5f);
+  Spectrum spectrum = magnitudeSpectrum(dc.data(), dc.size(), kRate, WindowType::Rectangular, 1024);
+  size_t peakBin = 1;
+  for (size_t i = 1; i < spectrum.magnitudes.size(); ++i) {
+    if (spectrum.magnitudes[i] > spectrum.magnitudes[peakBin]) {
+      peakBin = i;
+    }
+  }
+  EXPECT_GT(spectrum.magnitudes[0], spectrum.magnitudes[peakBin] * 100.0f);
+}
+
+TEST(AnalysisStftTest, FrameGeometryAndContent) {
+  auto sine = GenerateSine(48000, kRate, 750, 0.5f);
+  StftResult result = stft(sine.data(), sine.size(), kRate, 1024, 512);
+
+  EXPECT_EQ(result.frameSize, 1024u);
+  EXPECT_EQ(result.hopSize, 512u);
+  EXPECT_GT(result.frames.size(), 90u); // ~ (48000-1024)/512 frames
+  // Every steady-state frame peaks at the 750 Hz bin (bin 16 at 1024).
+  const size_t expectedBin = 16;
+  const auto& mid = result.frames[result.frames.size() / 2];
+  size_t peakBin = 0;
+  for (size_t i = 1; i < mid.size(); ++i) {
+    if (mid[i] > mid[peakBin]) {
+      peakBin = i;
+    }
+  }
+  EXPECT_EQ(peakBin, expectedBin);
+}
+
+TEST(AnalysisStatsTest, RmsAndPeakOfKnownSignals) {
+  std::vector<float> dc(1000, 0.5f);
+  EXPECT_FLOAT_EQ(rms(dc.data(), dc.size()), 0.5f);
+  EXPECT_FLOAT_EQ(peak(dc.data(), dc.size()), 0.5f);
+
+  auto sine = GenerateSine(48000, kRate, 1000, 0.5f);
+  EXPECT_NEAR(rms(sine.data(), sine.size()), 0.5f / std::sqrt(2.0f), 0.005f);
+  EXPECT_NEAR(peak(sine.data(), sine.size()), 0.5f, 0.01f);
+
+  EXPECT_FLOAT_EQ(rms(nullptr, 0), 0.0f);
+}
+
+TEST(AnalysisLufsTest, FacadeMatchesWrappedLoudnessMeter) {
+  // The facade must WRAP LoudnessMeter, not re-implement it: identical input
+  // must produce the identical integrated LUFS.
+  auto left = GenerateSine(96000, kRate, 440, 0.25f);
+  auto right = GenerateSine(96000, kRate, 554, 0.25f);
+  std::vector<float> interleaved(left.size() * 2);
+  for (size_t i = 0; i < left.size(); ++i) {
+    interleaved[i * 2] = left[i];
+    interleaved[i * 2 + 1] = right[i];
+  }
+
+  LoudnessMeter reference(kRate);
+  reference.processBuffer(left.data(), right.data(), left.size());
+
+  const float facade = integratedLufs(interleaved.data(), left.size(), 2, kRate);
+  EXPECT_FLOAT_EQ(facade, reference.integratedLufs());
+  EXPECT_LT(facade, 0.0f);
+  EXPECT_GT(facade, -40.0f);
+
+  EXPECT_FLOAT_EQ(integratedLufs(nullptr, 0, 2, kRate), LoudnessMeter::kSilenceLufs);
+}
+
+TEST(AnalysisSpectralTest, CentroidTracksFrequencyAndRolloffBoundsIt) {
+  auto low = GenerateSine(8192, kRate, 200, 0.5f);
+  auto high = GenerateSine(8192, kRate, 4000, 0.5f);
+
+  Spectrum lowSpec = magnitudeSpectrum(low.data(), low.size(), kRate);
+  Spectrum highSpec = magnitudeSpectrum(high.data(), high.size(), kRate);
+
+  const float lowCentroid = spectralCentroidHz(lowSpec);
+  const float highCentroid = spectralCentroidHz(highSpec);
+  EXPECT_LT(lowCentroid, highCentroid);
+  EXPECT_NEAR(highCentroid, 4000.0f, 800.0f); // leakage skews slightly
+
+  // Rolloff of a pure tone sits at/just above the tone.
+  const float rolloff = spectralRolloffHz(highSpec, 0.85f);
+  EXPECT_NEAR(rolloff, 4000.0f, 200.0f);
+
+  EXPECT_FLOAT_EQ(spectralCentroidHz(Spectrum{}), 0.0f);
+}
+
+TEST(AnalysisOnsetTest, DetectsToneBurstsNearTheirStarts) {
+  // Silence, then a burst at 1.0s, silence, burst at 2.0s.
+  std::vector<float> signal(3 * kRate, 0.0f);
+  auto burst = GenerateSine(kRate / 4, kRate, 880, 0.8f);
+  std::copy(burst.begin(), burst.end(), signal.begin() + 1 * kRate);
+  std::copy(burst.begin(), burst.end(), signal.begin() + 2 * kRate);
+
+  auto onsets = detectOnsets(signal.data(), signal.size(), kRate);
+  ASSERT_GE(onsets.size(), 2u);
+
+  auto nearest = [&](int64_t target) {
+    int64_t best = onsets.front();
+    for (int64_t onset : onsets) {
+      if (std::llabs(onset - target) < std::llabs(best - target)) {
+        best = onset;
+      }
+    }
+    return best;
+  };
+  EXPECT_LT(std::llabs(nearest(1 * kRate) - 1 * kRate), 2048);
+  EXPECT_LT(std::llabs(nearest(2 * kRate) - 2 * kRate), 2048);
+}
+
+TEST(AnalysisWaveformTest, PeaksProxyBoundsTheSignal) {
+  auto sine = GenerateSine(48000, kRate, 100, 0.5f);
+  WaveformPeaks proxy = waveformPeaks(sine.data(), sine.size(), 1, 100);
+
+  ASSERT_EQ(proxy.minPeaks.size(), 100u);
+  ASSERT_EQ(proxy.maxPeaks.size(), 100u);
+  for (size_t i = 0; i < 100; ++i) {
+    EXPECT_LE(proxy.minPeaks[i], proxy.maxPeaks[i]);
+    EXPECT_GE(proxy.minPeaks[i], -0.51f);
+    EXPECT_LE(proxy.maxPeaks[i], 0.51f);
+  }
+  // 100 Hz over 1s = 100 cycles; ~1 cycle per pixel → every pixel spans
+  // nearly the full amplitude.
+  EXPECT_LT(proxy.minPeaks[50], -0.4f);
+  EXPECT_GT(proxy.maxPeaks[50], 0.4f);
+}

--- a/tests/audio_io/audio_file_writer_test.cpp
+++ b/tests/audio_io/audio_file_writer_test.cpp
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G5 / FTR007: IAudioFileWriter round-trip tests.
+//
+// The acceptance gate: the writer produces WAV/AIFF/FLAC files that the SDK's
+// own reader opens and decodes back to the written samples — bit-exact for
+// float encodings, within one quantization step for integer encodings.
+
+#include <orpheus/audio_file_reader.h>
+#include <orpheus/audio_file_writer.h>
+
+#include "../support/fnv1a64.hpp"
+#include "../support/synth.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+using orpheus::tests::support::Fnv1a64;
+using orpheus::tests::support::GenerateSine;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr size_t kFrames = 24000; // 0.5s
+
+std::vector<float> makeStereoTestSignal(size_t frames) {
+  auto left = GenerateSine(frames, kSampleRate, 440, 0.5f);
+  auto right = GenerateSine(frames, kSampleRate, 554, 0.4f);
+  std::vector<float> interleaved(frames * 2, 0.0f);
+  for (size_t i = 0; i < frames; ++i) {
+    interleaved[i * 2] = left[i];
+    interleaved[i * 2 + 1] = right[i];
+  }
+  return interleaved;
+}
+
+class AudioFileWriterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    m_writer = createAudioFileWriter();
+    if (!m_writer) {
+      GTEST_SKIP() << "libsndfile not available - writer disabled";
+    }
+    m_tempDir = std::filesystem::temp_directory_path() / "orp134_writer";
+    std::filesystem::create_directories(m_tempDir);
+    m_signal = makeStereoTestSignal(kFrames);
+  }
+
+  void TearDown() override {
+    m_writer.reset();
+    std::error_code ec;
+    std::filesystem::remove_all(m_tempDir, ec);
+  }
+
+  // Write the standard stereo signal with the given config, read it back
+  // with the SDK reader, and return the decoded samples + metadata.
+  void roundTrip(const AudioFileWriterConfig& config, const std::string& name,
+                 std::vector<float>& decoded, AudioFileMetadata& readMeta) {
+    const std::string path = (m_tempDir / name).string();
+
+    ASSERT_EQ(m_writer->open(path, config), SessionGraphError::OK);
+    EXPECT_TRUE(m_writer->isOpen());
+
+    // Write in uneven chunks to exercise streaming appends.
+    size_t written = 0;
+    const size_t chunks[] = {1000, 3000, 7000, 13000};
+    for (size_t chunk : chunks) {
+      auto result = m_writer->writeSamples(m_signal.data() + written * 2, chunk);
+      ASSERT_TRUE(result.isOk()) << result.errorMessage;
+      EXPECT_EQ(result.value, chunk);
+      written += chunk;
+    }
+    ASSERT_EQ(written, kFrames);
+    EXPECT_EQ(m_writer->getFramesWritten(), static_cast<int64_t>(kFrames));
+
+    AudioFileMetadata writeMeta = m_writer->metadata();
+    EXPECT_EQ(writeMeta.format, config.format);
+    EXPECT_EQ(writeMeta.sample_rate, config.sample_rate);
+    EXPECT_EQ(writeMeta.num_channels, config.num_channels);
+    EXPECT_EQ(writeMeta.duration_samples, static_cast<int64_t>(kFrames));
+
+    ASSERT_EQ(m_writer->close(), SessionGraphError::OK);
+    EXPECT_FALSE(m_writer->isOpen());
+    EXPECT_EQ(m_writer->close(), SessionGraphError::OK) << "close must be idempotent";
+
+    // Read back with the SDK's own reader.
+    auto reader = createAudioFileReader();
+    ASSERT_NE(reader, nullptr);
+    auto openResult = reader->open(path);
+    ASSERT_TRUE(openResult.isOk()) << openResult.errorMessage;
+    readMeta = openResult.value;
+
+    decoded.assign(kFrames * 2, 0.0f);
+    auto readResult = reader->readSamples(decoded.data(), kFrames);
+    ASSERT_TRUE(readResult.isOk());
+    ASSERT_EQ(readResult.value, kFrames);
+    reader->close();
+  }
+
+  static float maxAbsDiff(const std::vector<float>& a, const std::vector<float>& b) {
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < a.size(); ++i) {
+      maxDiff = std::max(maxDiff, std::abs(a[i] - b[i]));
+    }
+    return maxDiff;
+  }
+
+  std::unique_ptr<IAudioFileWriter> m_writer;
+  std::filesystem::path m_tempDir;
+  std::vector<float> m_signal;
+};
+
+} // namespace
+
+TEST_F(AudioFileWriterTest, WavFloat32RoundTripIsBitExact) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::WAV;
+  config.sample_format = AudioSampleFormat::Float32;
+
+  std::vector<float> decoded;
+  AudioFileMetadata meta;
+  roundTrip(config, "rt_float32.wav", decoded, meta);
+
+  EXPECT_EQ(meta.format, AudioFileFormat::WAV);
+  EXPECT_EQ(meta.sample_rate, kSampleRate);
+  EXPECT_EQ(meta.num_channels, 2u);
+  EXPECT_EQ(meta.duration_samples, static_cast<int64_t>(kFrames));
+  EXPECT_EQ(meta.bit_depth, 32u);
+
+  // Float in, float container, float out: bit-exact.
+  EXPECT_EQ(Fnv1a64(decoded), Fnv1a64(m_signal)) << "float32 WAV round-trip must be bit-exact";
+}
+
+TEST_F(AudioFileWriterTest, WavInt16RoundTripWithinOneLsb) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::WAV;
+  config.sample_format = AudioSampleFormat::Int16;
+
+  std::vector<float> decoded;
+  AudioFileMetadata meta;
+  roundTrip(config, "rt_int16.wav", decoded, meta);
+
+  EXPECT_EQ(meta.bit_depth, 16u);
+  EXPECT_LT(maxAbsDiff(decoded, m_signal), 1.5f / 32768.0f)
+      << "int16 quantization error exceeded one LSB";
+}
+
+TEST_F(AudioFileWriterTest, AiffInt24RoundTripWithinOneLsb) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::AIFF;
+  config.sample_format = AudioSampleFormat::Int24;
+
+  std::vector<float> decoded;
+  AudioFileMetadata meta;
+  roundTrip(config, "rt_int24.aiff", decoded, meta);
+
+  EXPECT_EQ(meta.format, AudioFileFormat::AIFF);
+  EXPECT_EQ(meta.bit_depth, 24u);
+  EXPECT_LT(maxAbsDiff(decoded, m_signal), 1.5f / 8388608.0f)
+      << "int24 quantization error exceeded one LSB";
+}
+
+TEST_F(AudioFileWriterTest, FlacInt16RoundTripIsLossless) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::FLAC;
+  config.sample_format = AudioSampleFormat::Int16;
+
+  std::vector<float> decoded;
+  AudioFileMetadata meta;
+  roundTrip(config, "rt_flac16.flac", decoded, meta);
+
+  EXPECT_EQ(meta.format, AudioFileFormat::FLAC);
+  EXPECT_EQ(meta.duration_samples, static_cast<int64_t>(kFrames));
+  // FLAC is lossless over the quantized integers: same tolerance as int16 PCM.
+  EXPECT_LT(maxAbsDiff(decoded, m_signal), 1.5f / 32768.0f);
+}
+
+TEST_F(AudioFileWriterTest, FlacRejectsFloat32) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::FLAC;
+  config.sample_format = AudioSampleFormat::Float32;
+
+  EXPECT_EQ(m_writer->open((m_tempDir / "bad.flac").string(), config),
+            SessionGraphError::InvalidParameter)
+      << "FLAC is integer-only; Float32 must be rejected at open";
+  EXPECT_FALSE(m_writer->isOpen());
+}
+
+TEST_F(AudioFileWriterTest, UnsupportedContainerIsRejected) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::MP3;
+  EXPECT_EQ(m_writer->open((m_tempDir / "bad.mp3").string(), config),
+            SessionGraphError::NotSupported);
+
+  config.format = AudioFileFormat::OGG;
+  EXPECT_EQ(m_writer->open((m_tempDir / "bad.ogg").string(), config),
+            SessionGraphError::NotSupported);
+}
+
+TEST_F(AudioFileWriterTest, InvalidConfigsAreRejected) {
+  AudioFileWriterConfig config;
+  config.sample_rate = 0;
+  EXPECT_EQ(m_writer->open((m_tempDir / "bad_rate.wav").string(), config),
+            SessionGraphError::InvalidParameter);
+
+  config = AudioFileWriterConfig{};
+  config.num_channels = 0;
+  EXPECT_EQ(m_writer->open((m_tempDir / "bad_ch.wav").string(), config),
+            SessionGraphError::InvalidParameter);
+
+  EXPECT_EQ(m_writer->open("", AudioFileWriterConfig{}), SessionGraphError::InvalidParameter);
+}
+
+TEST_F(AudioFileWriterTest, WriteBeforeOpenReturnsNotReady) {
+  float dummy[2] = {0.0f, 0.0f};
+  auto result = m_writer->writeSamples(dummy, 1);
+  EXPECT_EQ(result.error, SessionGraphError::NotReady);
+  EXPECT_EQ(m_writer->getFramesWritten(), 0);
+}
+
+TEST_F(AudioFileWriterTest, MonoAndHighRateConfigs) {
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::WAV;
+  config.sample_format = AudioSampleFormat::Float32;
+  config.num_channels = 1;
+  config.sample_rate = 96000;
+
+  auto mono = GenerateSine(4800, 96000, 1000, 0.5f);
+  const std::string path = (m_tempDir / "mono96k.wav").string();
+
+  ASSERT_EQ(m_writer->open(path, config), SessionGraphError::OK);
+  auto writeResult = m_writer->writeSamples(mono.data(), mono.size());
+  ASSERT_TRUE(writeResult.isOk());
+  ASSERT_EQ(m_writer->close(), SessionGraphError::OK);
+
+  auto reader = createAudioFileReader();
+  auto openResult = reader->open(path);
+  ASSERT_TRUE(openResult.isOk());
+  EXPECT_EQ(openResult.value.num_channels, 1u);
+  EXPECT_EQ(openResult.value.sample_rate, 96000u);
+  EXPECT_EQ(openResult.value.duration_samples, static_cast<int64_t>(mono.size()));
+
+  std::vector<float> decoded(mono.size(), 0.0f);
+  auto readResult = reader->readSamples(decoded.data(), mono.size());
+  ASSERT_TRUE(readResult.isOk());
+  EXPECT_EQ(Fnv1a64(decoded), Fnv1a64(mono));
+}

--- a/tests/audio_io/audio_input_test.cpp
+++ b/tests/audio_io/audio_input_test.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G7: lock-free input ring + capture-stream contract tests.
+//
+// Covers single-threaded ring semantics (wrap, all-or-nothing overflow,
+// partial drains), a threaded producer/consumer stress with sequence
+// verification (run under TSAN in the sanitizer builds), and the G5+G7
+// pairing that makes "capture → disk" an SDK-supported path.
+
+#include <orpheus/audio_file_reader.h>
+#include <orpheus/audio_file_writer.h>
+#include <orpheus/audio_input.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace orpheus;
+
+// ---------------------------------------------------------------------------
+// Ring semantics (single-threaded)
+// ---------------------------------------------------------------------------
+
+TEST(AudioInputRingTest, CapacityRoundsUpToPowerOfTwo) {
+  AudioInputRing ring(2, 1000);
+  EXPECT_EQ(ring.capacityFrames(), 1024u);
+  EXPECT_EQ(ring.numChannels(), 2u);
+  EXPECT_EQ(ring.framesAvailable(), 0u);
+}
+
+TEST(AudioInputRingTest, WriteReadRoundTrip) {
+  AudioInputRing ring(2, 256);
+  std::vector<float> input(64 * 2);
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<float>(i);
+  }
+
+  EXPECT_EQ(ring.write(input.data(), 64), 64u);
+  EXPECT_EQ(ring.framesAvailable(), 64u);
+
+  std::vector<float> output(64 * 2, 0.0f);
+  EXPECT_EQ(ring.read(output.data(), 64), 64u);
+  EXPECT_EQ(ring.framesAvailable(), 0u);
+  EXPECT_EQ(input, output);
+}
+
+TEST(AudioInputRingTest, WrapAroundPreservesFrameOrder) {
+  AudioInputRing ring(1, 8); // tiny ring to force wrapping
+  float chunk[4];
+  float out[4];
+
+  float next = 0.0f;
+  float expected = 0.0f;
+  for (int round = 0; round < 10; ++round) {
+    for (float& sample : chunk) {
+      sample = next++;
+    }
+    ASSERT_EQ(ring.write(chunk, 4), 4u);
+    ASSERT_EQ(ring.read(out, 4), 4u);
+    for (float sample : out) {
+      EXPECT_EQ(sample, expected);
+      expected += 1.0f;
+    }
+  }
+}
+
+TEST(AudioInputRingTest, OverflowDropsWholeBufferAndCounts) {
+  AudioInputRing ring(1, 8);
+  float data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+  EXPECT_EQ(ring.write(data, 6), 6u);
+  // 2 frames free; a 4-frame write must drop ENTIRELY (no partial frames).
+  EXPECT_EQ(ring.write(data, 4), 0u);
+  EXPECT_EQ(ring.overflowCount(), 1u);
+  EXPECT_EQ(ring.framesAvailable(), 6u);
+
+  // A write that exactly fits still succeeds.
+  EXPECT_EQ(ring.write(data, 2), 2u);
+  EXPECT_EQ(ring.framesAvailable(), 8u);
+}
+
+TEST(AudioInputRingTest, PartialReadsDrainInOrder) {
+  AudioInputRing ring(1, 16);
+  float data[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  ASSERT_EQ(ring.write(data, 10), 10u);
+
+  float out[4] = {};
+  EXPECT_EQ(ring.read(out, 4), 4u);
+  EXPECT_EQ(out[0], 0.0f);
+  EXPECT_EQ(out[3], 3.0f);
+  EXPECT_EQ(ring.read(out, 4), 4u);
+  EXPECT_EQ(out[0], 4.0f);
+  EXPECT_EQ(ring.read(out, 4), 2u); // only 2 left
+  EXPECT_EQ(out[0], 8.0f);
+  EXPECT_EQ(out[1], 9.0f);
+  EXPECT_EQ(ring.read(out, 4), 0u); // empty
+}
+
+// ---------------------------------------------------------------------------
+// Threaded stress (SPSC contract; meaningful under TSAN)
+// ---------------------------------------------------------------------------
+
+TEST(AudioInputRingTest, ThreadedProducerConsumerPreservesSequence) {
+  AudioInputRing ring(1, 4096);
+  constexpr int64_t kTotalFrames = 480000; // 10s @ 48k
+  constexpr size_t kChunk = 480;
+
+  std::atomic<bool> failed{false};
+
+  std::thread producer([&]() {
+    float chunk[kChunk];
+    int64_t produced = 0;
+    while (produced < kTotalFrames) {
+      for (size_t i = 0; i < kChunk; ++i) {
+        chunk[i] = static_cast<float>(produced + static_cast<int64_t>(i));
+      }
+      if (ring.write(chunk, kChunk) == kChunk) {
+        produced += static_cast<int64_t>(kChunk);
+      } else {
+        std::this_thread::yield(); // ring full — consumer will catch up
+      }
+    }
+  });
+
+  float out[kChunk];
+  int64_t consumed = 0;
+  while (consumed < kTotalFrames && !failed.load()) {
+    const size_t got = ring.read(out, kChunk);
+    for (size_t i = 0; i < got; ++i) {
+      if (out[i] != static_cast<float>(consumed + static_cast<int64_t>(i))) {
+        failed.store(true);
+        break;
+      }
+    }
+    if (got == 0) {
+      std::this_thread::yield();
+    }
+    consumed += static_cast<int64_t>(got);
+  }
+
+  producer.join();
+  EXPECT_FALSE(failed.load()) << "frame sequence corrupted across threads";
+  EXPECT_EQ(consumed, kTotalFrames);
+}
+
+// ---------------------------------------------------------------------------
+// IAudioInputStream contract + the G5 pairing (capture → disk)
+// ---------------------------------------------------------------------------
+
+TEST(AudioInputStreamTest, StreamWrapsRingContract) {
+  AudioInputStreamConfig config;
+  config.num_channels = 2;
+  config.sample_rate = 48000;
+  config.ring_capacity_frames = 1024;
+
+  auto stream = createAudioInputStream(config);
+  ASSERT_NE(stream, nullptr);
+  EXPECT_EQ(stream->numChannels(), 2u);
+  EXPECT_EQ(stream->sampleRate(), 48000u);
+  EXPECT_EQ(stream->framesPending(), 0u);
+
+  std::vector<float> frames(256 * 2, 0.25f);
+  EXPECT_EQ(stream->capture(frames.data(), 256), 256u);
+  EXPECT_EQ(stream->framesPending(), 256u);
+
+  std::vector<float> drained(256 * 2, 0.0f);
+  EXPECT_EQ(stream->drain(drained.data(), 256), 256u);
+  EXPECT_EQ(drained, frames);
+  EXPECT_EQ(stream->overflowCount(), 0u);
+}
+
+TEST(AudioInputStreamTest, CaptureToDiskPairsWithAudioFileWriter) {
+  auto writer = createAudioFileWriter();
+  if (!writer) {
+    GTEST_SKIP() << "libsndfile not available";
+  }
+
+  const auto dir = std::filesystem::temp_directory_path() / "orp134_capture";
+  std::filesystem::create_directories(dir);
+  const std::string path = (dir / "capture.wav").string();
+
+  AudioInputStreamConfig config;
+  config.num_channels = 1;
+  auto stream = createAudioInputStream(config);
+
+  AudioFileWriterConfig writerConfig;
+  writerConfig.format = AudioFileFormat::WAV;
+  writerConfig.sample_format = AudioSampleFormat::Float32;
+  writerConfig.num_channels = 1;
+  ASSERT_EQ(writer->open(path, writerConfig), SessionGraphError::OK);
+
+  // "Audio thread" pushes 1s of a ramp; "writer thread" drains to disk.
+  constexpr size_t kTotal = 48000;
+  std::thread audio([&]() {
+    float chunk[480];
+    for (size_t produced = 0; produced < kTotal;) {
+      for (size_t i = 0; i < 480; ++i) {
+        chunk[i] = static_cast<float>(produced + i) / static_cast<float>(kTotal);
+      }
+      if (stream->capture(chunk, 480) == 480) {
+        produced += 480;
+      } else {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  size_t written = 0;
+  float buffer[1024];
+  while (written < kTotal) {
+    const size_t got = stream->drain(buffer, 1024);
+    if (got == 0) {
+      std::this_thread::yield();
+      continue;
+    }
+    auto result = writer->writeSamples(buffer, got);
+    ASSERT_TRUE(result.isOk());
+    written += got;
+  }
+  audio.join();
+  ASSERT_EQ(writer->close(), SessionGraphError::OK);
+
+  // Read back and verify the captured ramp survived intact.
+  auto reader = createAudioFileReader();
+  auto opened = reader->open(path);
+  ASSERT_TRUE(opened.isOk());
+  EXPECT_EQ(opened.value.duration_samples, static_cast<int64_t>(kTotal));
+
+  std::vector<float> decoded(kTotal, 0.0f);
+  auto read = reader->readSamples(decoded.data(), kTotal);
+  ASSERT_TRUE(read.isOk());
+  ASSERT_EQ(read.value, kTotal);
+  for (size_t i = 0; i < kTotal; i += 4801) {
+    EXPECT_FLOAT_EQ(decoded[i], static_cast<float>(i) / static_cast<float>(kTotal));
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+}

--- a/tests/cmake/find_package/main.cpp
+++ b/tests/cmake/find_package/main.cpp
@@ -1,9 +1,24 @@
 // SPDX-License-Identifier: MIT
 #include <orpheus/abi.h>
 
+// ORP134 G2 installed-header compile gate: the identity/time/media headers
+// must be self-contained when consumed from an installed SDK.
+#include <orpheus/audio_file_writer.h>
+#include <orpheus/identity.h>
+#include <orpheus/media_model.h>
+#include <orpheus/time_domain.h>
+
 int main() {
   uint32_t major = 0;
   uint32_t minor = 0;
+  // ORP134 G2: exercise the installed identity/time primitives.
+  const orpheus::ClipId clip = orpheus::ClipId::fromRaw(1);
+  const orpheus::TimeRange range =
+      orpheus::TimeRange::fromStartLength(orpheus::TimePoint::fromSamples(0), 48000);
+  if (!clip.isValid() || range.length() != 48000) {
+    return 1;
+  }
+
   const auto* session = orpheus_session_abi_v1(ORPHEUS_ABI_MAJOR, &major, &minor);
   return session == nullptr || major != ORPHEUS_ABI_MAJOR || minor != ORPHEUS_ABI_MINOR;
 }

--- a/tests/render_tracks_basic.cpp
+++ b/tests/render_tracks_basic.cpp
@@ -447,3 +447,49 @@ TEST(RenderTracksBasic, Float32PreservesSubLsbContent) {
   EXPECT_NEAR(mean, expected, tolerance);
   EXPECT_NEAR(max_abs, expected, tolerance);
 }
+
+// ORP134 G4 / ORP136 §2.3: dithered offline renders must be seed-deterministic.
+// RenderSpec is the render-job descriptor (sample rate, bit depth, channel
+// layout, dither + seed, output target); this test proves that the SAME job
+// descriptor reproduces byte-identical output — including the dither noise —
+// and that the dither seed is honored (a different seed changes the bytes).
+// Together with the undithered golden hashes above and the transport-side
+// block-size-invariance gate (transport_render_hash_test), this closes the
+// "same input -> same output, always" loop for the offline path.
+TEST(RenderTracksBasic, DitheredRenderIsSeedDeterministic) {
+  const auto* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+
+  auto renderHash = [&](const std::string& runName, std::uint64_t seed) {
+    ScratchDir scratch(std::string(test_info->name()) + "_" + runName);
+    auto ctx = MakeBaseContext(test_info->name(), 48000, 16, 1);
+    ctx.spec.output_directory = scratch.path();
+    ctx.spec.dither = true;
+    ctx.spec.dither_seed = seed;
+
+    orpheus::core::render::Clip clip;
+    clip.start_beats = 0.0;
+    clip.samples.push_back(
+        support::GenerateSine(ctx.spec.sample_rate_hz, ctx.spec.sample_rate_hz, 330u, 0.25f));
+
+    orpheus::core::render::Track track;
+    track.name = "dither_tone";
+    track.clips.push_back(std::move(clip));
+    ctx.tracks.push_back(std::move(track));
+
+    const auto outputs = orpheus::core::render::render_tracks(ctx.session, ctx.tracks, ctx.spec);
+    EXPECT_EQ(outputs.size(), 1u);
+    const support::ParsedWav wav = support::ReadWav(outputs.front());
+    return support::Fnv1a64(wav.data);
+  };
+
+  constexpr std::uint64_t kSeedA = 0x9e3779b97f4a7c15ull;
+  constexpr std::uint64_t kSeedB = 0x0123456789abcdefull;
+
+  const std::uint64_t first = renderHash("run1", kSeedA);
+  const std::uint64_t second = renderHash("run2", kSeedA);
+  const std::uint64_t reseeded = renderHash("run3", kSeedB);
+
+  EXPECT_EQ(first, second) << "same render job (incl. dither seed) must reproduce identical bytes";
+  EXPECT_NE(first, reseeded) << "a different dither seed must change the dither noise "
+                                "(otherwise the seed in the job descriptor is dead)";
+}

--- a/tests/routing/CMakeLists.txt
+++ b/tests/routing/CMakeLists.txt
@@ -109,3 +109,27 @@ if(TARGET Orpheus::diagnostics)
         COMMAND loudness_meter_test
     )
 endif()
+
+
+# ORP134 G3: graph-neutral routing seam + soundboard facade
+add_executable(audio_graph_test
+    audio_graph_test.cpp
+)
+
+target_link_libraries(audio_graph_test
+    PRIVATE
+        orpheus_routing
+        orpheus_session
+        GTest::gtest
+        GTest::gtest_main
+)
+
+target_include_directories(audio_graph_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+add_test(
+    NAME audio_graph_test
+    COMMAND audio_graph_test
+)

--- a/tests/routing/audio_graph_test.cpp
+++ b/tests/routing/audio_graph_test.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G3: graph-neutral routing seam tests.
+//
+// The seam's proof: the soundboard facade expressed in the neutral
+// vocabulary must translate to EXACTLY the routing configuration the
+// transport hard-wires today (transport_controller.cpp: MAX_ACTIVE_CLIPS*2
+// channels, 4 groups, stereo out) — and the vocabulary must also express
+// the downstream shapes (FourTrack buses, FreqFinder taps) that motivated it.
+
+#include <orpheus/audio_graph.h>
+#include <orpheus/routing_matrix.h>
+
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace orpheus;
+using namespace orpheus::graph;
+
+TEST(AudioGraphTest, SoundboardFacadeMatchesTransportTopology) {
+  // The transport's constructor values: 32 active clips x stereo pairs,
+  // 4 groups, stereo output.
+  SoundboardTopology topology;
+  topology.numClipSources = 32;
+  topology.numGroups = 4;
+  topology.numOutputs = 2;
+
+  GraphDescription graph = makeSoundboardGraph(topology);
+  std::string error;
+  ASSERT_TRUE(graph.validate(&error)) << error;
+
+  // 32 sources + 4 group buses + master + sink
+  EXPECT_EQ(graph.nodes.size(), 32u + 4u + 1u + 1u);
+  // 32 source->group + 4 group->master + master->sink
+  EXPECT_EQ(graph.connections.size(), 32u + 4u + 1u);
+
+  RoutingConfig config = toRoutingConfig(graph);
+  EXPECT_EQ(config.num_channels, 64); // MAX_ACTIVE_CLIPS * 2 (stereo pairs)
+  EXPECT_EQ(config.num_groups, 4);    // soundboard default
+  EXPECT_EQ(config.num_outputs, 2);   // stereo master out
+
+  // The translated config must initialize the REAL matrix.
+  auto matrix = createRoutingMatrix();
+  ASSERT_NE(matrix, nullptr);
+  EXPECT_EQ(matrix->initialize(config), SessionGraphError::OK);
+}
+
+TEST(AudioGraphTest, ValidateCatchesStructuralErrors) {
+  GraphDescription graph;
+  graph.nodes.push_back({1, NodeKind::Source, ChannelLayout::Stereo, "clip"});
+  graph.nodes.push_back({2, NodeKind::Sink, ChannelLayout::Stereo, "out"});
+
+  // Dangling connection target.
+  graph.connections.push_back({1, 99, ConnectionKind::Direct, 0.0f});
+  std::string error;
+  EXPECT_FALSE(graph.validate(&error));
+  EXPECT_NE(error.find("unknown node"), std::string::npos);
+
+  // Sources cannot have inputs.
+  graph.connections.clear();
+  graph.connections.push_back({2, 1, ConnectionKind::Direct, 0.0f});
+  EXPECT_FALSE(graph.validate(&error));
+
+  // Duplicate ids.
+  graph.connections.clear();
+  graph.nodes.push_back({1, NodeKind::Bus, ChannelLayout::Stereo, "dup"});
+  EXPECT_FALSE(graph.validate(&error));
+  EXPECT_NE(error.find("duplicate"), std::string::npos);
+
+  // Id 0 reserved.
+  GraphDescription zero;
+  zero.nodes.push_back({0, NodeKind::Bus, ChannelLayout::Stereo, "bad"});
+  EXPECT_FALSE(zero.validate(&error));
+}
+
+TEST(AudioGraphTest, VocabularyExpressesFourTrackBuses) {
+  // FourTrack shape: N mono track sources -> track bus -> master; a monitor
+  // bus fed by a SEND; an export sink fed from master.
+  GraphDescription graph;
+  NodeId next = 1;
+  const NodeId trackBus = next++;
+  const NodeId monitorBus = next++;
+  const NodeId master = next++;
+  const NodeId device = next++;
+  const NodeId exportSink = next++;
+  graph.nodes.push_back({trackBus, NodeKind::Bus, ChannelLayout::Stereo, "tracks"});
+  graph.nodes.push_back({monitorBus, NodeKind::Bus, ChannelLayout::Stereo, "monitor"});
+  graph.nodes.push_back({master, NodeKind::Bus, ChannelLayout::Stereo, "master"});
+  graph.nodes.push_back({device, NodeKind::Sink, ChannelLayout::Stereo, "device out"});
+  graph.nodes.push_back({exportSink, NodeKind::Sink, ChannelLayout::Stereo, "export"});
+
+  for (int track = 0; track < 4; ++track) {
+    const NodeId source = next++;
+    graph.nodes.push_back(
+        {source, NodeKind::Source, ChannelLayout::Mono, "track " + std::to_string(track)});
+    graph.connections.push_back({source, trackBus, ConnectionKind::Direct, 0.0f});
+    graph.connections.push_back({source, monitorBus, ConnectionKind::Send, -6.0f});
+  }
+  graph.connections.push_back({trackBus, master, ConnectionKind::Direct, 0.0f});
+  graph.connections.push_back({master, device, ConnectionKind::Direct, 0.0f});
+  graph.connections.push_back({master, exportSink, ConnectionKind::Direct, 0.0f});
+
+  std::string error;
+  EXPECT_TRUE(graph.validate(&error)) << error;
+}
+
+TEST(AudioGraphTest, VocabularyExpressesFreqFinderTaps) {
+  // FreqFinder shape: one source -> master -> device, with a unity TAP from
+  // the master bus into an analyzer sink.
+  GraphDescription graph;
+  graph.nodes.push_back({1, NodeKind::Source, ChannelLayout::Stereo, "file"});
+  graph.nodes.push_back({2, NodeKind::Bus, ChannelLayout::Stereo, "master"});
+  graph.nodes.push_back({3, NodeKind::Sink, ChannelLayout::Stereo, "device out"});
+  graph.nodes.push_back({4, NodeKind::Sink, ChannelLayout::Stereo, "analyzer"});
+  graph.connections.push_back({1, 2, ConnectionKind::Direct, 0.0f});
+  graph.connections.push_back({2, 3, ConnectionKind::Direct, 0.0f});
+  graph.connections.push_back({2, 4, ConnectionKind::Tap, 0.0f});
+
+  std::string error;
+  EXPECT_TRUE(graph.validate(&error)) << error;
+
+  // Taps must originate from buses/sources, never processors.
+  graph.nodes.push_back({5, NodeKind::Processor, ChannelLayout::Stereo, "eq"});
+  graph.connections.push_back({5, 4, ConnectionKind::Tap, 0.0f});
+  EXPECT_FALSE(graph.validate(&error));
+  EXPECT_NE(error.find("taps"), std::string::npos);
+}

--- a/tests/session/CMakeLists.txt
+++ b/tests/session/CMakeLists.txt
@@ -51,3 +51,28 @@ target_include_directories(identity_time_test
 orpheus_enable_warnings(identity_time_test)
 
 add_test(NAME identity_time_test COMMAND identity_time_test)
+
+# ORP134 G8: scene manager <-> routing matrix wiring (needs orpheus_routing)
+if(TARGET orpheus_routing)
+  add_executable(scene_routing_test
+    scene_routing_test.cpp
+  )
+
+  target_link_libraries(scene_routing_test
+    PRIVATE
+      Orpheus::core
+      orpheus_routing
+      GTest::gtest_main
+  )
+
+  target_include_directories(scene_routing_test
+    PRIVATE
+      ${CMAKE_SOURCE_DIR}/include
+      ${CMAKE_SOURCE_DIR}/src/core
+      ${CMAKE_SOURCE_DIR}/src/core/session
+  )
+
+  orpheus_enable_warnings(scene_routing_test)
+
+  add_test(NAME scene_routing_test COMMAND scene_routing_test)
+endif()

--- a/tests/session/CMakeLists.txt
+++ b/tests/session/CMakeLists.txt
@@ -31,3 +31,23 @@ orpheus_enable_warnings(scene_manager_test)
 
 include(GoogleTest)
 gtest_discover_tests(scene_manager_test)
+
+# ORP134 G2: identity & time-domain primitives (header-only; JSON round-trip)
+add_executable(identity_time_test
+  identity_time_test.cpp
+)
+
+target_link_libraries(identity_time_test
+  PRIVATE
+    Orpheus::core
+    GTest::gtest_main
+)
+
+target_include_directories(identity_time_test
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+orpheus_enable_warnings(identity_time_test)
+
+add_test(NAME identity_time_test COMMAND identity_time_test)

--- a/tests/session/identity_time_test.cpp
+++ b/tests/session/identity_time_test.cpp
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G2: identity & time-domain primitive tests.
+//
+// Covers: strong-ID type safety and hashing, deterministic allocation,
+// JSON serialization round-trips BY ID (the acceptance gate), sample-domain
+// canonical time with derived seconds/beats/timecode views, and the
+// media-model aggregates.
+
+#include <orpheus/identity.h>
+#include <orpheus/json.hpp>
+#include <orpheus/media_model.h>
+#include <orpheus/time_domain.h>
+
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+namespace {
+
+// IDs are 64-bit; the SDK's JSON value stores numbers as double (53-bit
+// mantissa), so IDs serialize as DECIMAL STRINGS. This helper pair is the
+// pattern hosts should copy.
+template <typename Id> std::string idToJsonString(Id id) {
+  return std::to_string(id.raw());
+}
+
+template <typename Id> Id idFromJsonString(const std::string& text) {
+  return Id::fromRaw(std::strtoull(text.c_str(), nullptr, 10));
+}
+
+} // namespace
+
+using namespace orpheus;
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+TEST(IdentityTest, DefaultIsInvalidAndValidIdsCompare) {
+  ClipId none;
+  EXPECT_FALSE(none.isValid());
+  EXPECT_EQ(none, ClipId::invalid());
+  EXPECT_EQ(none.raw(), 0u);
+
+  ClipId a = ClipId::fromRaw(1);
+  ClipId b = ClipId::fromRaw(2);
+  EXPECT_TRUE(a.isValid());
+  EXPECT_NE(a, b);
+  EXPECT_LT(a, b);
+  EXPECT_GE(b, a);
+}
+
+TEST(IdentityTest, StrongTypesDoNotMix) {
+  // Different tag → different type. (Compile-time property, asserted here.)
+  static_assert(!std::is_same_v<ClipId, TrackId>);
+  static_assert(!std::is_same_v<SessionId, MediaId>);
+  static_assert(!std::is_convertible_v<ClipId, TrackId>);
+  static_assert(!std::is_convertible_v<ClipId, uint64_t>);
+  static_assert(!std::is_convertible_v<uint64_t, ClipId>);
+  // Trivially copyable → safe as POD message payload on realtime paths.
+  static_assert(std::is_trivially_copyable_v<ClipId>);
+  static_assert(std::is_trivially_copyable_v<AutomationLaneId>);
+  SUCCEED();
+}
+
+TEST(IdentityTest, HashSupportsUnorderedContainers) {
+  std::unordered_map<ClipId, int> byClip;
+  byClip[ClipId::fromRaw(7)] = 70;
+  byClip[ClipId::fromRaw(9)] = 90;
+  EXPECT_EQ(byClip.at(ClipId::fromRaw(7)), 70);
+  EXPECT_EQ(byClip.at(ClipId::fromRaw(9)), 90);
+}
+
+TEST(IdentityTest, AllocatorIsDeterministicAndMonotonic) {
+  IdAllocator<ClipId> alloc;
+  ClipId first = alloc.allocate();
+  ClipId second = alloc.allocate();
+  EXPECT_EQ(first.raw(), 1u);
+  EXPECT_EQ(second.raw(), 2u);
+
+  // Replay from the same seed → same IDs (determinism rule).
+  IdAllocator<ClipId> replay;
+  EXPECT_EQ(replay.allocate(), first);
+  EXPECT_EQ(replay.allocate(), second);
+
+  // Watermark resume: continue above persisted IDs after a reload.
+  IdAllocator<ClipId> resumed(alloc.nextRaw());
+  EXPECT_EQ(resumed.allocate().raw(), 3u);
+
+  // reserveThrough bumps past foreign IDs seen during deserialization.
+  IdAllocator<ClipId> merged;
+  merged.reserveThrough(ClipId::fromRaw(41));
+  EXPECT_EQ(merged.allocate().raw(), 42u);
+}
+
+TEST(IdentityTest, JsonRoundTripById) {
+  // The acceptance gate: serialization round-trips BY ID, through the SDK's
+  // own JSON parser. IDs travel as decimal strings (64-bit safe; the JSON
+  // number type is a double).
+  IdAllocator<ClipId> clips;
+  IdAllocator<TrackId> tracks;
+
+  ClipId clip = clips.allocate();
+  TrackId track = tracks.allocate();
+
+  std::ostringstream wire;
+  wire << "{\"clip\":\"" << idToJsonString(clip) << "\","
+       << "\"track\":\"" << idToJsonString(track) << "\","
+       << "\"clip_watermark\":\"" << clips.nextRaw() << "\"}";
+
+  const std::string wireText = wire.str();
+  orpheus::json::JsonParser parser(wireText);
+  const orpheus::json::JsonValue doc = parser.Parse();
+  const auto& obj = orpheus::json::ExpectObject(doc, "identity round-trip");
+
+  ClipId clipBack = idFromJsonString<ClipId>(obj.object.at("clip").string);
+  TrackId trackBack = idFromJsonString<TrackId>(obj.object.at("track").string);
+  IdAllocator<ClipId> clipsBack(
+      std::strtoull(obj.object.at("clip_watermark").string.c_str(), nullptr, 10));
+
+  EXPECT_EQ(clipBack, clip);
+  EXPECT_EQ(trackBack, track);
+  // Post-reload allocation continues above every persisted ID.
+  EXPECT_GT(clipsBack.allocate(), clipBack);
+}
+
+TEST(IdentityTest, JsonStringPathPreserves64BitIds) {
+  // Above 2^53 a double-typed JSON number would corrupt the ID; the string
+  // path must not.
+  const uint64_t big = (1ull << 53) + 12345ull;
+  MediaId media = MediaId::fromRaw(big);
+
+  std::ostringstream wire;
+  wire << "{\"media\":\"" << idToJsonString(media) << "\"}";
+
+  const std::string wireText = wire.str();
+  orpheus::json::JsonParser parser(wireText);
+  const auto doc = parser.Parse();
+  MediaId back = idFromJsonString<MediaId>(doc.object.at("media").string);
+  EXPECT_EQ(back, media);
+  EXPECT_EQ(back.raw(), big);
+}
+
+// ---------------------------------------------------------------------------
+// Time domain
+// ---------------------------------------------------------------------------
+
+TEST(TimeDomainTest, SamplesAreCanonical) {
+  constexpr uint32_t kRate = 48000;
+  TimePoint p = TimePoint::fromSamples(96000);
+  EXPECT_EQ(p.samples(), 96000);
+  EXPECT_DOUBLE_EQ(p.toSeconds(kRate), 2.0);
+  EXPECT_DOUBLE_EQ(p.toBeats(120.0, kRate), 4.0);
+
+  // Derived-domain constructors round to the nearest sample.
+  EXPECT_EQ(TimePoint::fromSeconds(2.0, kRate).samples(), 96000);
+  EXPECT_EQ(TimePoint::fromBeats(4.0, 120.0, kRate).samples(), 96000);
+  EXPECT_EQ(TimePoint::fromSeconds(1.0 / 48000.0 * 0.6, kRate).samples(), 1); // rounds up
+}
+
+TEST(TimeDomainTest, ConversionsRoundTripWithinOneSample) {
+  constexpr uint32_t kRate = 48000;
+  constexpr double kTempo = 133.7;
+  for (int64_t samples : {0ll, 1ll, 479ll, 48000ll, 123456789ll}) {
+    TimePoint p = TimePoint::fromSamples(samples);
+    TimePoint viaSeconds = TimePoint::fromSeconds(p.toSeconds(kRate), kRate);
+    TimePoint viaBeats = TimePoint::fromBeats(p.toBeats(kTempo, kRate), kTempo, kRate);
+    EXPECT_LE(std::abs(viaSeconds - p), 1) << "seconds round-trip drifted at " << samples;
+    EXPECT_LE(std::abs(viaBeats - p), 1) << "beats round-trip drifted at " << samples;
+  }
+}
+
+TEST(TimeDomainTest, TimecodeIsIntegerExact) {
+  constexpr uint32_t kRate = 48000;
+  // 1h 02m 03s + 12 frames @ 25fps = 12/25s = 0.48s = 23040 samples
+  const int64_t samples = ((3600 + 120 + 3) * static_cast<int64_t>(kRate)) + 23040;
+  Timecode tc = TimePoint::fromSamples(samples).toTimecode(kRate, 25);
+  EXPECT_EQ(tc.hours, 1);
+  EXPECT_EQ(tc.minutes, 2);
+  EXPECT_EQ(tc.seconds, 3);
+  EXPECT_EQ(tc.frames, 12);
+
+  // Negative time clamps to zero rather than producing negative fields.
+  Timecode neg = TimePoint::fromSamples(-100).toTimecode(kRate, 25);
+  EXPECT_EQ(neg, Timecode{});
+}
+
+TEST(TimeDomainTest, RangesAreHalfOpen) {
+  TimeRange range = TimeRange::fromStartLength(TimePoint::fromSamples(1000), 500);
+  EXPECT_EQ(range.start().samples(), 1000);
+  EXPECT_EQ(range.end().samples(), 1500);
+  EXPECT_EQ(range.length(), 500);
+  EXPECT_FALSE(range.empty());
+
+  EXPECT_TRUE(range.contains(TimePoint::fromSamples(1000))); // inclusive start
+  EXPECT_TRUE(range.contains(TimePoint::fromSamples(1499)));
+  EXPECT_FALSE(range.contains(TimePoint::fromSamples(1500))); // exclusive end
+  EXPECT_FALSE(range.contains(TimePoint::fromSamples(999)));
+}
+
+TEST(TimeDomainTest, OverlapAndIntersection) {
+  TimeRange a = TimeRange::fromStartLength(TimePoint::fromSamples(0), 1000);
+  TimeRange b = TimeRange::fromStartLength(TimePoint::fromSamples(500), 1000);
+  TimeRange c = TimeRange::fromStartLength(TimePoint::fromSamples(2000), 100);
+
+  EXPECT_TRUE(a.overlaps(b));
+  EXPECT_TRUE(b.overlaps(a));
+  EXPECT_FALSE(a.overlaps(c));
+
+  TimeRange ab = a.intersect(b);
+  EXPECT_EQ(ab.start().samples(), 500);
+  EXPECT_EQ(ab.end().samples(), 1000);
+
+  EXPECT_TRUE(a.intersect(c).empty());
+
+  // Adjacent half-open ranges do not overlap.
+  TimeRange d = TimeRange::fromStartEnd(TimePoint::fromSamples(1000), TimePoint::fromSamples(2000));
+  EXPECT_FALSE(a.overlaps(d));
+
+  // Negative length clamps to empty.
+  EXPECT_TRUE(TimeRange::fromStartLength(TimePoint::fromSamples(10), -5).empty());
+}
+
+// ---------------------------------------------------------------------------
+// Media model aggregates
+// ---------------------------------------------------------------------------
+
+TEST(MediaModelTest, TakeSerializationRoundTripsById) {
+  Take take;
+  take.id = ClipId::fromRaw(11);
+  take.track = TrackId::fromRaw(3);
+  take.region.media = MediaId::fromRaw(77);
+  take.region.sourceRange = TimeRange::fromStartLength(TimePoint::fromSamples(480), 96000);
+  take.placedAt = TimePoint::fromSamples(24000);
+  take.index = 2;
+  take.name = "vocal pass 2";
+
+  std::ostringstream wire;
+  wire << "{\"id\":\"" << idToJsonString(take.id) << "\","
+       << "\"track\":\"" << idToJsonString(take.track) << "\","
+       << "\"media\":\"" << idToJsonString(take.region.media) << "\","
+       << "\"src_start\":" << take.region.sourceRange.start().samples() << ","
+       << "\"src_length\":" << take.region.sourceRange.length() << ","
+       << "\"placed_at\":" << take.placedAt.samples() << ","
+       << "\"index\":" << take.index << ","
+       << "\"name\":\"" << take.name << "\"}";
+
+  const std::string wireText = wire.str();
+  orpheus::json::JsonParser parser(wireText);
+  const auto parsed = parser.Parse();
+  const auto& obj = orpheus::json::ExpectObject(parsed, "take round-trip");
+
+  Take back;
+  back.id = idFromJsonString<ClipId>(obj.object.at("id").string);
+  back.track = idFromJsonString<TrackId>(obj.object.at("track").string);
+  back.region.media = idFromJsonString<MediaId>(obj.object.at("media").string);
+  back.region.sourceRange = TimeRange::fromStartLength(
+      TimePoint::fromSamples(static_cast<int64_t>(obj.object.at("src_start").number)),
+      static_cast<int64_t>(obj.object.at("src_length").number));
+  back.placedAt = TimePoint::fromSamples(static_cast<int64_t>(obj.object.at("placed_at").number));
+  back.index = static_cast<uint32_t>(obj.object.at("index").number);
+  back.name = obj.object.at("name").string;
+
+  EXPECT_EQ(back.id, take.id);
+  EXPECT_EQ(back.track, take.track);
+  EXPECT_EQ(back.region, take.region);
+  EXPECT_EQ(back.placedAt, take.placedAt);
+  EXPECT_EQ(back.index, take.index);
+  EXPECT_EQ(back.name, take.name);
+}
+
+TEST(MediaModelTest, LauncherSceneHoldsSlots) {
+  LauncherScene scene;
+  scene.name = "Act 1";
+  scene.slots.push_back({ClipId::fromRaw(5), 0, 2, 3});
+  scene.slots.push_back({ClipId::invalid(), 0, 2, 4}); // empty slot
+
+  EXPECT_EQ(scene.slots.size(), 2u);
+  EXPECT_TRUE(scene.slots[0].clip.isValid());
+  EXPECT_FALSE(scene.slots[1].clip.isValid());
+  EXPECT_EQ(scene.slots[0].row, 2);
+  EXPECT_EQ(scene.slots[0].column, 3);
+}

--- a/tests/session/scene_routing_test.cpp
+++ b/tests/session/scene_routing_test.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// ORP134 G8: scene manager <-> routing matrix wiring.
+//
+// Before this sprint, SceneManager's routing capture/recall existed but was
+// UNREACHABLE: setRoutingMatrix() lived only on the hidden concrete class, so
+// no consumer of createSceneManager() could ever wire it. These tests drive
+// the now-public ISceneManager::setRoutingMatrix() end to end, at Clip
+// Composer scale (multi-scene "tab" switching over group assignments/gains).
+
+#include <orpheus/routing_matrix.h>
+#include <orpheus/scene_manager.h>
+
+#include "session_graph.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+
+namespace {
+
+class SceneRoutingTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    m_graph = std::make_unique<core::SessionGraph>();
+    m_scenes = createSceneManager(m_graph.get());
+    ASSERT_NE(m_scenes, nullptr);
+
+    m_routing = createRoutingMatrix();
+    ASSERT_NE(m_routing, nullptr);
+
+    RoutingConfig config;
+    config.num_channels = 16;
+    config.num_groups = 4;
+    config.num_outputs = 2;
+    ASSERT_EQ(m_routing->initialize(config), SessionGraphError::OK);
+
+    // Wire the matrix through the PUBLIC interface (the G8 fix).
+    m_scenes->setRoutingMatrix(m_routing.get());
+  }
+
+  void assignTopology(uint8_t groupForEvenChannels, float gainDbGroup0) {
+    for (uint8_t ch = 0; ch < 16; ++ch) {
+      m_routing->setChannelGroup(ch,
+                                 (ch % 2 == 0) ? groupForEvenChannels : static_cast<uint8_t>(3));
+    }
+    GroupConfig group;
+    group.gain_db = gainDbGroup0;
+    m_routing->configureGroup(0, group);
+  }
+
+  std::unique_ptr<core::SessionGraph> m_graph;
+  std::unique_ptr<ISceneManager> m_scenes;
+  std::unique_ptr<IRoutingMatrix> m_routing;
+};
+
+} // namespace
+
+TEST_F(SceneRoutingTest, CaptureRecordsRoutingState) {
+  assignTopology(1, -6.0f);
+
+  const std::string sceneId = m_scenes->captureScene("Act 1");
+  ASSERT_FALSE(sceneId.empty());
+
+  const SceneSnapshot* scene = m_scenes->getScene(sceneId);
+  ASSERT_NE(scene, nullptr);
+  ASSERT_EQ(scene->clipGroups.size(), 16u);
+  EXPECT_EQ(scene->clipGroups[0], 1);
+  EXPECT_EQ(scene->clipGroups[1], 3);
+  ASSERT_EQ(scene->groupGains.size(), 4u);
+  EXPECT_FLOAT_EQ(scene->groupGains[0], -6.0f);
+}
+
+TEST_F(SceneRoutingTest, RecallRestoresRoutingState) {
+  assignTopology(1, -6.0f);
+  const std::string sceneA = m_scenes->captureScene("Act 1");
+
+  // Mutate the live matrix, then recall the captured scene.
+  assignTopology(2, +3.0f);
+  ASSERT_EQ(m_scenes->recallScene(sceneA), SessionGraphError::OK);
+
+  // Verify through the matrix's own snapshot API.
+  RoutingSnapshot restored = m_routing->saveSnapshot("verify");
+  ASSERT_GE(restored.channels.size(), 16u);
+  EXPECT_EQ(restored.channels[0].group_index, 1);
+  EXPECT_EQ(restored.channels[1].group_index, 3);
+  ASSERT_GE(restored.groups.size(), 1u);
+  EXPECT_FLOAT_EQ(restored.groups[0].gain_db, -6.0f);
+}
+
+TEST_F(SceneRoutingTest, EightTabPageSwitchingRoundTrip) {
+  // Clip Composer models 8 tabs; capture 8 scenes with distinct routing and
+  // switch between them repeatedly — every recall must restore ITS state.
+  std::vector<std::string> tabs;
+  for (int tab = 0; tab < 8; ++tab) {
+    assignTopology(static_cast<uint8_t>(tab % 4), static_cast<float>(tab) - 4.0f);
+    tabs.push_back(m_scenes->captureScene("Tab " + std::to_string(tab)));
+    ASSERT_FALSE(tabs.back().empty());
+  }
+
+  // Rapid page switching, out of order, twice around.
+  const int order[] = {5, 0, 7, 2, 6, 1, 4, 3, 3, 7, 0, 5};
+  for (int tab : order) {
+    ASSERT_EQ(m_scenes->recallScene(tabs[static_cast<size_t>(tab)]), SessionGraphError::OK);
+    RoutingSnapshot state = m_routing->saveSnapshot("verify");
+    ASSERT_GE(state.channels.size(), 16u);
+    EXPECT_EQ(state.channels[0].group_index, static_cast<uint8_t>(tab % 4))
+        << "tab " << tab << " restored the wrong group topology";
+    ASSERT_GE(state.groups.size(), 1u);
+    EXPECT_FLOAT_EQ(state.groups[0].gain_db, static_cast<float>(tab) - 4.0f)
+        << "tab " << tab << " restored the wrong group gain";
+  }
+}
+
+TEST_F(SceneRoutingTest, DetachedMatrixStillCapturesMetadata) {
+  m_scenes->setRoutingMatrix(nullptr);
+  const std::string sceneId = m_scenes->captureScene("no routing");
+  ASSERT_FALSE(sceneId.empty());
+  const SceneSnapshot* scene = m_scenes->getScene(sceneId);
+  ASSERT_NE(scene, nullptr);
+  EXPECT_TRUE(scene->clipGroups.empty());
+  EXPECT_TRUE(scene->groupGains.empty());
+  EXPECT_EQ(m_scenes->recallScene(sceneId), SessionGraphError::OK);
+}

--- a/tests/support/rt_guard.hpp
+++ b/tests/support/rt_guard.hpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// ORP136 §2.2: runtime realtime-safety harness support.
+//
+// A static grep (tools/realtime_audit.py) can prove a forbidden token is
+// absent from a callback's source; it cannot prove the absence of allocation
+// or blocking I/O at runtime. This header provides the runtime side:
+//
+//  * RtSection — RAII marker for "this thread is now inside an audio
+//    callback". Thread-local, nestable.
+//  * Allocation hooks — the including test binary defines
+//    ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS in exactly ONE translation unit to
+//    install global operator new/delete overrides. Any C++ allocation or
+//    deallocation performed while the calling thread is inside an RtSection
+//    is counted as a violation (the allocation itself still succeeds, so the
+//    system under test keeps running and the test can report precisely).
+//  * ProcIoCounters — Linux /proc/self/io sampling (read syscalls + bytes)
+//    so a test can prove a guarded render section performed file I/O — or
+//    prove that it did not. Returns has_value()==false where unsupported.
+//
+// Used by tests/transport/realtime_harness_test.cpp (the ORP134 G1 gate:
+// "zero allocations/locks/blocking calls across a multi-clip processAudio()
+// stress run") and reusable by future ORP136 gates.
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <new>
+#include <optional>
+#include <string>
+
+namespace orpheus::tests::support {
+
+struct RtGuardState {
+  // Depth of nested RtSections on this thread (0 == not in a callback).
+  static thread_local int t_sectionDepth;
+
+  // Global violation counters (atomic: violations from any guarded thread).
+  static std::atomic<std::uint64_t> s_allocViolations;
+  static std::atomic<std::uint64_t> s_deallocViolations;
+  static std::atomic<std::uint64_t> s_allocViolationBytes;
+
+  static void reset() {
+    s_allocViolations.store(0, std::memory_order_relaxed);
+    s_deallocViolations.store(0, std::memory_order_relaxed);
+    s_allocViolationBytes.store(0, std::memory_order_relaxed);
+  }
+
+  static std::uint64_t allocViolations() {
+    return s_allocViolations.load(std::memory_order_relaxed);
+  }
+  static std::uint64_t deallocViolations() {
+    return s_deallocViolations.load(std::memory_order_relaxed);
+  }
+  static std::uint64_t allocViolationBytes() {
+    return s_allocViolationBytes.load(std::memory_order_relaxed);
+  }
+  static std::uint64_t totalViolations() {
+    return allocViolations() + deallocViolations();
+  }
+};
+
+/// RAII: marks the current thread as executing an audio callback.
+class RtSection {
+public:
+  RtSection() {
+    ++RtGuardState::t_sectionDepth;
+  }
+  ~RtSection() {
+    --RtGuardState::t_sectionDepth;
+  }
+  RtSection(const RtSection&) = delete;
+  RtSection& operator=(const RtSection&) = delete;
+};
+
+inline bool inRtSection() {
+  return RtGuardState::t_sectionDepth > 0;
+}
+
+/// Linux /proc/self/io snapshot. syscr = read() syscall count, rchar = bytes
+/// requested from read-family syscalls (counted even when served from the
+/// page cache — which freshly-written test fixtures always are, so this is
+/// the right counter for "did the render section hit the filesystem").
+struct ProcIoCounters {
+  std::uint64_t syscr = 0;
+  std::uint64_t rchar = 0;
+};
+
+inline std::optional<ProcIoCounters> readProcIoCounters() {
+#if defined(__linux__)
+  std::ifstream io("/proc/self/io");
+  if (!io.is_open()) {
+    return std::nullopt;
+  }
+  ProcIoCounters counters;
+  std::string key;
+  std::uint64_t value = 0;
+  bool sawSyscr = false;
+  bool sawRchar = false;
+  while (io >> key >> value) {
+    if (key == "syscr:") {
+      counters.syscr = value;
+      sawSyscr = true;
+    } else if (key == "rchar:") {
+      counters.rchar = value;
+      sawRchar = true;
+    }
+  }
+  if (!sawSyscr || !sawRchar) {
+    return std::nullopt;
+  }
+  return counters;
+#else
+  return std::nullopt;
+#endif
+}
+
+} // namespace orpheus::tests::support
+
+// ---------------------------------------------------------------------------
+// Global allocation hooks. Define ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS in
+// exactly one TU of the test binary before including this header.
+// The hooks delegate to std::malloc/std::free (which sanitizers intercept
+// normally) and count — but do not block — allocations inside RtSections.
+// ---------------------------------------------------------------------------
+#ifdef ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS
+
+namespace orpheus::tests::support {
+
+thread_local int RtGuardState::t_sectionDepth = 0;
+std::atomic<std::uint64_t> RtGuardState::s_allocViolations{0};
+std::atomic<std::uint64_t> RtGuardState::s_deallocViolations{0};
+std::atomic<std::uint64_t> RtGuardState::s_allocViolationBytes{0};
+
+namespace detail {
+
+inline void* guardedAlloc(std::size_t size) {
+  if (RtGuardState::t_sectionDepth > 0) {
+    RtGuardState::s_allocViolations.fetch_add(1, std::memory_order_relaxed);
+    RtGuardState::s_allocViolationBytes.fetch_add(size, std::memory_order_relaxed);
+  }
+  return std::malloc(size);
+}
+
+inline void guardedFree(void* ptr) {
+  if (ptr != nullptr && RtGuardState::t_sectionDepth > 0) {
+    RtGuardState::s_deallocViolations.fetch_add(1, std::memory_order_relaxed);
+  }
+  std::free(ptr);
+}
+
+} // namespace detail
+} // namespace orpheus::tests::support
+
+void* operator new(std::size_t size) {
+  void* ptr = orpheus::tests::support::detail::guardedAlloc(size);
+  if (!ptr) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void* operator new[](std::size_t size) {
+  return ::operator new(size);
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+  return orpheus::tests::support::detail::guardedAlloc(size);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+  return orpheus::tests::support::detail::guardedAlloc(size);
+}
+
+void operator delete(void* ptr) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+void operator delete[](void* ptr) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
+  orpheus::tests::support::detail::guardedFree(ptr);
+}
+
+#endif // ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -574,6 +574,73 @@ if(TARGET orpheus_audio_io)
         COMMAND choke_and_voice_cap_test
     )
 
+    # ORP136 §2.2: runtime realtime-safety harness (alloc hooks + /proc/self/io).
+    # Gates ORP134 G1: proves at runtime whether the audio thread allocates or
+    # performs file I/O — not just that forbidden tokens are absent statically.
+    add_executable(realtime_harness_test
+        realtime_harness_test.cpp
+    )
+
+    target_link_libraries(realtime_harness_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(realtime_harness_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(realtime_harness_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(realtime_harness_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+            ${CMAKE_SOURCE_DIR}/tests
+    )
+
+    add_test(
+        NAME realtime_harness_test
+        COMMAND realtime_harness_test
+    )
+
+    # ORP136 §2.3: golden render-hash determinism gate (block-size invariance
+    # + run-to-run reproducibility). Parity oracle for the ORP134 G1 migration.
+    add_executable(transport_render_hash_test
+        transport_render_hash_test.cpp
+    )
+
+    target_link_libraries(transport_render_hash_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(transport_render_hash_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(transport_render_hash_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(transport_render_hash_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+            ${CMAKE_SOURCE_DIR}/tests
+    )
+
+    add_test(
+        NAME transport_render_hash_test
+        COMMAND transport_render_hash_test
+    )
+
     # ORP127 T8: end-to-end sample-rate conversion in the transport (G6)
     add_executable(sample_rate_conversion_test
         sample_rate_conversion_test.cpp

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -25,6 +25,30 @@ add_test(
     COMMAND transport_controller_test
 )
 
+# ORP133 G3: debug-build single-producer contract assertion (death test)
+add_executable(command_producer_assert_test
+    command_producer_assert_test.cpp
+)
+
+target_link_libraries(command_producer_assert_test
+    PRIVATE
+        orpheus_transport
+        orpheus_audio_io
+        orpheus_session
+        GTest::gtest
+)
+
+target_include_directories(command_producer_assert_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/src/core
+)
+
+add_test(
+    NAME command_producer_assert_test
+    COMMAND command_producer_assert_test
+)
+
 # Fade processing tests
 add_executable(fade_processing_test
     fade_processing_test.cpp

--- a/tests/transport/callback_queue_stress_test.cpp
+++ b/tests/transport/callback_queue_stress_test.cpp
@@ -362,9 +362,117 @@ TEST_F(CallbackQueueStressTest, CallbackLatency) {
             << "  Average: " << avg_lat << " µs\n"
             << "  Maximum: " << max_lat << " µs\n";
 
-  // Callbacks should complete within reasonable time (< 10ms)
-  EXPECT_LT(avg_lat, 10000.0);
+  // Callbacks should complete within reasonable time (< 10ms). Sanitizer
+  // builds (notably TSan, ~19ms observed) inflate the wall clock, so — as with
+  // the waveform and multi-clip perf bounds — the assertion is skipped there.
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+  constexpr bool kUnderSanitizer = true;
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) ||                         \
+    __has_feature(memory_sanitizer) || __has_feature(undefined_behavior_sanitizer)
+  constexpr bool kUnderSanitizer = true;
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+
+  if (!kUnderSanitizer) {
+    EXPECT_LT(avg_lat, 10000.0);
+  } else {
+    std::cout << "  - Latency bound skipped under sanitizer\n";
+  }
 }
+
+// ============================================================================
+// Event Ordering Tests (ORP133 G1)
+// ============================================================================
+
+namespace {
+
+// Records the exact dispatch sequence so FIFO ordering through the POD event
+// ring can be asserted (not just counts).
+class RecordingCallback : public ITransportCallback {
+public:
+  enum class Kind : uint8_t { Started, Stopped, Looped, Restarted, Seeked, Underrun };
+
+  struct Entry {
+    Kind kind;
+    ClipHandle handle;
+  };
+
+  std::vector<Entry> entries;
+
+  void onClipStarted(ClipHandle handle, TransportPosition /*position*/) override {
+    entries.push_back({Kind::Started, handle});
+  }
+  void onClipStopped(ClipHandle handle, TransportPosition /*position*/) override {
+    entries.push_back({Kind::Stopped, handle});
+  }
+  void onClipLooped(ClipHandle handle, TransportPosition /*position*/) override {
+    entries.push_back({Kind::Looped, handle});
+  }
+  void onClipRestarted(ClipHandle handle, TransportPosition /*position*/) override {
+    entries.push_back({Kind::Restarted, handle});
+  }
+  void onClipSeeked(ClipHandle handle, TransportPosition /*position*/) override {
+    entries.push_back({Kind::Seeked, handle});
+  }
+  void onBufferUnderrun(TransportPosition /*position*/) override {
+    entries.push_back({Kind::Underrun, 0});
+  }
+};
+
+} // namespace
+
+TEST_F(CallbackQueueStressTest, EventOrderingPreserved) {
+  // ORP133 G1: the audio→UI ring switched from std::function payloads to POD
+  // TransportEvents. Emission points map 1:1 to the old postCallback sites, so
+  // dispatch order must be exactly emission (FIFO) order. Drive a
+  // deterministic sequence and assert the exact dispatch sequence.
+  auto recorder = std::make_unique<RecordingCallback>();
+  m_transport->setCallback(recorder.get());
+
+  using Kind = RecordingCallback::Kind;
+
+  // Buffer 1: start clip 1 → Started(1)
+  m_transport->startClip(1);
+  simulateAudioCallback();
+
+  // Buffer 2: start clip 2 → Started(2)
+  m_transport->startClip(2);
+  simulateAudioCallback();
+
+  // Buffer 3+: stop clip 1. The default 10ms stop fade (480 samples @ 48kHz)
+  // completes within one 512-frame buffer for reader-less clips → Stopped(1).
+  m_transport->stopClip(1);
+  simulateAudioCallback(2);
+
+  // Next buffer: start clip 3 → Started(3)
+  m_transport->startClip(3);
+  simulateAudioCallback();
+
+  // Drain everything in ONE pass so ordering inside the ring is what's tested.
+  m_transport->processCallbacks();
+
+  ASSERT_EQ(recorder->entries.size(), 4u);
+  EXPECT_EQ(recorder->entries[0].kind, Kind::Started);
+  EXPECT_EQ(recorder->entries[0].handle, 1u);
+  EXPECT_EQ(recorder->entries[1].kind, Kind::Started);
+  EXPECT_EQ(recorder->entries[1].handle, 2u);
+  EXPECT_EQ(recorder->entries[2].kind, Kind::Stopped);
+  EXPECT_EQ(recorder->entries[2].handle, 1u);
+  EXPECT_EQ(recorder->entries[3].kind, Kind::Started);
+  EXPECT_EQ(recorder->entries[3].handle, 3u);
+
+  // Restore the fixture's counting callback before TearDown.
+  m_transport->setCallback(m_callback.get());
+}
+
+// NOTE: Restarted/Seeked event translation (payload + delivery) is covered by
+// clip_restart_test.cpp and clip_seek_test.cpp against registered audio files;
+// this suite focuses on ring mechanics with reader-less clips.
 
 // ============================================================================
 // Main Entry Point

--- a/tests/transport/command_producer_assert_test.cpp
+++ b/tests/transport/command_producer_assert_test.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// ORP133 G3: Debug-build enforcement of the transport command queue's
+// single-producer contract.
+//
+// The UI→audio command queue is a lock-free SPSC ring: exactly ONE control
+// thread may post commands (startClip/stopClip/updateClip*/...). postCommand()
+// captures the first producer thread in debug builds and asserts if a command
+// is later posted from a different thread. This test proves the assertion
+// fires (death test) and that the legal single-thread pattern does not.
+//
+// Release builds compile the check out entirely; the death test is skipped
+// when NDEBUG is defined.
+
+#include "../../src/core/transport/transport_controller.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+
+using namespace orpheus;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+
+} // namespace
+
+TEST(CommandProducerAssertTest, SingleThreadProducerIsAccepted) {
+  // The legal pattern: every control-mutating call from one thread.
+  TransportController transport(nullptr, kSampleRate);
+  for (int i = 0; i < 64; ++i) {
+    EXPECT_EQ(transport.startClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
+    EXPECT_EQ(transport.stopClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
+  }
+  SUCCEED();
+}
+
+TEST(CommandProducerAssertTest, DedicatedControlThreadIsAccepted) {
+  // A single non-main control thread is equally legal — the contract is ONE
+  // producer thread, not specifically the thread that constructed the object.
+  TransportController transport(nullptr, kSampleRate);
+  std::thread control([&transport]() {
+    for (int i = 0; i < 64; ++i) {
+      EXPECT_EQ(transport.startClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
+    }
+  });
+  control.join();
+  SUCCEED();
+}
+
+TEST(CommandProducerAssertTest, SecondProducerThreadAsserts) {
+#ifdef NDEBUG
+  GTEST_SKIP() << "Producer assertion is compiled out in release builds";
+#else
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+  EXPECT_DEATH(
+      {
+        TransportController transport(nullptr, kSampleRate);
+        // Main thread claims the producer role...
+        transport.startClip(1);
+        // ...so a post from any other thread violates the SPSC contract.
+        std::thread other([&transport]() { transport.startClip(2); });
+        other.join();
+      },
+      "single");
+#endif
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/transport/multi_clip_stress_test.cpp
+++ b/tests/transport/multi_clip_stress_test.cpp
@@ -442,9 +442,29 @@ TEST_F(MultiClipStressTest, CPUUsageMeasurement) {
 
   // RT-budget assertion: rendering 16 clips must fit comfortably within one
   // buffer's real-time budget. Half the budget is a generous, load-tolerant
-  // ceiling (real cost is a few percent).
-  EXPECT_LT(budget_fraction, 0.5)
-      << "16-clip render should use <50% of the buffer's real-time budget";
+  // ceiling (real cost is a few percent). Sanitizer builds (ASan/TSan/UBSan)
+  // inflate render timings unpredictably, so — matching the waveform perf
+  // bound — the wall-clock assertion is skipped there; the 16-clips-playing
+  // correctness check above still runs.
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+  constexpr bool kUnderSanitizer = true;
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) ||                         \
+    __has_feature(memory_sanitizer) || __has_feature(undefined_behavior_sanitizer)
+  constexpr bool kUnderSanitizer = true;
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+
+  if (!kUnderSanitizer) {
+    EXPECT_LT(budget_fraction, 0.5)
+        << "16-clip render should use <50% of the buffer's real-time budget";
+  } else {
+    std::cout << "  - RT-budget bound skipped under sanitizer\n";
+  }
 }
 
 // ============================================================================

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -11,11 +11,11 @@
 //  * ReaderlessMultiClipRenderIsAllocationFree proves the pure render path
 //    (voices, fades, gain smoothing, routing, snapshot publish, event ring)
 //    performs ZERO C++ allocations/deallocations on the callback thread.
-//  * FileBackedRenderStillDoesFileIO_KnownDebt pins the KNOWN architecture
-//    debt (docs/REALTIME_AUDIT.md, KNOWN_DEBT_PATTERNS): file-backed clips
-//    still read from disk inside processAudio(). It asserts the I/O is
-//    OBSERVED — when the ORP134 G1 streaming reader lands, this test will
-//    fail, and must be flipped to assert ZERO I/O (the strict gate).
+//  * FileBackedRenderDoesNoFileIO is the STRICT gate (flipped when the
+//    ORP134 G1 prepared/streaming sources landed): file-backed clips render
+//    from memory-resident PCM; the audio thread performs no file I/O at all.
+//    Before G1 this test asserted the opposite (the KNOWN_DEBT era observed
+//    ~2,400 read syscalls / ~4.9 MB per 300 buffers).
 //
 // Lock/race coverage is deliberately delegated to the ThreadSanitizer suite
 // (voice_state_tsan_test + this file built under -fsanitize=thread); a
@@ -26,6 +26,7 @@
 
 #include "../../src/core/transport/transport_controller.h"
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -34,6 +35,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace orpheus;
@@ -196,17 +198,17 @@ TEST_F(RealtimeHarnessTest, ReaderlessMultiClipRenderIsAllocationFree) {
 }
 
 // ============================================================================
-// KNOWN DEBT pin: file-backed clips still do file I/O inside the callback.
+// STRICT gate (ORP134 G1 flip point reached): file-backed clips perform NO
+// file I/O inside the callback. Decode happens in prepareClipAudio()/
+// startClip() on the control thread (prepared memory) or on the stream
+// worker (page ring); the audio thread memcpy-reads published PCM only.
 //
-// >>> ORP134 G1 FLIP POINT <<<
-// When the streaming reader lands and decode moves off the audio thread,
-// this test WILL FAIL (the I/O delta drops to ~0). That failure is the
-// signal to flip the assertions below to EXPECT_EQ(0, ...) — turning this
-// harness into the strict runtime gate that ORP134's acceptance requires —
-// and to flip tools/realtime_audit.py --fail-known-debt on in CI.
+// The /proc/self/io sampling itself costs a couple of tiny reads (observed
+// 2 syscalls / 112 bytes), so the bound is "far below one page", not zero.
+// The pre-G1 debt measured ~2,400 syscalls / ~4.9 MB in the same window.
 // ============================================================================
 
-TEST_F(RealtimeHarnessTest, FileBackedRenderStillDoesFileIO_KnownDebt) {
+TEST_F(RealtimeHarnessTest, FileBackedRenderDoesNoFileIO) {
   auto before = readProcIoCounters();
   if (!before.has_value()) {
     GTEST_SKIP() << "/proc/self/io not available on this platform";
@@ -243,13 +245,159 @@ TEST_F(RealtimeHarnessTest, FileBackedRenderStillDoesFileIO_KnownDebt) {
             << " bytes read, alloc violations = " << RtGuardState::allocViolations()
             << " (bytes = " << RtGuardState::allocViolationBytes() << ")\n";
 
-  // The debt is real and observable: libsndfile decodes on the audio thread
-  // (transport_controller.cpp render loop -> readSamples -> sf_readf_float).
-  EXPECT_GT(readCalls, 0u)
-      << "No file I/O observed on the audio thread. If the ORP134 streaming reader has "
-         "landed, FLIP this test: assert readCalls == 0 / readBytes == 0 and enable "
-         "realtime_audit.py --fail-known-debt in CI. Do not leave this inverted.";
-  EXPECT_GT(readBytes, 0u);
+  // Strict gate: no media I/O on the audio thread. Any regression that
+  // reintroduces callback-time decoding blows straight through this bound
+  // (the debt era measured ~4.9 MB here).
+  EXPECT_LT(readCalls, 8u) << "file I/O observed inside the audio callback";
+  EXPECT_LT(readBytes, 4096u) << "file I/O observed inside the audio callback";
+
+  // And the file-backed render path must stay allocation-free too.
+  EXPECT_EQ(RtGuardState::allocViolations(), 0u);
+  EXPECT_EQ(RtGuardState::deallocViolations(), 0u);
+}
+
+// ============================================================================
+// Streaming sources (ORP134 G1): long files play from a worker-fed page ring.
+// ============================================================================
+
+namespace {
+
+// Counts underrun events and remembers whether any samples were audible.
+class UnderrunCountingCallback : public ITransportCallback {
+public:
+  std::atomic<int> underruns{0};
+  void onClipStarted(ClipHandle, TransportPosition) override {}
+  void onClipStopped(ClipHandle, TransportPosition) override {}
+  void onClipLooped(ClipHandle, TransportPosition) override {}
+  void onBufferUnderrun(TransportPosition) override {
+    underruns.fetch_add(1, std::memory_order_relaxed);
+  }
+};
+
+bool bufferHasSignal(const std::vector<float>& left) {
+  for (float sample : left) {
+    if (sample != 0.0f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+TEST_F(RealtimeHarnessTest, StreamingSourcePlaysPrefilledWindowWithoutUnderrun) {
+  // Force the streaming path: anything longer than 1s streams.
+  m_transport->setPreparedSourceMaxFrames(48000);
+
+  UnderrunCountingCallback callback;
+  m_transport->setCallback(&callback);
+
+  // 10s file >> the 4-page resident window (~5.46s @ 48k).
+  std::string path = writeSineWav(m_tempDir, "stream_long.wav", 220.0f, 10.0f);
+  ASSERT_EQ(m_transport->registerClipAudio(1, path), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->prepareClipAudio(1), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->startClip(1), SessionGraphError::OK);
+
+  // Render 4s of audio — fully inside the synchronously prefilled window, so
+  // playback must be gap-free even without giving the worker any wall time.
+  constexpr int kBuffers = (4 * 48000) / static_cast<int>(kBufferFrames);
+  RtGuardState::reset();
+  int buffersWithSignal = 0;
+  for (int i = 0; i < kBuffers; ++i) {
+    guardedCallback();
+    if (bufferHasSignal(m_left)) {
+      ++buffersWithSignal;
+    }
+  }
+  m_transport->processCallbacks();
+
+  EXPECT_EQ(callback.underruns.load(), 0) << "prefilled window underran";
+  EXPECT_EQ(buffersWithSignal, kBuffers) << "silent buffers inside the prefilled window";
+  EXPECT_EQ(RtGuardState::allocViolations(), 0u) << "streaming read path allocated";
+
+  m_transport->setCallback(nullptr);
+}
+
+TEST_F(RealtimeHarnessTest, StreamingSeekBeyondWindowUnderrunsSilentlyThenRecovers) {
+  m_transport->setPreparedSourceMaxFrames(48000);
+
+  UnderrunCountingCallback callback;
+  m_transport->setCallback(&callback);
+
+  std::string path = writeSineWav(m_tempDir, "stream_seek.wav", 220.0f, 10.0f);
+  ASSERT_EQ(m_transport->registerClipAudio(1, path), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->prepareClipAudio(1), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->startClip(1), SessionGraphError::OK);
+  guardedCallback(); // materialize the voice
+
+  // Jump far beyond the resident window: the ring holds ~[0, 5.46s); seek 8s.
+  ASSERT_EQ(m_transport->seekClip(1, 8 * 48000), SessionGraphError::OK);
+
+  // The seek lands at the next callback; the target page is normally not
+  // resident yet, so the clip renders SILENCE + reports BufferUnderrun — and
+  // never blocks. Under heavy instrumentation (TSan) the 10ms worker poll can
+  // win the race and refill before this buffer renders; both outcomes honor
+  // the contract, so the strict miss assertions apply only when the miss
+  // actually happened. (The miss path itself is covered deterministically by
+  // StreamingClipSourceMissIsNonBlockingAndRecovers below.)
+  guardedCallback();
+  const bool firstPostSeekSilent = !bufferHasSignal(m_left);
+  m_transport->processCallbacks();
+  if (firstPostSeekSilent) {
+    EXPECT_GT(callback.underruns.load(), 0)
+        << "silent post-seek buffer must report a BufferUnderrun";
+  } else {
+    std::cout << "  - worker refilled before the first post-seek buffer "
+                 "(instrumentation slowdown); miss path covered by the unit test\n";
+  }
+
+  // Give the stream worker wall time to refill at the new position, then
+  // playback must recover with real audio.
+  bool recovered = false;
+  for (int attempt = 0; attempt < 200 && !recovered; ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    guardedCallback();
+    recovered = bufferHasSignal(m_left);
+  }
+  m_transport->processCallbacks();
+  EXPECT_TRUE(recovered) << "stream worker never refilled after the seek";
+
+  m_transport->setCallback(nullptr);
+}
+
+TEST_F(RealtimeHarnessTest, StreamingClipSourceMissIsNonBlockingAndRecovers) {
+  // Deterministic miss coverage: drive a StreamingClipSource directly with no
+  // worker thread, so nothing can refill behind the test's back.
+  std::string path = writeSineWav(m_tempDir, "stream_unit.wav", 220.0f, 10.0f);
+  auto reader = createAudioFileReader();
+  ASSERT_NE(reader, nullptr);
+  auto opened = reader->open(path);
+  ASSERT_TRUE(opened.isOk());
+
+  auto source = std::make_shared<StreamingClipSource>(
+      std::shared_ptr<IAudioFileReader>(std::move(reader)), opened.value.num_channels,
+      opened.value.duration_samples);
+  source->prefill(0);
+
+  std::vector<float> buffer(kBufferFrames * opened.value.num_channels, 0.0f);
+  size_t framesRead = 0;
+
+  // Resident read at the prefilled head succeeds with real audio.
+  ASSERT_TRUE(source->read(0, buffer.data(), kBufferFrames, framesRead));
+  EXPECT_EQ(framesRead, kBufferFrames);
+
+  // 8s is far outside the prefilled window: a guaranteed miss. read() must
+  // return false immediately (framesRead 0, dest untouched) — never block.
+  const int64_t farPos = 8 * 48000;
+  framesRead = 123;
+  EXPECT_FALSE(source->read(farPos, buffer.data(), kBufferFrames, framesRead));
+  EXPECT_EQ(framesRead, 0u);
+
+  // One worker pass (called synchronously here) refills at the demand the
+  // missed read published; the same read then succeeds.
+  source->service();
+  ASSERT_TRUE(source->read(farPos, buffer.data(), kBufferFrames, framesRead));
+  EXPECT_EQ(framesRead, kBufferFrames);
 }
 
 // ============================================================================

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+// ORP136 §2.2: runtime realtime-safety harness for the transport callback.
+//
+// tools/realtime_audit.py is a static gate; this test is the RUNTIME gate the
+// ORP134 streaming-reader sprint depends on ("do not start G1 without it").
+// It must be able to red/green the claim "no allocations / no file I/O on the
+// audio thread":
+//
+//  * GuardDetectsViolations proves the harness REDS on a real violation
+//    (self-test of the detector, not of the SDK).
+//  * ReaderlessMultiClipRenderIsAllocationFree proves the pure render path
+//    (voices, fades, gain smoothing, routing, snapshot publish, event ring)
+//    performs ZERO C++ allocations/deallocations on the callback thread.
+//  * FileBackedRenderStillDoesFileIO_KnownDebt pins the KNOWN architecture
+//    debt (docs/REALTIME_AUDIT.md, KNOWN_DEBT_PATTERNS): file-backed clips
+//    still read from disk inside processAudio(). It asserts the I/O is
+//    OBSERVED — when the ORP134 G1 streaming reader lands, this test will
+//    fail, and must be flipped to assert ZERO I/O (the strict gate).
+//
+// Lock/race coverage is deliberately delegated to the ThreadSanitizer suite
+// (voice_state_tsan_test + this file built under -fsanitize=thread); a
+// dlsym-interpose lock detector would fight the sanitizers' own interceptors.
+
+#define ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS
+#include "../support/rt_guard.hpp"
+
+#include "../../src/core/transport/transport_controller.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+using orpheus::tests::support::ProcIoCounters;
+using orpheus::tests::support::readProcIoCounters;
+using orpheus::tests::support::RtGuardState;
+using orpheus::tests::support::RtSection;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr size_t kBufferFrames = 512;
+
+// Minimal WAV writer (16-bit PCM stereo) — mirrors multi_clip_stress_test.
+std::string writeSineWav(const std::filesystem::path& dir, const std::string& name, float freq,
+                         float durationSeconds, uint32_t sampleRate = kSampleRate) {
+  const uint16_t numChannels = 2;
+  const int64_t numFrames = static_cast<int64_t>(durationSeconds * sampleRate);
+
+  std::string filepath = (dir / name).string();
+  std::ofstream file(filepath, std::ios::binary);
+
+  const uint32_t dataSize = static_cast<uint32_t>(numFrames * numChannels * sizeof(int16_t));
+  const uint32_t fileSize = 36 + dataSize;
+  const uint32_t fmtSize = 16;
+  const uint16_t audioFormat = 1; // PCM
+  const uint16_t blockAlign = numChannels * 2;
+  const uint32_t byteRate = sampleRate * blockAlign;
+  const uint16_t bitsPerSample = 16;
+
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&fileSize), 4);
+  file.write("WAVE", 4);
+  file.write("fmt ", 4);
+  file.write(reinterpret_cast<const char*>(&fmtSize), 4);
+  file.write(reinterpret_cast<const char*>(&audioFormat), 2);
+  file.write(reinterpret_cast<const char*>(&numChannels), 2);
+  file.write(reinterpret_cast<const char*>(&sampleRate), 4);
+  file.write(reinterpret_cast<const char*>(&byteRate), 4);
+  file.write(reinterpret_cast<const char*>(&blockAlign), 2);
+  file.write(reinterpret_cast<const char*>(&bitsPerSample), 2);
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&dataSize), 4);
+
+  for (int64_t i = 0; i < numFrames; ++i) {
+    float s = 0.3f * std::sin(2.0f * static_cast<float>(M_PI) * freq * static_cast<float>(i) /
+                              static_cast<float>(kSampleRate));
+    int16_t v = static_cast<int16_t>(s * 32767.0f);
+    file.write(reinterpret_cast<const char*>(&v), 2); // L
+    file.write(reinterpret_cast<const char*>(&v), 2); // R
+  }
+  file.close();
+  return filepath;
+}
+
+class RealtimeHarnessTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    m_tempDir = std::filesystem::temp_directory_path() / "orp136_rt_harness";
+    std::filesystem::create_directories(m_tempDir);
+    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_left.assign(kBufferFrames, 0.0f);
+    m_right.assign(kBufferFrames, 0.0f);
+    m_buffers[0] = m_left.data();
+    m_buffers[1] = m_right.data();
+    RtGuardState::reset();
+  }
+
+  void TearDown() override {
+    m_transport.reset();
+    std::error_code ec;
+    std::filesystem::remove_all(m_tempDir, ec);
+  }
+
+  // One simulated audio callback, guarded as a realtime section.
+  void guardedCallback() {
+    RtSection section;
+    m_transport->processAudio(m_buffers, 2, kBufferFrames);
+  }
+
+  std::filesystem::path m_tempDir;
+  std::unique_ptr<TransportController> m_transport;
+  std::vector<float> m_left;
+  std::vector<float> m_right;
+  float* m_buffers[2] = {nullptr, nullptr};
+};
+
+} // namespace
+
+// ============================================================================
+// Detector self-test: the harness must RED on a real violation.
+// ============================================================================
+
+TEST_F(RealtimeHarnessTest, GuardDetectsViolations) {
+  RtGuardState::reset();
+  ASSERT_EQ(RtGuardState::totalViolations(), 0u);
+
+  {
+    RtSection section;
+    volatile int* leak = new int(42); // deliberate violation
+    delete leak;                      // second deliberate violation
+  }
+
+  EXPECT_EQ(RtGuardState::allocViolations(), 1u) << "operator new inside an RtSection must red";
+  EXPECT_EQ(RtGuardState::deallocViolations(), 1u)
+      << "operator delete inside an RtSection must red";
+
+  // Outside a section, allocations are not violations.
+  RtGuardState::reset();
+  volatile int* fine = new int(7);
+  delete fine;
+  EXPECT_EQ(RtGuardState::totalViolations(), 0u);
+}
+
+// ============================================================================
+// GREEN gate: the pure render path performs zero allocations.
+// ============================================================================
+
+TEST_F(RealtimeHarnessTest, ReaderlessMultiClipRenderIsAllocationFree) {
+  constexpr int kNumClips = 16;
+  constexpr int kNumBuffers = 500;
+
+  // Reader-less clips exercise the voice/fade/gain/routing/snapshot/event
+  // machinery without touching the (known-debt) file-read path.
+  for (int i = 0; i < kNumClips; ++i) {
+    ASSERT_EQ(m_transport->startClip(static_cast<ClipHandle>(i + 1)), SessionGraphError::OK);
+  }
+
+  RtGuardState::reset();
+  for (int buffer = 0; buffer < kNumBuffers; ++buffer) {
+    guardedCallback();
+
+    // UI-thread work between callbacks (unguarded): churn voices so the
+    // guarded path also covers voice add/remove/restart and event posting.
+    if (buffer % 50 == 10) {
+      ClipHandle handle = static_cast<ClipHandle>(buffer % kNumClips + 1);
+      m_transport->stopClip(handle);
+    }
+    if (buffer % 50 == 30) {
+      ClipHandle handle = static_cast<ClipHandle>(buffer % kNumClips + 1);
+      m_transport->startClip(handle);
+    }
+    if (buffer % 97 == 0) {
+      m_transport->stopOtherClips(static_cast<ClipHandle>(1));
+    }
+    if (buffer % 100 == 60) {
+      m_transport->processCallbacks(); // drain event ring on the "UI thread"
+    }
+  }
+
+  EXPECT_EQ(RtGuardState::allocViolations(), 0u)
+      << "processAudio() allocated on the callback thread (" << RtGuardState::allocViolationBytes()
+      << " bytes)";
+  EXPECT_EQ(RtGuardState::deallocViolations(), 0u)
+      << "processAudio() deallocated on the callback thread";
+
+  std::cout << "[RT Harness] reader-less stress: " << kNumBuffers << " buffers x " << kNumClips
+            << " clips, alloc violations = " << RtGuardState::allocViolations()
+            << ", dealloc violations = " << RtGuardState::deallocViolations() << "\n";
+}
+
+// ============================================================================
+// KNOWN DEBT pin: file-backed clips still do file I/O inside the callback.
+//
+// >>> ORP134 G1 FLIP POINT <<<
+// When the streaming reader lands and decode moves off the audio thread,
+// this test WILL FAIL (the I/O delta drops to ~0). That failure is the
+// signal to flip the assertions below to EXPECT_EQ(0, ...) — turning this
+// harness into the strict runtime gate that ORP134's acceptance requires —
+// and to flip tools/realtime_audit.py --fail-known-debt on in CI.
+// ============================================================================
+
+TEST_F(RealtimeHarnessTest, FileBackedRenderStillDoesFileIO_KnownDebt) {
+  auto before = readProcIoCounters();
+  if (!before.has_value()) {
+    GTEST_SKIP() << "/proc/self/io not available on this platform";
+  }
+
+  constexpr int kNumClips = 8;
+  constexpr int kNumBuffers = 300; // ~3.2s of audio -> far beyond any prefetch
+
+  for (int i = 0; i < kNumClips; ++i) {
+    ClipHandle handle = static_cast<ClipHandle>(i + 1);
+    std::string path = writeSineWav(m_tempDir, "debt_" + std::to_string(i) + ".wav",
+                                    220.0f + 55.0f * static_cast<float>(i), 4.0f);
+    ASSERT_EQ(m_transport->registerClipAudio(handle, path), SessionGraphError::OK);
+    ASSERT_EQ(m_transport->prepareClipAudio(handle), SessionGraphError::OK);
+    ASSERT_EQ(m_transport->startClip(handle), SessionGraphError::OK);
+  }
+
+  // Sample I/O counters around ONLY the guarded render loop.
+  before = readProcIoCounters();
+  ASSERT_TRUE(before.has_value());
+  RtGuardState::reset();
+
+  for (int buffer = 0; buffer < kNumBuffers; ++buffer) {
+    guardedCallback();
+  }
+
+  auto after = readProcIoCounters();
+  ASSERT_TRUE(after.has_value());
+
+  const std::uint64_t readCalls = after->syscr - before->syscr;
+  const std::uint64_t readBytes = after->rchar - before->rchar;
+
+  std::cout << "[RT Harness] file-backed render: " << readCalls << " read syscalls, " << readBytes
+            << " bytes read, alloc violations = " << RtGuardState::allocViolations()
+            << " (bytes = " << RtGuardState::allocViolationBytes() << ")\n";
+
+  // The debt is real and observable: libsndfile decodes on the audio thread
+  // (transport_controller.cpp render loop -> readSamples -> sf_readf_float).
+  EXPECT_GT(readCalls, 0u)
+      << "No file I/O observed on the audio thread. If the ORP134 streaming reader has "
+         "landed, FLIP this test: assert readCalls == 0 / readBytes == 0 and enable "
+         "realtime_audit.py --fail-known-debt in CI. Do not leave this inverted.";
+  EXPECT_GT(readBytes, 0u);
+}
+
+// ============================================================================
+// Callback duration accounting (report always; bound only unsanitized).
+// ============================================================================
+
+TEST_F(RealtimeHarnessTest, CallbackDurationWithinBudget) {
+  constexpr int kNumClips = 16;
+  constexpr int kNumBuffers = 300;
+
+  for (int i = 0; i < kNumClips; ++i) {
+    ASSERT_EQ(m_transport->startClip(static_cast<ClipHandle>(i + 1)), SessionGraphError::OK);
+  }
+  guardedCallback(); // warm-up: materialize voices
+
+  double maxUs = 0.0;
+  double totalUs = 0.0;
+  for (int buffer = 0; buffer < kNumBuffers; ++buffer) {
+    auto start = std::chrono::steady_clock::now();
+    guardedCallback();
+    auto end = std::chrono::steady_clock::now();
+    double us = std::chrono::duration<double, std::micro>(end - start).count();
+    maxUs = std::max(maxUs, us);
+    totalUs += us;
+  }
+
+  const double budgetUs = (static_cast<double>(kBufferFrames) * 1e6) / kSampleRate; // ~10667us
+  std::cout << "[RT Harness] duration: avg " << (totalUs / kNumBuffers) << " us, max " << maxUs
+            << " us, budget " << budgetUs << " us\n";
+
+  // Wall-clock bounds are skipped under sanitizers (same policy as the
+  // waveform and multi-clip perf bounds).
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+  constexpr bool kUnderSanitizer = true;
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer) ||                         \
+    __has_feature(memory_sanitizer) || __has_feature(undefined_behavior_sanitizer)
+  constexpr bool kUnderSanitizer = true;
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+#else
+  constexpr bool kUnderSanitizer = false;
+#endif
+
+  if (!kUnderSanitizer) {
+    EXPECT_LT(maxUs, budgetUs) << "a single reader-less callback exceeded the realtime budget";
+  } else {
+    std::cout << "  - duration bound skipped under sanitizer\n";
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -94,12 +94,15 @@ TEST_F(TransportControllerTest, StopAllClips) {
   EXPECT_EQ(m_transport->stopAllClips(), SessionGraphError::OK);
 }
 
-TEST_F(TransportControllerTest, StopAllInGroup) {
-  // Stop all clips in group 0
-  EXPECT_EQ(m_transport->stopAllInGroup(0), SessionGraphError::OK);
-
-  // Invalid group index should fail
-  EXPECT_EQ(m_transport->stopAllInGroup(4), SessionGraphError::InvalidParameter);
+TEST_F(TransportControllerTest, StopAllInGroupReportsNotSupported) {
+  // ORP133 G2: stopAllInGroup was a silent no-op in every release (the
+  // transport has no clip→group mapping — grouping is a host concern). It now
+  // reports that truthfully: NotSupported for every group index, never a
+  // silent no-op. Hosts scope group-stops with stopOtherClips() + their own
+  // group model.
+  EXPECT_EQ(m_transport->stopAllInGroup(0), SessionGraphError::NotSupported);
+  EXPECT_EQ(m_transport->stopAllInGroup(3), SessionGraphError::NotSupported);
+  EXPECT_EQ(m_transport->stopAllInGroup(4), SessionGraphError::NotSupported);
 }
 
 TEST_F(TransportControllerTest, GetCurrentPosition) {

--- a/tests/transport/transport_render_hash_test.cpp
+++ b/tests/transport/transport_render_hash_test.cpp
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+// ORP136 §2.3: golden render-hash determinism gate for the transport render
+// path — and the parity oracle for the ORP134 G1 streaming-reader migration.
+//
+// The same clip set, rendered from sample 0 with identical metadata, must
+// produce BIT-IDENTICAL output regardless of callback block size. The output
+// is hashed (FNV-1a 64 over the raw float bytes) at four block sizes and the
+// hashes must agree; a repeated run must reproduce the same hash exactly.
+//
+// When ORP134 G1 swaps the audio-thread file reads for prepared/streamed
+// sources, these hashes are the proof of parity: the streaming path must
+// reproduce the hash the reading path produced (same platform, same build).
+//
+// Cross-platform tolerance strategy (documented per ORP136 §2.3): the target
+// is bit-identical output everywhere. Within one platform+toolchain this test
+// asserts exact equality. Hashes are NOT hard-coded as cross-platform golden
+// constants yet, because the EqualPower fade path calls std::sin per sample
+// and libm results differ across platforms; pinning that math (e.g. a
+// polynomial or table, std::bit_cast discipline) is ORP134 G4 scope. Any
+// cross-platform drift observed before then is a determinism bug to FILE,
+// not to mask in this test.
+//
+// Scenario constraints that keep the output block-size-invariant:
+//  * all starts/metadata land before the first rendered buffer (command
+//    materialization is buffer-quantized by design);
+//  * no looping clips (loop wrap re-seeks at buffer granularity — that
+//    quantization is documented transport behavior, not a hash bug);
+//  * natural OUT-point completion IS covered (the stop fade anchors at the
+//    exact OUT sample, ORP127 G3).
+
+#include "../../src/core/transport/transport_controller.h"
+#include "../support/fnv1a64.hpp"
+#include "../support/synth.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+using orpheus::tests::support::Fnv1a64;
+using orpheus::tests::support::GenerateSine;
+using orpheus::tests::support::kFnv1a64Offset;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+// 98304 = 2^15 * 3: divisible by every tested block size.
+constexpr size_t kTotalFrames = 98304;
+constexpr size_t kBlockSizes[] = {256, 512, 1024, 2048};
+
+// Deterministic PCM16 WAV writer fed from the integer-table sine in
+// synth.hpp — no libm in fixture generation, so fixture bytes are identical
+// on every platform.
+std::string writePcm16Wav(const std::filesystem::path& dir, const std::string& name,
+                          const std::vector<float>& samples, uint16_t numChannels) {
+  const int64_t numFrames = static_cast<int64_t>(samples.size() / numChannels);
+  std::string filepath = (dir / name).string();
+  std::ofstream file(filepath, std::ios::binary);
+
+  const uint32_t dataSize = static_cast<uint32_t>(numFrames * numChannels * sizeof(int16_t));
+  const uint32_t fileSize = 36 + dataSize;
+  const uint32_t fmtSize = 16;
+  const uint16_t audioFormat = 1; // PCM
+  const uint16_t blockAlign = static_cast<uint16_t>(numChannels * 2);
+  const uint32_t byteRate = kSampleRate * blockAlign;
+  const uint16_t bitsPerSample = 16;
+  const uint32_t sampleRate = kSampleRate;
+
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&fileSize), 4);
+  file.write("WAVE", 4);
+  file.write("fmt ", 4);
+  file.write(reinterpret_cast<const char*>(&fmtSize), 4);
+  file.write(reinterpret_cast<const char*>(&audioFormat), 2);
+  file.write(reinterpret_cast<const char*>(&numChannels), 2);
+  file.write(reinterpret_cast<const char*>(&sampleRate), 4);
+  file.write(reinterpret_cast<const char*>(&byteRate), 4);
+  file.write(reinterpret_cast<const char*>(&blockAlign), 2);
+  file.write(reinterpret_cast<const char*>(&bitsPerSample), 2);
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&dataSize), 4);
+
+  for (float s : samples) {
+    float clamped = std::min(1.0f, std::max(-1.0f, s));
+    int16_t v = static_cast<int16_t>(clamped * 32767.0f);
+    file.write(reinterpret_cast<const char*>(&v), 2);
+  }
+  file.close();
+  return filepath;
+}
+
+std::vector<float> interleaveStereo(const std::vector<float>& left,
+                                    const std::vector<float>& right) {
+  std::vector<float> out(left.size() * 2, 0.0f);
+  for (size_t i = 0; i < left.size(); ++i) {
+    out[i * 2] = left[i];
+    out[i * 2 + 1] = right[i];
+  }
+  return out;
+}
+
+class TransportRenderHashTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    m_tempDir = std::filesystem::temp_directory_path() / "orp136_render_hash";
+    std::filesystem::create_directories(m_tempDir);
+
+    // Fixture 1: stereo dual sine, 1.5s — plays to natural EOF inside the
+    // render window (covers OUT-point completion + default stop fade).
+    {
+      auto left = GenerateSine(72000, kSampleRate, 440, 0.5f);
+      auto right = GenerateSine(72000, kSampleRate, 554, 0.5f);
+      m_fixture1 = writePcm16Wav(m_tempDir, "hash_stereo.wav", interleaveStereo(left, right), 2);
+    }
+    // Fixture 2: stereo sine, 2.2s — trimmed + faded + gain (exercises trim
+    // enforcement, EqualPower/Linear fade envelopes, clip gain).
+    {
+      auto left = GenerateSine(105600, kSampleRate, 220, 0.6f);
+      auto right = GenerateSine(105600, kSampleRate, 330, 0.6f);
+      m_fixture2 = writePcm16Wav(m_tempDir, "hash_trimmed.wav", interleaveStereo(left, right), 2);
+    }
+    // Fixture 3: mono sine, 1.0s — mono → phantom-center duplication path.
+    {
+      auto mono = GenerateSine(48000, kSampleRate, 660, 0.4f);
+      m_fixture3 = writePcm16Wav(m_tempDir, "hash_mono.wav", mono, 1);
+    }
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(m_tempDir, ec);
+  }
+
+  // Build the standard scenario on a fresh controller and render the whole
+  // window at the given block size, returning the FNV-1a hash of every
+  // output sample (L bytes then R bytes, buffer by buffer).
+  uint64_t renderScenarioHash(size_t blockFrames) {
+    EXPECT_EQ(kTotalFrames % blockFrames, 0u) << "block size must divide the render window";
+
+    TransportController transport(nullptr, kSampleRate);
+
+    EXPECT_EQ(transport.registerClipAudio(1, m_fixture1), SessionGraphError::OK);
+    EXPECT_EQ(transport.registerClipAudio(2, m_fixture2), SessionGraphError::OK);
+    EXPECT_EQ(transport.registerClipAudio(3, m_fixture3), SessionGraphError::OK);
+
+    // Clip 2: trim + fades + gain. All metadata lands before the first
+    // buffer, so every block size sees identical voice state.
+    ClipMetadata meta;
+    meta.trimInSamples = 1000;
+    meta.trimOutSamples = 40000;
+    meta.fadeInSeconds = 0.05;
+    meta.fadeOutSeconds = 0.05;
+    meta.fadeInCurve = FadeCurve::EqualPower;
+    meta.fadeOutCurve = FadeCurve::Linear;
+    meta.gainDb = -6.0f;
+    meta.loopEnabled = false;
+    EXPECT_EQ(transport.updateClipMetadata(2, meta), SessionGraphError::OK);
+    EXPECT_EQ(transport.updateClipGain(3, 3.0f), SessionGraphError::OK);
+
+    EXPECT_EQ(transport.prepareClipAudio(1), SessionGraphError::OK);
+    EXPECT_EQ(transport.prepareClipAudio(2), SessionGraphError::OK);
+    EXPECT_EQ(transport.prepareClipAudio(3), SessionGraphError::OK);
+
+    EXPECT_EQ(transport.startClip(1), SessionGraphError::OK);
+    EXPECT_EQ(transport.startClip(2), SessionGraphError::OK);
+    EXPECT_EQ(transport.startClip(3), SessionGraphError::OK);
+
+    std::vector<float> left(blockFrames, 0.0f);
+    std::vector<float> right(blockFrames, 0.0f);
+    float* buffers[2] = {left.data(), right.data()};
+
+    // Accumulate the CONTIGUOUS per-channel sample streams before hashing.
+    // (Hashing per-buffer L/R chunks would make the hash-stream order depend
+    // on the block size even when the audio itself is identical.)
+    std::vector<float> streamL;
+    std::vector<float> streamR;
+    streamL.reserve(kTotalFrames);
+    streamR.reserve(kTotalFrames);
+
+    const size_t numBuffers = kTotalFrames / blockFrames;
+    for (size_t i = 0; i < numBuffers; ++i) {
+      transport.processAudio(buffers, 2, blockFrames);
+      streamL.insert(streamL.end(), left.begin(), left.end());
+      streamR.insert(streamR.end(), right.begin(), right.end());
+    }
+    transport.processCallbacks();
+
+    uint64_t hash = Fnv1a64(reinterpret_cast<const std::uint8_t*>(streamL.data()),
+                            streamL.size() * sizeof(float), kFnv1a64Offset);
+    hash = Fnv1a64(reinterpret_cast<const std::uint8_t*>(streamR.data()),
+                   streamR.size() * sizeof(float), hash);
+    return hash;
+  }
+
+  std::filesystem::path m_tempDir;
+  std::string m_fixture1;
+  std::string m_fixture2;
+  std::string m_fixture3;
+};
+
+} // namespace
+
+TEST_F(TransportRenderHashTest, HashIsIdenticalAcrossBlockSizes) {
+  uint64_t reference = 0;
+  bool haveReference = false;
+
+  for (size_t blockFrames : kBlockSizes) {
+    uint64_t hash = renderScenarioHash(blockFrames);
+    std::cout << "[Render Hash] block " << blockFrames << ": 0x" << std::hex << hash << std::dec
+              << "\n";
+    if (!haveReference) {
+      reference = hash;
+      haveReference = true;
+    } else {
+      EXPECT_EQ(hash, reference) << "block size " << blockFrames
+                                 << " produced different audio than the reference block size "
+                                 << kBlockSizes[0]
+                                 << " — the render path is block-size dependent (determinism bug)";
+    }
+  }
+}
+
+TEST_F(TransportRenderHashTest, HashIsReproducibleAcrossRuns) {
+  const uint64_t first = renderScenarioHash(512);
+  const uint64_t second = renderScenarioHash(512);
+  EXPECT_EQ(first, second) << "same input, same block size, different output — "
+                              "the render path is nondeterministic";
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/docs_path_audit.py
+++ b/tools/docs_path_audit.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Docs-path validation gate (ORP133 G6 / ORP136 §2.7).
+
+Keeps the ORP133 documentation truth pass from rotting. Fails on:
+
+1. Internal markdown links in LIVE docs that point at nonexistent paths.
+2. References to ``apps/clip-composer`` — the app was extracted to the
+   external ``chrislyons/clip-composer`` repository (ORP131). Historical
+   mentions are allowed only when the same line clearly labels them as such
+   (``former``/``archiv``/``extracted``/``ORP131``).
+3. References to CMake options that do not exist in the root CMakeLists.txt
+   (e.g. the removed ``ORPHEUS_ENABLE_APP_CLIP_COMPOSER``).
+
+Scope: live top-level docs + docs/*.md. Frozen historical records (the ORP074
+sprint records, the TypeScript-era upgrade/migration guides, docs/orp/,
+docs/archive/) are exempt — they describe the repo as it was, and docs/INDEX.md
+labels them as historical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+
+# Live documents whose internal links must resolve.
+LINK_CHECKED_DOCS = [
+    "README.md",
+    "ARCHITECTURE.md",
+    "ROADMAP.md",
+    "CLAUDE.md",
+]
+LINK_CHECKED_GLOBS = ["docs/*.md"]
+
+# Documents scanned for forbidden patterns (superset of the above).
+PATTERN_CHECKED_EXTRA = ["CHANGELOG.md"]
+
+# Frozen historical records: they intentionally describe a repo state that no
+# longer exists (pre-extraction paths, TypeScript-era options). docs/INDEX.md
+# labels them as historical. New live docs must NOT be added here casually.
+HISTORICAL_DOCS = {
+    "docs/SDK_SPRINT_SUMMARY.md",
+    "docs/SDK_TEAM_HANDOFF.md",
+    "docs/UPGRADING_TO_1.0.md",
+    "docs/MIGRATION_v0_to_v1.md",
+}
+
+# Handles both [t](path) and the angle-bracket form [t](<path with (parens)>).
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\((<[^>]*>|[^)\s]+)\)")
+EXTRACTED_APP_RE = re.compile(r"apps/clip-composer")
+HISTORICAL_LABEL_RE = re.compile(r"former|archiv|extracted|ORP131", re.IGNORECASE)
+# Only -D-prefixed tokens are treated as CMake configure options; bare
+# ORPHEUS_* identifiers can legitimately be env vars or code symbols.
+CMAKE_OPTION_RE = re.compile(r"-D(ORPHEUS_[A-Z0-9_]+|ORP_[A-Z0-9_]+)")
+CMAKE_DEFINED_RE = re.compile(r"\b(ORPHEUS_[A-Z0-9_]+|ORP_[A-Z0-9_]+)\b")
+
+# Non-option CMake/doc tokens that legitimately match the option regex.
+CMAKE_TOKEN_ALLOWLIST = {
+    "ORP_BUILD_REAPER",   # documented as deprecated in CMakeLists.txt itself
+    "ORP_BUILD_MINHOST",  # documented as deprecated in CMakeLists.txt itself
+    "ORPHEUS_BUILD_SHARED",  # compatibility shim handled in CMakeLists.txt
+}
+
+
+@dataclass
+class Violation:
+    path: Path
+    line: int
+    kind: str
+    detail: str
+
+
+def repo_cmake_tokens(root: Path) -> set[str]:
+    """All ORPHEUS_*/ORP_* identifiers defined or handled by the build."""
+    tokens: set[str] = set(CMAKE_TOKEN_ALLOWLIST)
+    for cmake in [root / "CMakeLists.txt", *root.glob("cmake/*.cmake")]:
+        if cmake.exists():
+            tokens.update(CMAKE_DEFINED_RE.findall(cmake.read_text(encoding="utf-8")))
+    return tokens
+
+
+def iter_docs(root: Path) -> list[Path]:
+    docs: list[Path] = []
+    for name in LINK_CHECKED_DOCS:
+        path = root / name
+        if path.exists():
+            docs.append(path)
+    for pattern in LINK_CHECKED_GLOBS:
+        docs.extend(sorted(root.glob(pattern)))
+    return [doc for doc in docs if str(doc.relative_to(root)) not in HISTORICAL_DOCS]
+
+
+def check_links(doc: Path, root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    text = doc.read_text(encoding="utf-8", errors="replace")
+    in_code_block = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.strip().startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        for match in MD_LINK_RE.finditer(line):
+            target = match.group(1).strip()
+            if target.startswith("<") and target.endswith(">"):
+                target = target[1:-1].strip()
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            if "://" in target:
+                continue
+            path_part = urllib.parse.unquote(target.split("#", 1)[0])
+            if not path_part:
+                continue
+            if path_part.startswith("/"):
+                resolved = root / path_part.lstrip("/")
+            else:
+                resolved = (doc.parent / path_part).resolve()
+            if not resolved.exists():
+                violations.append(
+                    Violation(doc, lineno, "broken-link", f"link target does not exist: {target}")
+                )
+    return violations
+
+
+def check_patterns(doc: Path, valid_tokens: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    text = doc.read_text(encoding="utf-8", errors="replace")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if EXTRACTED_APP_RE.search(line) and not HISTORICAL_LABEL_RE.search(line):
+            violations.append(
+                Violation(
+                    doc,
+                    lineno,
+                    "extracted-app-path",
+                    "apps/clip-composer is external (ORP131); label historical mentions "
+                    "as former/archived or point at chrislyons/clip-composer",
+                )
+            )
+        for token in CMAKE_OPTION_RE.findall(line):
+            if token not in valid_tokens:
+                violations.append(
+                    Violation(
+                        doc,
+                        lineno,
+                        "unknown-cmake-option",
+                        f"{token} is not defined in CMakeLists.txt/cmake/ (removed or misspelled)",
+                    )
+                )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    root = args.root.resolve()
+
+    valid_tokens = repo_cmake_tokens(root)
+    violations: list[Violation] = []
+
+    docs = iter_docs(root)
+    for doc in docs:
+        violations.extend(check_links(doc, root))
+        violations.extend(check_patterns(doc, valid_tokens))
+
+    for name in PATTERN_CHECKED_EXTRA:
+        path = root / name
+        if path.exists():
+            violations.extend(check_patterns(path, valid_tokens))
+
+    for violation in violations:
+        rel = violation.path.relative_to(root)
+        print(f"FAIL: {rel}:{violation.line}: [{violation.kind}] {violation.detail}")
+
+    if violations:
+        print(f"Docs-path audit failed: {len(violations)} violation(s).")
+        return 1
+
+    print(f"Docs-path audit passed: {len(docs) + len(PATTERN_CHECKED_EXTRA)} documents checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/realtime_audit.py
+++ b/tools/realtime_audit.py
@@ -3,8 +3,12 @@
 """Static realtime-safety audit for Orpheus callback paths.
 
 The audit is intentionally conservative. It fails on forbidden patterns in
-hardware-driver callbacks and reports known transport/app debt separately so CI
-can guard new driver regressions while the streaming architecture is developed.
+hardware-driver callbacks and scans the transport render path for file-reader
+patterns. Since the ORP134 G1 streaming migration the in-repo scan runs with
+--fail-known-debt in CI (strict gate): the render path must stay free of
+readSamples/seek/decoder calls. Adjacent-repo app debt is still reported (and
+fails under --fail-known-debt --include-adjacent) until the app-side sprints
+land in those repos.
 """
 
 from __future__ import annotations
@@ -132,12 +136,14 @@ def default_targets(root: Path, include_adjacent: bool) -> list[ScanTarget]:
             r"void\s+TransportController::processAudio\s*\(",
             False,
         ),
-        ScanTarget(
-            "libsndfile reader",
-            root / "src/core/audio_io/audio_file_reader_libsndfile.cpp",
-            r"Result<size_t>\s+AudioFileReaderLibsndfile::readSamples\s*\(",
-            False,
-        ),
+        # ORP134 G1 note: the former "libsndfile reader" target is retired.
+        # AudioFileReaderLibsndfile::readSamples of course contains readSamples/
+        # sf_readf_float — that is its job. It was tracked as debt only because
+        # the transport render path used to CALL it from the audio callback;
+        # since the prepared/streaming clip-source migration, readers are
+        # background-only decode APIs (prepareClipAudio / MediaStreamWorker)
+        # and the render-path target above is the strict gate that keeps them
+        # off the callback.
     ]
 
     if include_adjacent:


### PR DESCRIPTION
## Summary

This PR lands the ORP133 realtime callback safety truth pass, the ORP136 verification bootstrap, and the ORP134 streaming-reader sprint — delivering zero-allocation audio threads, lock-free command processing, and prepared/streaming clip sources that eliminate file I/O from the audio callback. ORP135 was deliberately not implemented (directional bets only); its follow-on scaffold is `docs/orp/ORP137`.

## Key Changes

### ORP133: Realtime Callback Safety & Contract Truth
- **Audio→UI event ring is now POD (G1).** Replaced `std::function` payloads with trivially-copyable `TransportEvent` structs; `processCallbacks()` translates them to public `ITransportCallback` virtuals on the UI thread. Emission points map 1:1 to the old sites (ordering test included). No public API change.
- **`stopAllInGroup()` deprecated → `NotSupported` (G2).** It was a silent no-op in every release — the transport has no clip→group mapping; grouping is a host concern built on `stopOtherClips()` (ORP127 G7). Dead `StopGroup` command arm deleted; deprecate-and-report, not a silent behavior change.
- **Command-queue threading contract enforced (G3).** Control-mutating transport methods are single-producer; debug builds assert if commands are posted from multiple threads (death test, TSAN-green). All entry points funnel through one `postCommand()` choke point.
- **Version truth (G4) + docs truth pass (G5).** SDK version is **0.3.0**, sourced from `project(orpheus VERSION ...)`; README/ARCHITECTURE/ROADMAP/docs indexes no longer describe the extracted `apps/clip-composer`, removed CMake options, or the archived TypeScript layer as live.
- **Docs-path validation (G6).** New `tools/docs_path_audit.py` gate (ctest + CI lint step) fails on broken internal links, unlabeled references to the extracted app subdir, and CMake options that no longer exist. Red/green verified.

### ORP136: Verification Bootstrap (built before the streaming migration, as required)
- **Runtime realtime-safety harness (§2.2).** `tests/support/rt_guard.hpp` provides `RtSection` RAII markers, global allocation hooks, and `/proc/self/io` syscall sampling; `realtime_harness_test.cpp` proves zero allocations and zero file I/O across multi-clip render stress runs, with a detector self-test proving it reds on real violations.
- **Determinism gates (§2.3).** `transport_render_hash_test.cpp` verifies bit-identical output across block sizes 256/512/1024/2048 (the parity oracle for the G1 migration); `DitheredRenderIsSeedDeterministic` closes the offline loop (same job descriptor → identical bytes including dither; different seed → different bytes).

### ORP134: Streaming Clip Sources & Platform Primitives
- **Prepared/streaming clip sources (G1 — the defining migration).** New `clip_source.h/cpp`: `IClipSource` (immutable, position-explicit PCM view), `PreparedClipSource` (whole file decoded to memory on the control thread), `StreamingClipSource` (fixed 4×64k-frame page ring for long files, strict FREE/READY ownership handoff — TSAN-clean by construction), and `MediaStreamWorker` (lazy background refill thread). A streaming cache miss renders silence + emits `onBufferUnderrun` — never blocks. Seeks became prefetch hints; there is no file cursor near the callback, which also makes multi-voice playback of one clip correct by construction. Public transport API unchanged; `startClip()` prepares lazily via `ensurePreparedSourceLocked()` for hosts that never call `prepareClipAudio()`.
- **Identity & time-domain primitives (G2).** `identity.h` (strong-typed `SessionId`/`TrackId`/`ClipId`/`MediaId`/`AutomationLaneId` + deterministic `IdAllocator`), `time_domain.h` (sample-canonical `TimePoint`/`TimeRange` with derived seconds/beats/timecode views), `media_model.h` (`MediaRegion`, `Take`, `ClipSlot`, `LauncherScene`). All additive — the pointer-based `SessionGraph` is untouched. JSON round-trip by ID (incl. >2^53 safety) + installed-header compile gate.
- **Graph-neutral routing seam (G3).** `audio_graph.h/cpp`: sources/processors/buses/sinks/sends/taps vocabulary as a validated `GraphDescription`; `makeSoundboardGraph()` expresses the transport's hard-wired topology and `toRoutingConfig()` maps it onto the existing matrix (not replaced). Tests prove the facade equals the transport's config and that the vocabulary expresses FourTrack buses and FreqFinder taps.
- **Audio file writer (G5 / FTR007).** `audio_file_writer.h` + libsndfile implementation: WAV/AIFF (Int16/Int24/Float32) and FLAC (Int16/Int24, Float32 rejected). Round-trip tests through the SDK's own reader: bit-exact float32 WAV, ≤1 LSB integer encodings. FourTrack can drop its local `WavWriter`.
- **Offline analysis facade (G6).** `audio_analysis.h/cpp` (`orpheus::analysis`): radix-2 FFT/STFT, RMS/peak, integrated LUFS (wraps `LoudnessMeter` — float-exact parity asserted, not re-implemented), spectral centroid/rolloff, spectral-flux onsets, in-memory waveform proxy. Correctness gates on known signals.
- **Lock-free input ring & capture contract (G7).** `audio_input.h/cpp`: `AudioInputRing` (SPSC, audio-thread producer never blocks, drops whole buffers on overflow and counts them) + `IAudioInputStream`. Paired with the G5 writer, "capture → disk" is now an SDK-supported path (integration test verifies every sample). Take/punch/latency policy stays host-side by design.
- **Scene manager wiring (G8).** `ISceneManager::setRoutingMatrix()` promoted to the public interface (it previously existed only on the hidden concrete class — routing capture/recall was unreachable). New tests cover capture/recall of group assignments/gains and an 8-tab out-of-order page-switching round-trip. `assignedClips` documented as host presentation state by design.

## Verification

- **`tools/realtime_audit.py --fail-known-debt` passes with 0 findings** and now runs strict in CI (`realtime_static_audit` flipped from report → fail).
- **Bit-exact parity:** identical golden render hash before/after the streaming migration, at all four block sizes.
- **Runtime-measured:** file-backed callback went from ~2,400 read syscalls / ~4.9 MB per 300 buffers to ~0, with zero allocations.
- 132/132 ctest green (Debug + ASan/UBSan); transport and all new suites green under ThreadSanitizer; Release build clean; clang-format-14 clean; docs-path gate green.

## Reconciliation note (ORP132 §3)

`--fail-known-debt --include-adjacent` still reports the Clip Composer analyzer and FourTrack engine reads — app-repo debt that `REALTIME_AUDIT.md` assigns to the downstream sprints. The SDK's contribution to the cross-repo gate is now zero.

## Downstream follow-ups (separate sprints, not this PR)

- **FourTrack:** adopt prepared/streaming sources in `Engine::processAudio()`; replace local `WavWriter` with `IAudioFileWriter`; adopt `IAudioInputStream`. Bump submodule pin.
- **Clip Composer:** move in-callback analyzer to a telemetry ring; wire `setRoutingMatrix()` for tab/scene recall. Bump submodule pin. Note: prepared clips now decode fully to RAM (≤ ~30 s threshold; longer files stream) — sessions that prewarm every clip will use more memory.
- **FreqFinder:** adopt `orpheus::analysis` and the graph `Tap` vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQay4F5iFZfNAHCixsvrkS