### PR TITLE
fix(routing): remove processRouting block-size ceiling via internal chunking (FTR028)

### DIFF
--- a/include/orpheus/routing_matrix.h
+++ b/include/orpheus/routing_matrix.h
@@ -22,6 +22,20 @@ class IRoutingCallback;
 /// Special value indicating channel is not assigned to any group
 constexpr uint8_t UNASSIGNED_GROUP = 255;
 
+/// FTR028: Internal processing-slice size (frames) used by processRouting().
+///
+/// The routing matrix pre-allocates its scratch buffers to this size and
+/// processes audio in slices no larger than this on the real-time path (no
+/// audio-thread allocation, ever). processRouting() accepts an arbitrary
+/// num_frames and chunks internally over slices of this size, so hosts do NOT
+/// need to cap their block size against it.
+///
+/// It is exposed so real-time hosts that want each processRouting() call to
+/// map to exactly one internal slice (e.g. to align with their audio device
+/// buffer size) can size their render blocks against it. Offline hosts
+/// (bounce/export) may pass blocks of any size and let chunking handle it.
+constexpr uint32_t kRoutingSliceFrames = 2048;
+
 // ============================================================================
 // Routing Configuration Types
 // ============================================================================
@@ -403,13 +417,29 @@ public:
   ///
   /// @param channel_inputs Input buffers [num_channels][num_frames] (planar float32)
   /// @param master_output Output buffer [num_outputs][num_frames] (planar float32)
-  /// @param num_frames Number of frames to process
+  /// @param num_frames Number of frames to process (any size; see @note below)
   /// @return Error code (unlikely to fail in audio thread)
   ///
   /// @note Zero allocations, lock-free, real-time safe
   /// @note Input buffers can be nullptr for channels with no audio
+  /// @note FTR028: num_frames may be arbitrarily large. Internally the matrix
+  ///       processes the buffer in slices of at most kRoutingSliceFrames
+  ///       (== maxBlockFrames()); this chunking is allocation-free and
+  ///       lock-free, so large offline blocks (bounce/export) "just work"
+  ///       without the host needing to cap its render block size. Metering
+  ///       reflects the final slice of the call.
   virtual SessionGraphError processRouting(const float* const* channel_inputs,
                                            float** master_output, uint32_t num_frames) = 0;
+
+  /// FTR028: Largest number of frames processed in a single internal slice.
+  ///
+  /// processRouting() accepts any num_frames and chunks internally, so hosts
+  /// are NOT required to respect this limit. It is exposed so real-time hosts
+  /// that want a 1:1 mapping between a processRouting() call and one internal
+  /// slice can size their render loops against it.
+  ///
+  /// @return Slice size in frames (kRoutingSliceFrames)
+  virtual uint32_t maxBlockFrames() const = 0;
 };
 
 // ============================================================================

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -511,13 +511,64 @@ SessionGraphError RoutingMatrix::reset() {
 // Audio Processing
 // ============================================================================
 
+uint32_t RoutingMatrix::maxBlockFrames() const {
+  return static_cast<uint32_t>(MAX_BUFFER_SIZE);
+}
+
 SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inputs,
                                                 float** master_output, uint32_t num_frames) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
 
+  // FTR028: Accept arbitrarily large blocks by chunking over slices of at most
+  // MAX_BUFFER_SIZE frames. This is allocation-free and lock-free — we only
+  // offset into the caller-supplied planar buffers and reuse the pre-allocated
+  // scratch inside processRoutingBlock. Offline hosts (bounce/export) can pass
+  // any block size and it "just works"; the previous private ceiling no longer
+  // silently rejects large blocks.
+  //
+  // Get active config (lock-free read) to know the channel/output counts for
+  // pointer offsetting.
+  {
+    int cfg_idx = m_active_config_idx.load(std::memory_order_acquire);
+    const RoutingConfig& cfg = m_config_buffers[cfg_idx];
+
+    // Stack-resident pointer scratch (no heap allocation). Sized to the ABI
+    // maxima (64 channels, 32 outputs) so a large channel/output count never
+    // allocates on the audio path.
+    const float* input_slice_ptrs[64];
+    float* output_slice_ptrs[32];
+
+    uint32_t offset = 0;
+    while (offset < num_frames) {
+      const uint32_t slice =
+          std::min<uint32_t>(num_frames - offset, static_cast<uint32_t>(MAX_BUFFER_SIZE));
+
+      for (uint8_t ch = 0; ch < cfg.num_channels; ++ch) {
+        const float* in = channel_inputs ? channel_inputs[ch] : nullptr;
+        input_slice_ptrs[ch] = in ? (in + offset) : nullptr;
+      }
+      for (uint8_t out = 0; out < cfg.num_outputs; ++out) {
+        output_slice_ptrs[out] = master_output[out] + offset;
+      }
+
+      SessionGraphError err = processRoutingBlock(input_slice_ptrs, output_slice_ptrs, slice);
+      if (err != SessionGraphError::OK) {
+        return err;
+      }
+
+      offset += slice;
+    }
+  }
+
+  return SessionGraphError::OK;
+}
+
+SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel_inputs,
+                                                     float** master_output, uint32_t num_frames) {
   if (num_frames > MAX_BUFFER_SIZE) {
+    // Defensive: processRouting() never hands us a slice larger than this.
     return SessionGraphError::InvalidParameter;
   }
 

--- a/src/core/routing/routing_matrix.h
+++ b/src/core/routing/routing_matrix.h
@@ -147,8 +147,16 @@ public:
   // Audio processing
   SessionGraphError processRouting(const float* const* channel_inputs, float** master_output,
                                    uint32_t num_frames) override;
+  uint32_t maxBlockFrames() const override;
 
 private:
+  // FTR028: Process a single slice of at most MAX_BUFFER_SIZE frames. The
+  // public processRouting() loops over this for arbitrarily large blocks;
+  // this stays allocation-free and lock-free (operates on pre-allocated
+  // scratch), so large offline blocks incur no audio-thread allocation.
+  SessionGraphError processRoutingBlock(const float* const* channel_inputs, float** master_output,
+                                        uint32_t num_frames);
+
   // Internal helpers
   void initializeChannels();
   void initializeGroups();
@@ -197,7 +205,10 @@ private:
   std::vector<StereoGroupBuffer> m_group_buffers; // [num_groups] stereo L/R pairs
   std::vector<float> m_temp_buffer;               // Temp buffer for processing
 
-  static constexpr size_t MAX_BUFFER_SIZE = 2048;
+  // FTR028: Internal slice size. Kept in lock-step with the public
+  // orpheus::kRoutingSliceFrames contract so hosts and the implementation
+  // agree on the chunking granularity.
+  static constexpr size_t MAX_BUFFER_SIZE = kRoutingSliceFrames;
   static constexpr uint8_t UNASSIGNED_GROUP = 255;
 };
 

--- a/tests/routing/routing_matrix_test.cpp
+++ b/tests/routing/routing_matrix_test.cpp
@@ -594,23 +594,27 @@ TEST_F(RoutingMatrixTest, ProcessWithoutInitializeFails) {
   EXPECT_EQ(result, SessionGraphError::NotInitialized);
 }
 
-TEST_F(RoutingMatrixTest, ProcessWithOversizedBufferFails) {
-  matrix->initialize(config);
+TEST_F(RoutingMatrixTest, ProcessWithOversizedBufferSucceeds) {
+  // FTR028: a block larger than the internal slice (MAX_BUFFER_SIZE = 2048) is
+  // no longer rejected — processRouting() chunks it internally and processes
+  // the whole block. (Previously this returned InvalidParameter and produced
+  // no output, which silently summed FourTrack bounces to silence.)
+  matrix->initialize(config); // 4 channels per SetUp()
 
-  // Create oversized buffer (> MAX_BUFFER_SIZE = 2048)
-  auto inputs = createTestInputs(1, 4096);
+  // Inputs must match config.num_channels (4) to be dereferenced safely.
+  auto inputs = createTestInputs(4, 4096);
   auto input_ptrs = toPointerArray(inputs);
 
   std::vector<std::vector<float>> outputs(2);
   for (auto& out : outputs) {
-    out.resize(4096);
+    out.resize(4096, 0.0f);
   }
   auto output_ptrs = toPointerArray(outputs);
 
-  // Process should fail
+  // Process should succeed for the oversized block.
   auto result = matrix->processRouting(input_ptrs.data(), output_ptrs.data(), 4096);
 
-  EXPECT_EQ(result, SessionGraphError::InvalidParameter);
+  EXPECT_EQ(result, SessionGraphError::OK);
 }
 
 // ============================================================================
@@ -800,6 +804,135 @@ TEST_F(RoutingMatrixTest, HeadroomModeLogarithmicAttenuates) {
   float expected_none = 4.0f * (0.707107f * 0.5f);
   float expected_log = expected_none * (1.0f / std::sqrt(4.0f));
   EXPECT_NEAR(outputs[0][BUFFER_SIZE - 1], expected_log, 0.1f);
+}
+
+// ============================================================================
+// FTR028: Block-size ceiling / internal chunking
+// ============================================================================
+//
+// Regression coverage for FTR028: processRouting() must accept blocks larger
+// than the internal slice size (kRoutingSliceFrames == 2048) by chunking
+// internally, rather than silently rejecting them and producing no output.
+// A large offline bounce/export block must pass signal through at the correct
+// gain across the ENTIRE block, including past the 2048-frame boundary.
+
+// Helper: single-channel, single-group config with a DC (constant) input so
+// the expected output is exactly predictable (no smoothing transient: gain and
+// pan default to unity/center and never change, so the smoothers sit still).
+namespace {
+constexpr float kConstantPowerCenter = 0.707f; // pan law at center (-3 dB)
+
+void configureSingleChannelDC(IRoutingMatrix& matrix, RoutingConfig& config) {
+  config.num_channels = 1;
+  config.num_groups = 1;
+  config.num_outputs = 2;
+  config.enable_metering = false;
+  config.enable_clipping_protection = false; // keep math linear for assertions
+  ASSERT_EQ(matrix.initialize(config), SessionGraphError::OK);
+}
+} // namespace
+
+TEST_F(RoutingMatrixTest, ExposesMaxBlockFramesContract) {
+  matrix->initialize(config);
+  // FTR028: the internal slice granularity is exposed publicly and matches the
+  // documented constant.
+  EXPECT_EQ(matrix->maxBlockFrames(), kRoutingSliceFrames);
+  EXPECT_EQ(kRoutingSliceFrames, 2048u);
+}
+
+TEST_F(RoutingMatrixTest, ProcessRoutingBoundaryBlockPassesSignal) {
+  // Exactly the slice boundary (2048) must still work and pass signal.
+  configureSingleChannelDC(*matrix, config);
+
+  const uint32_t frames = kRoutingSliceFrames; // 2048
+  const float amplitude = 0.5f;
+
+  std::vector<float> input(frames, amplitude);
+  const float* input_ptrs[1] = {input.data()};
+
+  std::vector<std::vector<float>> outputs(2, std::vector<float>(frames, -999.0f));
+  auto output_ptrs = toPointerArray(outputs);
+
+  auto result = matrix->processRouting(input_ptrs, output_ptrs.data(), frames);
+  ASSERT_EQ(result, SessionGraphError::OK);
+
+  // DC input through unity gain + constant-power center pan.
+  const float expected = amplitude * kConstantPowerCenter; // ~0.3535
+  EXPECT_NEAR(outputs[0][frames - 1], expected, 0.01f);
+  EXPECT_NEAR(outputs[1][frames - 1], expected, 0.01f);
+}
+
+TEST_F(RoutingMatrixTest, ProcessRoutingLargeBlockChunksAndPassesSignal) {
+  // FTR028 core: a 4096-frame block (2x the internal slice) must NOT be
+  // rejected and must pass signal across the WHOLE block, including samples
+  // past the 2048 boundary that the old ceiling would have dropped.
+  configureSingleChannelDC(*matrix, config);
+
+  const uint32_t frames = 4096; // 2 * kRoutingSliceFrames
+  const float amplitude = 0.5f;
+
+  std::vector<float> input(frames, amplitude);
+  const float* input_ptrs[1] = {input.data()};
+
+  // Pre-fill outputs with a sentinel so untouched samples are detectable.
+  std::vector<std::vector<float>> outputs(2, std::vector<float>(frames, -999.0f));
+  auto output_ptrs = toPointerArray(outputs);
+
+  auto result = matrix->processRouting(input_ptrs, output_ptrs.data(), frames);
+  ASSERT_EQ(result, SessionGraphError::OK);
+
+  const float expected = amplitude * kConstantPowerCenter; // ~0.3535
+
+  // Assert CONTENT at exact sample positions across the entire block:
+  // first sample, just before the boundary, exactly at the boundary (first
+  // sample of the second slice), and the last sample.
+  for (uint32_t pos : {0u, 2047u, 2048u, frames - 1}) {
+    EXPECT_NEAR(outputs[0][pos], expected, 0.01f) << "left @ frame " << pos;
+    EXPECT_NEAR(outputs[1][pos], expected, 0.01f) << "right @ frame " << pos;
+  }
+
+  // No sentinel survived anywhere: every sample was written (no silent tail).
+  for (uint32_t i = 0; i < frames; ++i) {
+    ASSERT_GT(outputs[0][i], expected - 0.05f) << "left silent/untouched @ " << i;
+    ASSERT_GT(outputs[1][i], expected - 0.05f) << "right silent/untouched @ " << i;
+  }
+}
+
+TEST_F(RoutingMatrixTest, ProcessRoutingLargeBlockMatchesChunkedEquivalent) {
+  // The chunked large-block path must produce identical output to feeding the
+  // same signal as consecutive 2048-frame calls — proving chunking is a pure
+  // decomposition, not an approximation. Uses a fresh matrix per path.
+  const uint32_t total = 5000; // deliberately not a multiple of 2048
+  const float amplitude = 0.4f;
+  std::vector<float> input(total, amplitude);
+
+  // Path A: single large call.
+  auto matrixA = createRoutingMatrix();
+  RoutingConfig cfgA = config;
+  configureSingleChannelDC(*matrixA, cfgA);
+  const float* inA[1] = {input.data()};
+  std::vector<std::vector<float>> outA(2, std::vector<float>(total, 0.0f));
+  std::vector<float*> outAptr = {outA[0].data(), outA[1].data()};
+  ASSERT_EQ(matrixA->processRouting(inA, outAptr.data(), total), SessionGraphError::OK);
+
+  // Path B: consecutive slices of <= 2048.
+  auto matrixB = createRoutingMatrix();
+  RoutingConfig cfgB = config;
+  configureSingleChannelDC(*matrixB, cfgB);
+  std::vector<std::vector<float>> outB(2, std::vector<float>(total, 0.0f));
+  uint32_t off = 0;
+  while (off < total) {
+    uint32_t slice = std::min<uint32_t>(total - off, kRoutingSliceFrames);
+    const float* inB[1] = {input.data() + off};
+    float* outBptr[2] = {outB[0].data() + off, outB[1].data() + off};
+    ASSERT_EQ(matrixB->processRouting(inB, outBptr, slice), SessionGraphError::OK);
+    off += slice;
+  }
+
+  for (uint32_t i = 0; i < total; ++i) {
+    EXPECT_NEAR(outA[0][i], outB[0][i], 1e-6f) << "left mismatch @ " << i;
+    EXPECT_NEAR(outA[1][i], outB[1][i], 1e-6f) << "right mismatch @ " << i;
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes the FTR028 routing-matrix block-size trap. `RoutingMatrix::processRouting` rejected any block larger than the **private** `MAX_BUFFER_SIZE = 2048` ceiling with `InvalidParameter` and produced **no output**. The public header documented no such limit, so FourTrack passed 4096-frame offline bounce blocks, ignored the return code, and **silently summed every bounce/export to silence** (well-formed WAVs of the right length, all zeros).

Full write-up: `fourtrack/docs/ftr/FTR028 SDK Note - Routing Matrix Block-Size Ceiling.md`.

## Approach — chosen option and why

The note offered three options: (1) expose the constant, (2) chunk internally, (3) document only. I implemented **option 2 (internal chunking) + option 1 (expose the constant)**, not the minimum.

Chunking is the host-neutral, trap-proof answer and aligns with the SDK's graceful-degradation / broadcast-safe principle: a large offline block should *just work* for every host, not only the one that hit the trap. Exposing the constant is belt-and-suspenders for real-time hosts that still want a 1:1 call-to-slice mapping.

## Changes

- `processRouting` now accepts **arbitrary `num_frames`** and loops over slices of at most `kRoutingSliceFrames` (2048), offsetting into the caller's planar buffers. Per-slice work moved into a private `processRoutingBlock` that reuses the pre-allocated scratch.
  - **Allocation-free / lock-free** on the audio path: slice pointer arrays are stack-resident, sized to the 64ch/32out ABI maxima — no heap on the render path.
  - For `num_frames <= 2048` this is a single slice → behavior is bit-identical to before.
- Public contract exposed: `orpheus::kRoutingSliceFrames` and `IRoutingMatrix::maxBlockFrames()`. `MAX_BUFFER_SIZE` now derives from the public constant so host and impl can't drift.
- Doc note on `processRouting` that `num_frames` may be arbitrarily large.

## Tests (`tests/routing/routing_matrix_test.cpp`)

- **ProcessRoutingLargeBlockChunksAndPassesSignal** — 4096 block passes signal at the correct gain at exact sample positions (0, 2047, 2048, 4095); asserts **content**, and that no sample is left untouched (no silent tail).
- **ProcessRoutingBoundaryBlockPassesSignal** — exactly 2048 still works.
- **ProcessRoutingLargeBlockMatchesChunkedEquivalent** — one 5000-frame call == consecutive <=2048 slices (chunking is pure decomposition).
- **ExposesMaxBlockFramesContract** — public constant/query == 2048.
- Repurposed the obsolete `ProcessWithOversizedBufferFails` → `ProcessWithOversizedBufferSucceeds`.

## Verification

Debug build with AddressSanitizer + UBSan, full suite: **133/133 passed**. `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)