### PR TITLE
docs(orp): ORP135 minhost decomposition + ORP136 TODO triage hand-offs

### DIFF
--- a/docs/orp/ORP.md
+++ b/docs/orp/ORP.md
@@ -92,6 +92,8 @@ Project documentation index for orpheus-sdk.
 - [[ORP129 Variable-Rate and Reverse Scrub Reader SDK Implementation]]
 - [[ORP130 CoreAudio Input Capture]]
 - [[ORP131 Clip Composer Subdirectory Archival]]
+- [[ORP135 Minhost Adapter Decomposition]]
+- [[ORP136 TODO and Incomplete-Feature Triage]]
 
 ## Navigation
 

--- a/docs/orp/ORP135 Minhost Adapter Decomposition.md
+++ b/docs/orp/ORP135 Minhost Adapter Decomposition.md
@@ -1,0 +1,126 @@
+# ORP135 Minhost Adapter Decomposition
+
+**Status:** Design / Hand-off — approved for implementation, not yet started
+**Author:** Cleanup sprint, 2026-07-10
+**Scope:** `adapters/minhost/` — split the monolithic `main.cpp` into modules
+**Severity:** Medium — maintainability; violates the ≤300 LOC adapter guideline
+**Related:** ORP133/134 (realtime-safety hardening), the `adapters/shared`
+`Orpheus::adapters_common` library introduced in the same cleanup sprint
+
+---
+
+## Context
+
+`adapters/minhost/main.cpp` is a **single 1,532-line translation unit** — a
+minimal standalone CLI host used for testing and offline rendering of Orpheus
+sessions. `CLAUDE.md` sets a **≤300 LOC guideline for adapters**; minhost is 5×
+over. The file mixes at least five responsibilities in one namespace:
+
+- CLI argument parsing (global options + per-command flag parsing)
+- JSON error/summary serialization
+- ABI negotiation (now partly extracted — see below)
+- Session preparation from a loaded `SessionGraph`
+- Five command handlers: `load`, `render-tracks`, `render-click`,
+  `simulate-transport`, plus dispatch in `Run()`/`main()`
+
+This makes the adapter hard to navigate, hard to test in isolation, and a poor
+reference for anyone writing a new host adapter.
+
+**Why a design doc rather than an ad-hoc edit:** the split touches the one file
+that the unity-include test (`tests/json_minhost_bridge_tests.cpp`,
+`#include "../adapters/minhost/main.cpp"`) compiles directly, so the module
+boundaries and the test's include strategy must be decided deliberately.
+
+## Current structure (map)
+
+Line anchors as of this doc (`adapters/minhost/main.cpp`, one `namespace minhost`):
+
+| Concern | Symbols | Approx. lines |
+|---|---|---|
+| Error/summary I/O | `ErrorInfo`, `PrintJsonError`, `PrintError`, `JsonEscape`, `FormatNumber`, `FormatBeats` | 39–208, 464–491 |
+| Scalar parsing | `ParseDouble`, `ParseUint32`, `ParseUint16`, `ParseRangeArgument`, `SplitCommaSeparated` | 97–164, 598–617 |
+| ABI | `AbiContext`, `PrintNegotiationSummary`, `NegotiateApis`, `PrintAbiJson` | 208–259, 492–515 |
+| Session prep | `SessionLoadOptions`, `SessionContext`, `PrepareSession`, `PrintSessionSummary`, `MergeSessionOptions`, `ClipIntersectsRange`, `ParseSessionCommonArg` | 260–463, 516–536, 618–659 |
+| Help text | `PrintGlobalHelp` + 4 per-command help fns | 537–597 |
+| `load` | `LoadCommandOptions`, `ParseLoadCommand`, `RunLoadCommand` | 660–768 |
+| `render-tracks` | `RenderTracksCommandOptions`, `ParseRenderTracksCommand`, `RunRenderTracksCommand` | 769–918 |
+| `render-click` | `ClickSpecOverrides`, `ParseClickSpecOverrides`, `RenderClickCommandOptions`, `Merge…`, `Parse…`, `BeatsToBars`, `ComputeBarsFromRange`, `RunRenderClickCommand` | 919–1220 |
+| `simulate-transport` | `SimulateTransportCommandOptions`, `Parse…`, `RunTransportSimulation`, `Run…` | 1221–1320 |
+| Dispatch | `ParsedCommand`, `ParseArguments`, `Run`, `main` | 1321–1532 |
+
+### Already extracted (do not re-do)
+- **ABI negotiation** null+version check is now `orpheus::adapters::NegotiateAbi<>`
+  in `adapters/shared/abi_negotiation.h`. `NegotiateApis` already calls it.
+- **Tempo math** (`secondsPerBeat`) is now `include/orpheus/music_timing.h`.
+- **SessionGuard** lives in `adapters/shared/session_guard.h`.
+- Both are reachable via the `Orpheus::adapters_common` INTERFACE target the
+  minhost executable now links.
+
+## Proposed target layout
+
+Keep a single `namespace minhost`; split by concern into a small set of TUs
+under `adapters/minhost/`. Each command handler owns its own options struct,
+parser, and runner:
+
+```
+adapters/minhost/
+  main.cpp                 # thin: main() + Run() dispatch only  (~120 LOC)
+  cli_common.{h,cpp}       # ErrorInfo, JSON I/O, scalar parsers, help text
+  session_prep.{h,cpp}     # SessionLoadOptions/Context, PrepareSession, summaries
+  abi_context.{h,cpp}      # AbiContext, PrintNegotiationSummary, NegotiateApis, PrintAbiJson
+  commands/
+    load.{h,cpp}
+    render_tracks.{h,cpp}
+    render_click.{h,cpp}
+    simulate_transport.{h,cpp}
+```
+
+Cross-cutting duplication to collapse **while** splitting (each appears 3–4×
+across the parse functions today):
+
+- **Flag-with-value parsing** (`--sr`, `--bd`, `--session`, `--tracks`,
+  `--range`): extract `bool ParseValuedFlag(args, index, flag, handler, error)`
+  into `cli_common`. Removes ~120 LOC of near-identical blocks.
+- **JSON field extraction** in `ParseClickSpecOverrides` (8 near-identical
+  `find(...) + type check + assign` blocks): extract
+  `template<typename T> bool ExtractJsonField(obj, key, T& out)`.
+
+## Build / test changes
+
+- `adapters/minhost/CMakeLists.txt`: list the new sources; the target already
+  links `Orpheus::core` + `Orpheus::adapters_common`.
+- **Unity-include test:** `tests/json_minhost_bridge_tests.cpp` currently
+  `#include`s `main.cpp` to reach `minhost::` internals. After the split it must
+  instead compile against the new TUs. Two options — pick during implementation:
+  1. Preferred: make an `orpheus_minhost_lib` OBJECT/STATIC library of the
+     non-`main()` sources; both `orpheus_minhost` and `orpheus_tests` link it.
+     The test then includes the relevant headers instead of `main.cpp`.
+  2. Minimal: point the test's `#include` at the specific new TU(s) it exercises
+     and add their dir to the test include path (already includes
+     `adapters/shared`).
+
+## Constraints
+
+- **Behaviour-preserving.** No change to CLI surface, flags, exit codes, JSON
+  output shape, or rendered bytes. minhost output is used by determinism tests.
+- Formatting: `clang-format` (CI-enforced, husky pre-commit).
+- Each new TU should land comfortably under the 300 LOC guideline.
+
+## Verification
+
+- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build`
+- `ctest --test-dir build --output-on-failure` — full suite must stay green
+  (baseline: 134/134). `json_minhost_bridge` is the direct guard.
+- Smoke parity on a fixture session — output must be byte-identical to
+  pre-split for each command:
+  - `orpheus_minhost load <session.json>`
+  - `orpheus_minhost render-tracks <session.json> --out /tmp/rt.wav`
+  - `orpheus_minhost render-click --tempo 120 --bars 4 --out /tmp/rc.wav`
+  - `orpheus_minhost simulate-transport <session.json>`
+- Debug build runs ASan+UBSan — must stay clean.
+
+## Hand-off
+
+Suitable for a build/adapter-focused implementation agent or session. Land on a
+branch off `main` (`refactor/orp-minhost-split`) → PR. Do **not** commit to
+`main` directly.

--- a/docs/orp/ORP136 TODO and Incomplete-Feature Triage.md
+++ b/docs/orp/ORP136 TODO and Incomplete-Feature Triage.md
@@ -1,0 +1,68 @@
+# ORP136 TODO and Incomplete-Feature Triage
+
+**Status:** Triage / Hand-off — catalogue only, no code changes in this doc
+**Author:** Cleanup sprint, 2026-07-10
+**Scope:** In-tree `TODO` markers under `src/` and `adapters/`
+**Severity:** Mixed — includes at least one correctness bug (see RT-1)
+**Related:** ORP135 (minhost decomposition), routing/scene subsystems
+
+---
+
+## Context
+
+A cleanup-sprint audit found **10 `TODO` markers** in the C++ core. These are not
+formatting debt — several flag **incomplete features or latent correctness
+bugs** that need owning-team scheduling, not a blind refactor-pass fix. This doc
+catalogues each with a severity and a suggested owner so the work can be
+scheduled deliberately. No `TODO` text or code is changed here.
+
+Line anchors are as of 2026-07-10; verify before acting.
+
+## Findings
+
+### Correctness / behaviour bugs (schedule first)
+
+| ID | Location | Marker | Impact |
+|----|----------|--------|--------|
+| **RT-1** | `src/core/routing/routing_matrix.cpp:437` | `snapshot.timestamp_ms = 0; // TODO: Get actual timestamp` | Routing snapshots always report a **0 ms timestamp**. Any consumer that time-orders or ages snapshots (metering UI, logging) gets wrong/constant timing. Likely a real bug, not just a stub. |
+| **RT-2** | `src/core/routing/routing_matrix.cpp:652` and `:720` | `// TODO: Proper stereo metering would meter both channels` (×2) | Stereo metering meters **one channel only** → understated/incorrect level readings for stereo material. Two sites, presumably peak + RMS paths. |
+
+### Incomplete features (scoped work, need API extension)
+
+| ID | Location | Marker | Notes |
+|----|----------|--------|-------|
+| **SC-1** | `src/core/session/scene_manager.cpp:232` | `// TODO: Capture clip assignments from SessionGraph.` | Scene capture does not persist clip assignments. |
+| **SC-2** | `src/core/session/scene_manager.cpp:280` | `// TODO: Stop all playback (requires ITransportController reference)` | Scene recall cannot stop playback — needs a transport reference wired into `SceneManager`. |
+| **SC-3** | `src/core/session/scene_manager.cpp:312` | `// TODO: Restore clip assignments (requires SessionGraph API extension)` | Counterpart to SC-1; blocked on a `SessionGraph` API addition. |
+| **IO-1** | `src/core/audio_io/audio_file_reader_libsndfile.cpp:253` | `// TODO: Implement SHA-256 hashing` | Content hashing for determinism/integrity is stubbed. Relevant to the offline-first / bit-identical guarantees; decide whether it is required for a shipped feature or aspirational. |
+
+### Performance / integration (lower priority)
+
+| ID | Location | Marker | Notes |
+|----|----------|--------|-------|
+| **PF-1** | `src/core/audio_io/waveform_processor.cpp:163` | `// TODO: Pre-compute LOD pyramid at multiple resolutions` | Waveform LOD optimisation; UI responsiveness, not correctness. |
+| **TC-1** | `src/core/transport/transport_controller.cpp:1123` | `// TODO: Report error (too many active clips globally)` | Global active-clip cap is enforced but the error is swallowed — a diagnostics gap, confirm it is not silently dropping clips. |
+| **CA-1** | `src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp:272` | `// TODO: Get active clip count from transport controller (for now, use 0)` | Driver hard-codes active-clip count to 0; affects any load-based logic in the CoreAudio path. macOS-only. |
+
+## Suggested routing
+
+- **RT-1, RT-2** → routing/DSP owner. Treat RT-1/RT-2 as bugs; each wants a
+  regression test in `tests/` (routing snapshot timestamp; stereo meter on a
+  known-asymmetric stereo signal).
+- **SC-1..SC-3** → session/scene owner; SC-3 gated on a `SessionGraph` API
+  addition, so scope SC-1/SC-3 together.
+- **IO-1** → audio-io owner; first a product decision (is SHA-256 hashing a
+  committed feature?), then implement or delete the stub + comment.
+- **PF-1, TC-1, CA-1** → schedule opportunistically; TC-1 and CA-1 are worth a
+  quick confirm that neither silently drops data.
+
+## Verification (per fix, when scheduled)
+
+Each item lands on its own branch off `main` → PR, with a test that fails before
+and passes after. Do not batch unrelated items into one commit. Full suite
+(`ctest --test-dir build`) must stay green; Debug ASan+UBSan clean.
+
+## Hand-off
+
+This is a report. Convert each row into a tracked task for the owning team.
+Nothing here should be fixed blind as part of a formatting/refactor sweep.


### PR DESCRIPTION
Design/hand-off docs for the dense follow-up work from the cleanup sprint.

- **ORP135** — design for splitting the 1532-LOC `adapters/minhost/main.cpp` into `cli_common` / `session_prep` / `abi_context` / `commands/*` modules, incl. the unity-include test strategy. Approved, routed to a build/adapter implementation agent.
- **ORP136** — triage of the 10 in-tree `TODO` markers (incl. the always-0 routing snapshot timestamp and one-channel stereo metering correctness bugs), routed to owning teams. Report only.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)