### PR TITLE
ORP134: Bidirectional streaming window & deterministic export

### DIFF
--- a/include/orpheus/clip_source.h
+++ b/include/orpheus/clip_source.h
@@ -103,10 +103,16 @@ private:
 };
 
 /// Fixed-page streaming source for long files.
+///
+/// The resident window is BIDIRECTIONAL (FTR025 T3b): one page behind the
+/// demand position plus the demand page and two pages ahead. Forward playback
+/// keeps ~2.7 s of lookahead; reverse/scrub playback keeps ~1.4 s of runway
+/// behind the cursor, so position-explicit reads serve true backward playback
+/// (descending positions) without a miss at every backward page crossing.
 class StreamingClipSource : public IClipSource {
 public:
   static constexpr size_t kPageFrames = 65536; ///< frames per page (~1.4s @ 48k)
-  static constexpr size_t kNumPages = 4;       ///< resident window ≈ 5.5s @ 48k
+  static constexpr size_t kNumPages = 4;       ///< 1 behind + demand page + 2 ahead (≈5.5s @ 48k)
 
   /// BACKGROUND/CONTROL THREAD. The reader is retained and used exclusively
   /// from worker/control threads (guarded by an internal mutex).
@@ -127,10 +133,13 @@ public:
     return false;
   }
 
-  /// Fill every page of the window starting at `pos` synchronously.
-  /// CONTROL/WORKER THREAD. Called by prepareClipAudio so playback from the
-  /// trim-in point starts without an initial underrun.
-  void prefill(int64_t pos);
+  /// Fill up to `max_pages` non-resident pages of the window around `pos`
+  /// synchronously — the demand page first, then the forward pages, then the
+  /// behind page. CONTROL/WORKER THREAD. Called by prepareClipAudio so
+  /// playback from the trim-in point starts without an initial underrun.
+  /// Hosts with latency-bounded transitions can pass max_pages = 1 to prime
+  /// only the audible page and leave the rest to the worker.
+  void prefill(int64_t pos, size_t max_pages = kNumPages);
 
   /// One worker pass: refill FREE pages inside the current demand window.
   /// WORKER THREAD ONLY.

--- a/src/core/audio_io/audio_file_writer_libsndfile.cpp
+++ b/src/core/audio_io/audio_file_writer_libsndfile.cpp
@@ -98,6 +98,13 @@ SessionGraphError AudioFileWriterLibsndfile::open(const std::string& file_path,
   // letting them wrap (libsndfile default float->int conversion can wrap).
   sf_command(m_file, SFC_SET_CLIPPING, nullptr, SF_TRUE);
 
+  // libsndfile adds a PEAK chunk to float WAV/AIFF by default, and that chunk
+  // embeds a wall-clock timestamp — the same input would produce different
+  // bytes on every run, violating the SDK's bit-identical determinism
+  // guarantee (and FourTrack's byte-identical export gate, FTR025). Peak
+  // metadata is a nicety, determinism is a contract: disable it.
+  sf_command(m_file, SFC_SET_ADD_PEAK_CHUNK, nullptr, SF_FALSE);
+
   m_file_path = file_path;
   m_frames_written.store(0, std::memory_order_release);
 

--- a/src/core/audio_io/audio_file_writer_libsndfile.cpp
+++ b/src/core/audio_io/audio_file_writer_libsndfile.cpp
@@ -175,7 +175,13 @@ SessionGraphError AudioFileWriterLibsndfile::close() {
     return SessionGraphError::OK; // Already closed — idempotent
   }
 
-  sf_write_sync(m_file);
+  // sf_close() flushes all encoder state through to the OS; it deliberately
+  // does NOT fsync. Durability ordering is host policy — hosts with an
+  // explicit fsync discipline (e.g. FourTrack's FTR002 commit-marker order)
+  // fsync at their own commit points. An unconditional sf_write_sync here
+  // put a multi-millisecond blocking fsync inside every close, which hosts
+  // cannot opt out of and which broke FourTrack's sub-ms transport
+  // transition bound the moment close() sat on a record-stop path.
   const int err = sf_close(m_file);
   m_file = nullptr;
   m_is_open.store(false, std::memory_order_release);

--- a/src/core/transport/clip_source.cpp
+++ b/src/core/transport/clip_source.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "clip_source.h"
+#include <orpheus/clip_source.h>
 
 #include <algorithm>
 #include <chrono>
@@ -96,14 +96,16 @@ bool StreamingClipSource::read(int64_t pos, float* dest, size_t frames, size_t& 
   size_t toCopy = static_cast<size_t>(std::min<int64_t>(static_cast<int64_t>(frames), available));
 
   // Publish the demand position and retire every READY page outside the
-  // demand window [alignDown(pos), +kNumPages pages). Retirement here — on
-  // the audio thread, the pages' owner — is what hands FREE pages back to the
-  // worker after seeks/loops; without it the ring would pin stale pages
-  // forever. (Release store; the worker acquires before writing.)
+  // demand window — one page BEHIND the demand page (reverse/scrub runway,
+  // FTR025 T3b) through two pages ahead. Retirement here — on the audio
+  // thread, the pages' owner — is what hands FREE pages back to the worker
+  // after seeks/loops; without it the ring would pin stale pages forever.
+  // (Release store; the worker acquires before writing.) The window must
+  // match what prefill()/service() fill, or the two sides would thrash.
   m_demand.store(pos, std::memory_order_relaxed);
-  const int64_t windowBase = alignDown(pos);
+  const int64_t windowBase = alignDown(pos) - static_cast<int64_t>(kPageFrames);
   const int64_t windowEnd =
-      windowBase + static_cast<int64_t>(kNumPages) * static_cast<int64_t>(kPageFrames);
+      alignDown(pos) + static_cast<int64_t>(kNumPages - 1) * static_cast<int64_t>(kPageFrames);
   for (auto& page : m_pages) {
     const int64_t start = page.start.load(std::memory_order_acquire);
     if (start >= 0 && (start < windowBase || start >= windowEnd)) {
@@ -169,12 +171,25 @@ bool StreamingClipSource::fillPage(int64_t alignedStart) {
   return true;
 }
 
-void StreamingClipSource::prefill(int64_t pos) {
+void StreamingClipSource::prefill(int64_t pos, size_t max_pages) {
   const int64_t base = alignDown(std::max<int64_t>(0, pos));
-  for (size_t i = 0; i < kNumPages; ++i) {
-    const int64_t start = base + static_cast<int64_t>(i) * static_cast<int64_t>(kPageFrames);
-    if (start >= m_lengthFrames) {
-      break;
+
+  // Fill order: the audible (demand) page first, then the forward pages, then
+  // the behind page — so a max_pages-capped prime always makes the position
+  // under the cursor playable, and reverse runway comes after lookahead. The
+  // candidate set matches the retirement window in read() exactly.
+  int64_t wanted[kNumPages];
+  size_t num_wanted = 0;
+  for (size_t i = 0; i + 1 < kNumPages; ++i) {
+    wanted[num_wanted++] = base + static_cast<int64_t>(i) * static_cast<int64_t>(kPageFrames);
+  }
+  wanted[num_wanted++] = base - static_cast<int64_t>(kPageFrames);
+
+  size_t filled = 0;
+  for (size_t i = 0; i < num_wanted && filled < max_pages; ++i) {
+    const int64_t start = wanted[i];
+    if (start < 0 || start >= m_lengthFrames) {
+      continue;
     }
     bool resident = false;
     for (auto& page : m_pages) {
@@ -183,8 +198,8 @@ void StreamingClipSource::prefill(int64_t pos) {
         break;
       }
     }
-    if (!resident) {
-      fillPage(start);
+    if (!resident && fillPage(start)) {
+      ++filled;
     }
   }
 }

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "clip_source.h" // ORP134 G1: prepared/streaming realtime sources
+#include <orpheus/clip_source.h> // ORP134 G1: prepared/streaming realtime sources
 
 #include <orpheus/audio_file_reader.h>
 #include <orpheus/routing_matrix.h>

--- a/tests/audio_io/audio_file_writer_test.cpp
+++ b/tests/audio_io/audio_file_writer_test.cpp
@@ -11,12 +11,15 @@
 #include "../support/fnv1a64.hpp"
 #include "../support/synth.hpp"
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace orpheus;
@@ -221,6 +224,47 @@ TEST_F(AudioFileWriterTest, WriteBeforeOpenReturnsNotReady) {
   auto result = m_writer->writeSamples(dummy, 1);
   EXPECT_EQ(result.error, SessionGraphError::NotReady);
   EXPECT_EQ(m_writer->getFramesWritten(), 0);
+}
+
+TEST_F(AudioFileWriterTest, RepeatedWritesAreByteIdentical) {
+  // Determinism is a contract: the same samples must produce the same file
+  // bytes on every run. libsndfile's default PEAK chunk for float files embeds
+  // a wall-clock timestamp, which broke this — the writer disables it.
+  auto readBytes = [](const std::filesystem::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+  };
+
+  const struct {
+    AudioFileFormat format;
+    AudioSampleFormat sample_format;
+    const char* ext;
+  } cases[] = {
+      {AudioFileFormat::WAV, AudioSampleFormat::Float32, "wav"},
+      {AudioFileFormat::AIFF, AudioSampleFormat::Float32, "aiff"},
+      {AudioFileFormat::FLAC, AudioSampleFormat::Int24, "flac"},
+  };
+  for (const auto& c : cases) {
+    AudioFileWriterConfig config;
+    config.format = c.format;
+    config.sample_format = c.sample_format;
+
+    std::filesystem::path paths[2];
+    for (int run = 0; run < 2; ++run) {
+      paths[run] = m_tempDir / ("det_" + std::to_string(run) + "." + c.ext);
+      ASSERT_EQ(m_writer->open(paths[run].string(), config), SessionGraphError::OK);
+      auto result = m_writer->writeSamples(m_signal.data(), kFrames);
+      ASSERT_TRUE(result.isOk());
+      ASSERT_EQ(m_writer->close(), SessionGraphError::OK);
+      // A wall-clock-stamped chunk only differs across seconds; make sure the
+      // two runs cannot land in the same second and mask the regression.
+      if (run == 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+      }
+    }
+    EXPECT_EQ(readBytes(paths[0]), readBytes(paths[1]))
+        << "." << c.ext << " output must be byte-identical across runs";
+  }
 }
 
 TEST_F(AudioFileWriterTest, MonoAndHighRateConfigs) {

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -400,6 +400,56 @@ TEST_F(RealtimeHarnessTest, StreamingClipSourceMissIsNonBlockingAndRecovers) {
   EXPECT_EQ(framesRead, kBufferFrames);
 }
 
+TEST_F(RealtimeHarnessTest, StreamingSourceServesDescendingReadsAcrossPageBoundaries) {
+  // FTR025 T3b: reverse scrub reads DESCENDING positions. The demand window
+  // keeps one page behind the demand page, so backward page crossings land on
+  // resident pages (given ordinary worker passes) all the way down to frame 0
+  // — no miss-per-page-boundary, no silence cliff.
+  std::string path = writeSineWav(m_tempDir, "stream_rev.wav", 220.0f, 10.0f);
+  auto reader = createAudioFileReader();
+  ASSERT_NE(reader, nullptr);
+  auto opened = reader->open(path);
+  ASSERT_TRUE(opened.isOk());
+  const uint16_t channels = opened.value.num_channels;
+
+  auto source =
+      std::make_shared<StreamingClipSource>(std::shared_ptr<IAudioFileReader>(std::move(reader)),
+                                            channels, opened.value.duration_samples);
+
+  // Start deep in the file (inside page 3, ~4.3s) and walk backward to 0.
+  const int64_t start = 3 * static_cast<int64_t>(StreamingClipSource::kPageFrames) + 1000;
+  source->prefill(start);
+
+  std::vector<float> buffer(kBufferFrames * channels, 0.0f);
+  int64_t pos = start;
+  int misses = 0;
+  int reads = 0;
+  while (pos >= 0) {
+    size_t framesRead = 0;
+    if (!source->read(pos, buffer.data(), kBufferFrames, framesRead)) {
+      ++misses;
+    } else {
+      EXPECT_GT(framesRead, 0u) << "descending read at " << pos;
+      float peak = 0.0f;
+      for (size_t i = 0; i < framesRead * channels; ++i) {
+        peak = std::max(peak, std::abs(buffer[i]));
+      }
+      EXPECT_GT(peak, 0.01f) << "silent descending read at " << pos;
+    }
+    ++reads;
+    // One synchronous worker pass per buffer — far LESS worker time than the
+    // production 10ms poll provides (~9 buffers per pass at 48k/512).
+    source->service();
+    if (pos == 0) {
+      break;
+    }
+    pos = std::max<int64_t>(0, pos - static_cast<int64_t>(kBufferFrames));
+  }
+
+  EXPECT_EQ(misses, 0) << "backward page crossings missed (" << misses << "/" << reads
+                       << " reads) — the behind-page window is not being kept resident";
+}
+
 // ============================================================================
 // Callback duration accounting (report always; bound only unsanitized).
 // ============================================================================


### PR DESCRIPTION
## Summary

Extends `StreamingClipSource` to support true backward playback (reverse scrub, descending position reads) by maintaining a bidirectional resident window—one page behind the demand position plus lookahead pages. Also hardens audio file export determinism by disabling libsndfile's wall-clock-stamped PEAK chunk and removing a blocking fsync from the close path.

## Key Changes

**Transport (Bidirectional Streaming Window)**
- Shift resident window to include one page *behind* the demand position (FTR025 T3b), enabling reverse/scrub playback without a miss at every backward page crossing
- Update `read()` retirement logic to retire pages outside the new window bounds (one page behind through two pages ahead)
- Refactor `prefill()` to accept `max_pages` parameter and fill in priority order: demand page first, then forward pages, then behind page—ensures latency-bounded transitions can prime only the audible page
- Add comprehensive test `StreamingSourceServesDescendingReadsAcrossPageBoundaries` validating zero-miss backward playback across page boundaries

**Audio File Writer (Determinism)**
- Disable libsndfile's default PEAK chunk on float WAV/AIFF files via `SFC_SET_ADD_PEAK_CHUNK` (the chunk embeds a wall-clock timestamp, breaking bit-identical determinism)
- Remove `sf_write_sync()` call from `close()` path—durability is host policy; unconditional fsync blocked FourTrack's sub-millisecond transport transitions
- Add test `RepeatedWritesAreByteIdentical` verifying output is byte-identical across runs for WAV, AIFF, and FLAC formats

**Include Path Cleanup**
- Update local includes to use public header path: `#include <orpheus/clip_source.h>` (was `#include "clip_source.h"`)

## Implementation Details

- Window size remains 4 pages (~5.5s @ 48kHz): 1 behind + demand + 2 ahead
- Forward playback keeps ~2.7s lookahead; reverse playback keeps ~1.4s runway behind cursor
- `prefill()` fill order ensures max_pages-capped priming always makes the demand position playable
- Retirement window in `read()` matches the candidate set in `prefill()` exactly to prevent thrashing
- PEAK chunk disabling is a libsndfile command-level setting; no file format changes

https://claude.ai/code/session_014hL3obM8MAwTX2rVtG9C3g