### PR TITLE
feat(transport): derive TransportPosition::beats from live session tempo (FTR027 §1)

### DIFF
--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -63,7 +63,7 @@ enum class VoiceMode : uint8_t {
 struct TransportPosition {
   int64_t samples; ///< Absolute position in samples (authoritative)
   double seconds;  ///< Derived: samples / sample_rate
-  double beats;    ///< Derived: seconds * tempo / 60.0
+  double beats;    ///< Derived: seconds * session tempo (SessionGraph::tempo) / 60.0
 };
 
 /// Clip metadata for batch updates
@@ -282,6 +282,11 @@ public:
   ///
   /// This function is thread-safe and can be called from any thread.
   /// Position is sample-accurate (±1 sample tolerance).
+  ///
+  /// Beats are derived from the session tempo (SessionGraph::tempo). The
+  /// tempo is sampled at construction and republished on each
+  /// processCallbacks() pump, so a set_tempo() change is reflected in beats
+  /// after the next pump (FTR027 §1).
   ///
   /// @return Current transport position (samples, seconds, beats)
   virtual TransportPosition getCurrentPosition() const = 0;

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -106,8 +106,12 @@ TransportController::TransportController(core::SessionGraph* sessionGraph, uint3
     m_clipChannelPointers[i] = m_clipChannelBuffers[i].data();
   }
 
-  // TODO: m_sessionGraph will be used for querying clip metadata (trim points, routing, etc.)
-  (void)m_sessionGraph; // Suppress unused warning for now
+  // FTR027 §1: seed the tempo cache from the session graph so beats derive
+  // from the real session tempo immediately, before the first
+  // processCallbacks() pump.
+  if (m_sessionGraph) {
+    m_tempoBpm.store(m_sessionGraph->tempo(), std::memory_order_relaxed);
+  }
 }
 
 TransportController::~TransportController() = default;
@@ -283,8 +287,11 @@ TransportPosition TransportController::getCurrentPosition() const {
   position.samples = samples;
   position.seconds = static_cast<double>(samples) / static_cast<double>(m_sampleRate);
 
-  // TODO: Get tempo from SessionGraph
-  double tempo = 120.0; // Default tempo
+  // FTR027 §1: beats derive from the live session tempo. Read through the
+  // atomic cache, not SessionGraph::tempo() directly — this query is called
+  // from the audio thread (event position stamps) and tempo() is a plain
+  // control-thread field.
+  double tempo = m_tempoBpm.load(std::memory_order_relaxed);
   position.beats = position.seconds * tempo / 60.0;
 
   return position;
@@ -1340,6 +1347,14 @@ void TransportController::postTransportEvent(const TransportEvent& event) {
 }
 
 void TransportController::processCallbacks() {
+  // FTR027 §1: pick up session tempo changes on the control-thread pump.
+  // SessionGraph::set_tempo() mutates a plain field on the (single) control
+  // thread; this same-thread read republishes it through the atomic cache for
+  // getCurrentPosition() readers on any thread.
+  if (m_sessionGraph) {
+    m_tempoBpm.store(m_sessionGraph->tempo(), std::memory_order_relaxed);
+  }
+
   // ORP121 C-03 / ORP133 G1: Lock-free SPSC event queue
   // UI thread reads POD events from the ring buffer (no mutex, no blocking)
   // and translates them into the host's ITransportCallback virtuals. Events

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -412,6 +412,14 @@ private:
   // Transport position (audio thread writes, UI thread reads)
   std::atomic<int64_t> m_currentSample{0};
 
+  // FTR027 §1: session tempo cache. SessionGraph::tempo() is a plain double
+  // mutated on the control thread, but getCurrentPosition() derives beats on
+  // the audio thread (event position stamps) and on arbitrary query threads —
+  // so the live value is published through this atomic instead of read from
+  // the graph directly. Seeded in the constructor, refreshed on every
+  // processCallbacks() pump (control thread).
+  std::atomic<double> m_tempoBpm{120.0};
+
   // ORP121 C-03 / ORP133 G1: Lock-free event queue (Audio → UI thread)
   // SPSC ring buffer: Audio thread writes, UI thread reads - no contention
   // Power of 2 size for efficient modulo via bitwise AND. Payload is the POD

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -3,6 +3,12 @@
 #include <gtest/gtest.h>
 #include <orpheus/transport_controller.h>
 
+// FTR027 §1: concrete controller access for processAudio()/processCallbacks()
+#include "transport/transport_controller.h"
+
+#include <memory>
+#include <vector>
+
 using namespace orpheus;
 
 // Mock session graph for testing
@@ -111,6 +117,57 @@ TEST_F(TransportControllerTest, GetCurrentPosition) {
   // Initially at sample 0
   EXPECT_EQ(pos.samples, 0);
   EXPECT_DOUBLE_EQ(pos.seconds, 0.0);
+}
+
+namespace {
+
+// Advance the transport by exactly one second of silence (no active clips —
+// the timeline still moves).
+void advanceOneSecond(TransportController& transport, uint32_t sampleRate) {
+  constexpr size_t kBlock = 480;
+  std::vector<float> left(kBlock, 0.0f);
+  std::vector<float> right(kBlock, 0.0f);
+  float* buffers[2] = {left.data(), right.data()};
+  for (uint32_t rendered = 0; rendered < sampleRate; rendered += kBlock) {
+    transport.processAudio(buffers, 2, kBlock);
+  }
+}
+
+} // namespace
+
+// FTR027 §1: TransportPosition::beats derives from the session graph's real
+// tempo, not a hardcoded 120 BPM.
+TEST_F(TransportControllerTest, BeatsFollowSessionTempoAtConstruction) {
+  m_sessionGraph->set_tempo(90.0);
+  auto transport = std::make_unique<TransportController>(m_sessionGraph.get(), 48000);
+
+  advanceOneSecond(*transport, 48000);
+
+  TransportPosition pos = transport->getCurrentPosition();
+  EXPECT_EQ(pos.samples, 48000);
+  EXPECT_DOUBLE_EQ(pos.seconds, 1.0);
+  // 90 BPM = 1.5 beats per second. The old hardcoded tempo would report 2.0.
+  EXPECT_DOUBLE_EQ(pos.beats, 1.5);
+}
+
+// FTR027 §1: a set_tempo() change after construction reaches beats on the
+// next processCallbacks() pump.
+TEST_F(TransportControllerTest, BeatsTrackLiveTempoChange) {
+  auto transport = std::make_unique<TransportController>(m_sessionGraph.get(), 48000);
+
+  advanceOneSecond(*transport, 48000);
+
+  // Session default is 120 BPM = 2 beats per second.
+  EXPECT_DOUBLE_EQ(transport->getCurrentPosition().beats, 2.0);
+
+  m_sessionGraph->set_tempo(150.0);
+
+  // Not yet published: beats still reflect the previously cached tempo.
+  EXPECT_DOUBLE_EQ(transport->getCurrentPosition().beats, 2.0);
+
+  transport->processCallbacks(); // control-thread pump republishes the tempo
+
+  EXPECT_DOUBLE_EQ(transport->getCurrentPosition().beats, 2.5);
 }
 
 TEST_F(TransportControllerTest, Callback) {


### PR DESCRIPTION
## Summary

Implements §1 of the FTR027 advisory (FourTrack → SDK): wire `SessionGraph::tempo_bpm_` into the transport so `TransportPosition::beats` derives from the real session tempo instead of the hardcoded `double tempo = 120.0` stub behind the `// TODO: Get tempo from SessionGraph` in `transport_controller.cpp`.

## Design

`getCurrentPosition()` is not only a UI-thread query — the audio thread calls it to stamp positions onto transport events (ClipStarted/Stopped/Looped, BufferUnderrun). `SessionGraph::tempo()` reads a plain `double` mutated by control-thread `set_tempo()`, so reading the graph directly from this query would be a data race and would break the documented "queries are lock-free readers of a published snapshot" contract (ORP133 G3).

Instead, the tempo is published through an `std::atomic<double>` cache on `TransportController`:

- **Seeded at construction** from `SessionGraph::tempo()` (this also retires the `(void)m_sessionGraph` unused-warning suppression — the graph is now genuinely consumed).
- **Refreshed on each `processCallbacks()` pump** — a same-thread read of the control-thread field, republished through the atomic for readers on any thread.
- **Read relaxed in `getCurrentPosition()`**, keeping the query audio-safe (no locks, no allocation).

A `set_tempo()` change is therefore reflected in `beats` after the next `processCallbacks()` pump; the public header documents this pickup semantic.

Explicitly **not** in scope, per FTR027 §1: no `TimeSignature` or bar concept (that stays host-owned), and no `ITriggerVoice` primitive (a future de-duplication play — if ever built, it should be a standalone utility in the `PolyphaseResampler` mold, not a new pure-virtual on `IAudioFileReader`/`IRoutingMatrix`, since a new `= 0` breaks existing implementers).

## Tests

Two new cases in `transport_controller_test`:

- `BeatsFollowSessionTempoAtConstruction` — session at 90 BPM, advance exactly one second of audio, assert `beats == 1.5` (the old hardcoded tempo would report 2.0).
- `BeatsTrackLiveTempoChange` — default 120 BPM reports 2.0 beats after one second; `set_tempo(150)` is not visible until `processCallbacks()` runs, then `beats == 2.5`.

Full suite: **132/132 ctest cases pass** (Debug, ASan + UBSan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fmdwTtjBXuqmWqteLggQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_014fmdwTtjBXuqmWqteLggQ9)_