### PR TITLE
feat(orp): continue ORP141 reliability adoption

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,31 +8,39 @@
 
 # ORP141 Resume Checkpoint (2026-07-14)
 
-- Pause boundary: do not begin R4 until R3 is resolved.
-- Active branch: `feat/orp141-reliability-adoption`; PR: #206; all checkpoint
-  changes are pushed.
-- `ci/trim-macos-matrix-cost` is already merged into `main` (tip
-  `b3e4d740` is an ancestor). Media integrity commit `d47fc60f` is also on
-  `main`.
-- R0, R1, and R2 are complete. See the implementation checkpoint in
-  `docs/orp/ORP141 Reliability and Adoption Sprint Plan.md`.
-- R3 committed work: public DLL factory exports; WASAPI shared-mode endpoint
-  enumeration, format fallback, negotiated rate/buffer reporting, callback
-  lifecycle, tests, package target, support matrix, Linux backend decision, and
-  manual self-hosted hardware acceptance workflow.
-- Pending CI: manually dispatched run `29309941110` for PR #206 was still
-  queued when pausing. Inspect Windows compile/package results first. Likely
-  risk area: MSVC/WASAPI headers, warnings, and import/export behavior.
-- Hardware gate: no Windows real-device record exists yet. Do not label WASAPI
-  Supported until `.github/workflows/wasapi-hardware-acceptance.yml` produces a
-  passing artifact on `[self-hosted, Windows, x64, audio-hardware]`.
-- Verification: local macOS build passed. Full CTest passed 137/138; the sole
-  failure was stale duplicate JSON golden fixtures under `tools/fixtures`.
-  Those were versioned in `f16b6c5c`, then `conformance_json` passed. Thus all
-  138 configured contracts were observed passing across the full run and
-  targeted rerun.
+- Pause boundary: R4 transaction and ShmUI contracts are complete. The next
+  task is `Expose fixed-capacity decimated realtime telemetry`; it is marked in
+  progress but has no edits yet.
+- Active branch: `feat/orp141-reliability-adoption`; PR #206. Working tree was
+  clean and all work was pushed through `c5a1fc6c`.
+- Recent commits:
+  - `5fbae07f` — public stable-ID `SessionGraph` transactions/snapshots
+  - `120cabb7` — versioned ShmUI-JUCE manifest integrity validator
+  - `c5a1fc6c` — real JUCE 8.0.4 no-OpenGL add_subdirectory consumer
+- R4 completed work:
+  - `include/orpheus/session_graph.h` is installed/public and exposes stable
+    `SessionId`/`TrackId`/`ClipId`, canonical `TimeRange` snapshots, coalesced
+    revision change sets, rollback-on-destruction transactions, and restore for
+    app-owned undo/redo.
+  - `packages/shmui-juce/shmui-juce-import.json` records the upstream revision,
+    exported components, required JUCE modules, token contract, optional
+    default-off OpenGL feature, hash algorithm, and imported-content SHA-256.
+  - `tools/shmui_juce_manifest.py --check` is registered in CTest.
+  - The checksum-pinned JUCE fixture builds and runs
+    `Orpheus::shmui_juce` without creating/linking the OpenGL target. The Ubuntu
+    Release CI leg now runs it.
+- Verification observed:
+  - `SessionGraphTransactions.*:SessionGraphInvariants.*`: 8/8 passed.
+  - `shmui_juce_manifest` CTest passed; 53 imported files matched the manifest.
+  - The non-OpenGL fixture built all ShmUI sources and its runtime smoke test
+    passed locally.
+- R4 remaining: fixed-capacity decimated realtime telemetry; explicitly keep
+  app analysis/view-model state outside core; export both public contracts
+  through clean-prefix package fixtures.
+- R3 remains truthfully open: hosted run `29309941110` is still queued without
+  jobs, Windows package/ABI proof is unavailable, and no self-hosted WASAPI
+  real-device artifact exists. Do not promote the Windows support tier.
+- The entire `Release Operating Model` todo phase was dropped for this session
+  at the user's direction. It remains deferred work, not completed work.
 - Fixture quirk: session goldens exist in both `tests/fixtures/session` and
   `tools/fixtures`; schema changes must update both sets.
-- Resume sequence: inspect/fix CI run, commit and push any R3 fixes, obtain or
-  explicitly retain the hardware-evidence blocker, then update R3 todos. Only
-  after that start R4.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,8 +9,8 @@
 # ORP141 Resume Checkpoint (2026-07-14)
 
 - Pause boundary: do not begin R4 until R3 is resolved.
-- Active branch: `feat/orp141-reliability-adoption`; PR: #206; pushed tip:
-  `bc015758`.
+- Active branch: `feat/orp141-reliability-adoption`; PR: #206; all checkpoint
+  changes are pushed.
 - `ci/trim-macos-matrix-cost` is already merged into `main` (tip
   `b3e4d740` is an ancestor). Media integrity commit `d47fc60f` is also on
   `main`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,14 +31,14 @@
   - The live transport telemetry integration test passed.
   - `realtime_static_audit` and `cmake_find_package` passed.
   - Full configured suite passed: 143/143.
-- R3 remains truthfully open: latest-commit Windows CI run `29316779217` is
-  queued without job records, so hosted package/ABI proof is unavailable; no
-  self-hosted WASAPI real-device artifact exists. Do not promote the Windows
-  support tier without those observed records.
-- Direct dispatch of `wasapi-hardware-acceptance.yml` returned GitHub API 404
-  because the new manual workflow is not on the default branch. Hardware proof
-  requires that workflow to land and a matching self-hosted
-  `[Windows, x64, audio-hardware]` runner to execute it.
+- R3 evidence is explicitly deferred. GitHub reports repository Actions as
+  disabled (`enabled: false`); the user elected to keep it disabled, so
+  latest-commit Windows run `29316779217` remains queued without job records
+  and cannot prove package/ABI conformance.
+- GitHub reports zero self-hosted runners. Direct dispatch of
+  `wasapi-hardware-acceptance.yml` also returned API 404 because the new manual
+  workflow is not on the default branch. Do not promote Windows/WASAPI support
+  without a later hosted CI record and real-device artifact.
 - R5 gate review found only FourTrack's conditional interest, not two
   independent requirements, and R1–R4 have not shipped/soaked together. The
   voice implementation, policy, realtime tests, and migration guidance jobs

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,39 +8,44 @@
 
 # ORP141 Resume Checkpoint (2026-07-14)
 
-- Pause boundary: R4 transaction and ShmUI contracts are complete. The next
-  task is `Expose fixed-capacity decimated realtime telemetry`; it is marked in
-  progress but has no edits yet.
-- Active branch: `feat/orp141-reliability-adoption`; PR #206. Working tree was
-  clean and all work was pushed through `c5a1fc6c`.
-- Recent commits:
-  - `5fbae07f` — public stable-ID `SessionGraph` transactions/snapshots
-  - `120cabb7` — versioned ShmUI-JUCE manifest integrity validator
-  - `c5a1fc6c` — real JUCE 8.0.4 no-OpenGL add_subdirectory consumer
-- R4 completed work:
-  - `include/orpheus/session_graph.h` is installed/public and exposes stable
-    `SessionId`/`TrackId`/`ClipId`, canonical `TimeRange` snapshots, coalesced
-    revision change sets, rollback-on-destruction transactions, and restore for
-    app-owned undo/redo.
-  - `packages/shmui-juce/shmui-juce-import.json` records the upstream revision,
-    exported components, required JUCE modules, token contract, optional
-    default-off OpenGL feature, hash algorithm, and imported-content SHA-256.
-  - `tools/shmui_juce_manifest.py --check` is registered in CTest.
-  - The checksum-pinned JUCE fixture builds and runs
-    `Orpheus::shmui_juce` without creating/linking the OpenGL target. The Ubuntu
-    Release CI leg now runs it.
-- Verification observed:
-  - `SessionGraphTransactions.*:SessionGraphInvariants.*`: 8/8 passed.
-  - `shmui_juce_manifest` CTest passed; 53 imported files matched the manifest.
-  - The non-OpenGL fixture built all ShmUI sources and its runtime smoke test
-    passed locally.
-- R4 remaining: fixed-capacity decimated realtime telemetry; explicitly keep
-  app analysis/view-model state outside core; export both public contracts
-  through clean-prefix package fixtures.
-- R3 remains truthfully open: hosted run `29309941110` is still queued without
-  jobs, Windows package/ABI proof is unavailable, and no self-hosted WASAPI
-  real-device artifact exists. Do not promote the Windows support tier.
-- The entire `Release Operating Model` todo phase was dropped for this session
-  at the user's direction. It remains deferred work, not completed work.
+- Active branch: `feat/orp141-reliability-adoption`; PR #206. R4 is complete
+  and pushed through `3e6daffd` (`feat(telemetry): add bounded realtime
+  snapshots`).
+- R4 public contracts:
+  - `include/orpheus/session_graph.h` exposes stable-ID transactions,
+    pointer-free canonical snapshots, revisioned change sets, rollback, and
+    restore for application-owned undo/redo.
+  - The ShmUI-JUCE import has a versioned 53-file manifest and a real pinned
+    JUCE 8.0.4 non-OpenGL `add_subdirectory` consumer.
+  - `include/orpheus/realtime_telemetry.h` exposes a fixed 64-slot SPSC ring,
+    configurable callback-block decimation, monotonic sequence/drop reporting,
+    canonical post-block `TimePoint`, callback/underrun diagnostics,
+    active-voice count, and fixed group/master meters.
+  - `ITransportController::getRealtimeTelemetry()` exposes the transport-owned
+    bridge. FFTs, histories, smoothing, analyzers, and UI view models remain
+    message-thread application state outside core.
+  - The clean-prefix `find_package` workflow fixture compiles and runs both the
+    public `SessionGraph` and telemetry contracts with no private header.
+- Verification observed after R4:
+  - Four telemetry queue/cadence/diagnostic tests passed.
+  - The live transport telemetry integration test passed.
+  - `realtime_static_audit` and `cmake_find_package` passed.
+  - Full configured suite passed: 143/143.
+- R3 remains truthfully open: hosted Windows CI has not supplied package/ABI
+  proof, and no self-hosted WASAPI real-device artifact exists. Do not promote
+  the Windows support tier without those observed records.
+- R5 remains gated on its stated two-independent-consumer evidence and shipped/
+  soaked R1–R4 entry criteria. Do not infer evidence or start the voice utility
+  until the gate is met.
+- The entire Release Operating Model is deferred at the user's direction. Its
+  recorded, incomplete jobs for a later session are:
+  - enforce CMake single-source versioning;
+  - run installed ABI compatibility and migration checks;
+  - model consumer needs only in SDK-owned fixtures;
+  - preserve the realtime release-blocker suite;
+  - maintain a hardware-backed long-running soak scenario;
+  - gate release supply-chain metadata and dependency audits;
+  - update public contract documentation atomically; and
+  - verify overall installation and truthfulness criteria.
 - Fixture quirk: session goldens exist in both `tests/fixtures/session` and
   `tools/fixtures`; schema changes must update both sets.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,3 +5,34 @@
 
 *No recent activity*
 </claude-mem-context>
+
+# ORP141 Resume Checkpoint (2026-07-14)
+
+- Pause boundary: do not begin R4 until R3 is resolved.
+- Active branch: `feat/orp141-reliability-adoption`; PR: #206; pushed tip:
+  `bc015758`.
+- `ci/trim-macos-matrix-cost` is already merged into `main` (tip
+  `b3e4d740` is an ancestor). Media integrity commit `d47fc60f` is also on
+  `main`.
+- R0, R1, and R2 are complete. See the implementation checkpoint in
+  `docs/orp/ORP141 Reliability and Adoption Sprint Plan.md`.
+- R3 committed work: public DLL factory exports; WASAPI shared-mode endpoint
+  enumeration, format fallback, negotiated rate/buffer reporting, callback
+  lifecycle, tests, package target, support matrix, Linux backend decision, and
+  manual self-hosted hardware acceptance workflow.
+- Pending CI: manually dispatched run `29309941110` for PR #206 was still
+  queued when pausing. Inspect Windows compile/package results first. Likely
+  risk area: MSVC/WASAPI headers, warnings, and import/export behavior.
+- Hardware gate: no Windows real-device record exists yet. Do not label WASAPI
+  Supported until `.github/workflows/wasapi-hardware-acceptance.yml` produces a
+  passing artifact on `[self-hosted, Windows, x64, audio-hardware]`.
+- Verification: local macOS build passed. Full CTest passed 137/138; the sole
+  failure was stale duplicate JSON golden fixtures under `tools/fixtures`.
+  Those were versioned in `f16b6c5c`, then `conformance_json` passed. Thus all
+  138 configured contracts were observed passing across the full run and
+  targeted rerun.
+- Fixture quirk: session goldens exist in both `tests/fixtures/session` and
+  `tools/fixtures`; schema changes must update both sets.
+- Resume sequence: inspect/fix CI run, commit and push any R3 fixes, obtain or
+  explicitly retain the hardware-evidence blocker, then update R3 todos. Only
+  after that start R4.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,6 +35,10 @@
   queued without job records, so hosted package/ABI proof is unavailable; no
   self-hosted WASAPI real-device artifact exists. Do not promote the Windows
   support tier without those observed records.
+- Direct dispatch of `wasapi-hardware-acceptance.yml` returned GitHub API 404
+  because the new manual workflow is not on the default branch. Hardware proof
+  requires that workflow to land and a matching self-hosted
+  `[Windows, x64, audio-hardware]` runner to execute it.
 - R5 gate review found only FourTrack's conditional interest, not two
   independent requirements, and R1–R4 have not shipped/soaked together. The
   voice implementation, policy, realtime tests, and migration guidance jobs

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,12 +31,15 @@
   - The live transport telemetry integration test passed.
   - `realtime_static_audit` and `cmake_find_package` passed.
   - Full configured suite passed: 143/143.
-- R3 remains truthfully open: hosted Windows CI has not supplied package/ABI
-  proof, and no self-hosted WASAPI real-device artifact exists. Do not promote
-  the Windows support tier without those observed records.
-- R5 remains gated on its stated two-independent-consumer evidence and shipped/
-  soaked R1–R4 entry criteria. Do not infer evidence or start the voice utility
-  until the gate is met.
+- R3 remains truthfully open: latest-commit Windows CI run `29316779217` is
+  queued without job records, so hosted package/ABI proof is unavailable; no
+  self-hosted WASAPI real-device artifact exists. Do not promote the Windows
+  support tier without those observed records.
+- R5 gate review found only FourTrack's conditional interest, not two
+  independent requirements, and R1–R4 have not shipped/soaked together. The
+  voice implementation, policy, realtime tests, and migration guidance jobs
+  are explicitly dropped for this checkpoint rather than implemented without
+  the required evidence.
 - The entire Release Operating Model is deferred at the user's direction. Its
   recorded, incomplete jobs for a later session are:
   - enforce CMake single-source versioning;

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -140,6 +140,21 @@ jobs:
         shell: bash
         timeout-minutes: 10
 
+      - name: Build ShmUI-JUCE consumer without OpenGL
+        if: matrix.os == 'ubuntu-latest' && matrix.build_type == 'Release'
+        run: |
+          sudo apt-get install -y \
+            libfontconfig1-dev libfreetype-dev libx11-dev libxcomposite-dev \
+            libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev
+          cmake \
+            -Dsource_dir=tests/cmake/shmui_no_opengl \
+            -Dbinary_dir="${RUNNER_TEMP}/shmui-no-opengl" \
+            -Dshmui_source_dir=packages/shmui-juce \
+            -Dbuild_type=Release \
+            -P tests/cmake/run_shmui_no_opengl.cmake
+        shell: bash
+        timeout-minutes: 10
+
       - name: Upload test logs on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/.github/workflows/wasapi-hardware-acceptance.yml
+++ b/.github/workflows/wasapi-hardware-acceptance.yml
@@ -1,0 +1,44 @@
+name: WASAPI Hardware Acceptance
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  real-device:
+    name: Shared-mode real-device acceptance
+    runs-on: [self-hosted, Windows, x64, audio-hardware]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Configure
+        run: >-
+          cmake -S . -B build-hardware -G "Visual Studio 17 2022" -A x64
+          -DORP_WITH_TESTS=OFF
+          -DORPHEUS_ENABLE_REALTIME=ON
+          -DORPHEUS_ENABLE_WASAPI=ON
+
+      - name: Build acceptance executable
+        run: >-
+          cmake --build build-hardware --config Release
+          --target orpheus_wasapi_hardware_acceptance --parallel
+
+      - name: Exercise default hardware endpoint
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force build-hardware/evidence | Out-Null
+          & build-hardware/tools/Release/orpheus_wasapi_hardware_acceptance.exe |
+            Tee-Object -FilePath build-hardware/evidence/wasapi-hardware.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload acceptance record
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: wasapi-hardware-${{ github.run_id }}
+          path: build-hardware/evidence/wasapi-hardware.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -14,7 +14,7 @@ repository claims.
 | Installed CMake package and documented target manifest | Supported; clean-prefix fixture | Supported; clean-prefix fixture and DLL ABI-link gate | Supported; clean-prefix fixture |
 | Dummy audio driver | Supported | Supported | Supported |
 | CoreAudio device backend | Supported on Apple platforms | Unavailable | Unavailable |
-| WASAPI device backend | Unavailable | Experimental; disabled by default and not release-supported | Unavailable |
+| WASAPI device backend | Unavailable | Release candidate: shared-mode enumeration/playback enabled by default; hardware acceptance pending | Unavailable |
 | ASIO device backend | Unavailable | Optional source integration requiring a separately supplied ASIO SDK; not release-supported | Unavailable |
 | ALSA device backend | Unavailable | Unavailable | Not implemented |
 | JACK device backend | Unavailable | Unavailable | Not implemented |
@@ -54,12 +54,33 @@ Platform and optional targets appear only when their build feature and dependenc
 are enabled. Consumers must not infer availability from the operating system; they
 must test the CMake target or query the driver capability API.
 
+## Linux backend decision
+
+ALSA, JACK, and PipeWire are distinct providers, not interchangeable labels for
+a generic Linux backend. Orpheus currently ships none of them and therefore
+claims only host-neutral core/package support on Linux. The first provider must
+land behind its own CMake target and capability identity, then pass the common
+device conformance contract: truthful enumeration, selected-device open,
+negotiated format/buffer reporting, callback lifecycle, xrun accounting, and a
+hardware-backed acceptance artifact. Until all gates pass, the dummy driver is
+the only advertised Linux audio driver.
+
+## Hardware acceptance records
+
+CoreAudio hardware acceptance is exercised on the maintained macOS workstation.
+WASAPI has no passing real-device artifact in this repository yet. The manual
+`wasapi-hardware-acceptance` workflow is the release gate; ordinary hosted
+Windows CI is compile/package conformance only and cannot promote the backend.
+
 ## Known unavailable capabilities
 
 - No Linux production device backend is shipped. ALSA, JACK, and PipeWire remain
   separate future capabilities; Orpheus does not advertise a generic Linux driver.
-- WASAPI source is experimental and disabled by default. Shared/exclusive-mode and
-  real-device acceptance remain prerequisites for release support.
+- WASAPI shared-mode enumeration, requested-format negotiation, callback
+  playback, and negotiated rate/buffer reporting are implemented and required
+  to compile in Windows CI. Promotion from release candidate to Supported is
+  blocked until the self-hosted real-device acceptance workflow publishes a
+  passing artifact.
 - ASIO requires a separately supplied vendor SDK and is not part of release
   artifacts or required CI.
 - Plugin hosting, network audio, WASM/mobile, and device-specific control drivers

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -3,7 +3,7 @@
 # ORP141 — Reliability and Adoption Sprint Plan
 
 **Document type:** Product and engineering sprint plan  
-**Status:** In progress — R0/R1/R2 complete; R3 implementation committed, CI and hardware evidence pending  
+**Status:** In progress — R0/R1/R2 complete; R3 implementation committed with external CI/hardware evidence pending; R4 active
 **Scope:** Orpheus SDK core, packages, release artifacts, and SDK-owned conformance fixtures only. No child-app source changes, submodule-pin updates, application CI work, or UI feature work are deliverables of this plan.
 **Related:** [[ORP136 TODO and Incomplete-Feature Triage]] · [[ORP137 Hardening Program Completion and Downstream Follow-ups]] · [[ORP135 LATER Sprint - Platform Leadership Bets]] · [[ORP142 Downstream Consumer Adoption Notes]] · FreqFinder [[FRQ033 Orpheus SDK Release Package Refresh for Analysis Facade]] · FourTrack [[FTR027 SDK Note - Real-Time Sample-Accurate Event Primitive]] · [[FTR028 SDK Note - Routing Matrix Block-Size Ceiling]]
 
@@ -31,10 +31,13 @@
   self-hosted `wasapi-hardware-acceptance` workflow publishes a passing record.
 - Local verification observed all 138 configured contracts passing across the
   full run plus the corrected JSON conformance rerun. Windows CI run
-  `29309941110` is the pending cross-platform checkpoint.
-- Work intentionally pauses before R4. Resume by resolving the Windows CI run
-  and hardware-evidence status; do not begin R4/R5 until that checkpoint is
-  committed and pushed.
+  `29309941110` remains queued without jobs; WASAPI promotion and the three R3
+  evidence tasks remain open rather than being inferred from hosted CI.
+- R4 is active. The public `SessionGraph` header now exposes stable
+  `SessionId`/`TrackId`/`ClipId` edits, canonical `TimeRange` snapshots,
+  coalesced revisioned change sets, rollback-on-destruction transactions, and
+  snapshot restore for application-owned undo/redo. Runtime transport and
+  application presentation state remain outside the transactional edit domain.
 
 ## 1. Decision
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -33,6 +33,11 @@
   Latest-commit Windows CI run `29316779217` is queued without job records;
   WASAPI promotion and the three R3 evidence tasks remain open rather than
   being inferred from workflow configuration or macOS verification.
+- A direct dispatch of `wasapi-hardware-acceptance.yml` returned GitHub API
+  `404` because that newly added manual workflow is not yet present on the
+  default branch. Real-device evidence therefore requires both the workflow to
+  land on the default branch and a matching self-hosted
+  `[Windows, x64, audio-hardware]` runner; neither condition is inferred here.
 - R4 is complete. The public `SessionGraph` header now exposes stable
   `SessionId`/`TrackId`/`ClipId` edits, canonical `TimeRange` snapshots,
   coalesced revisioned change sets, rollback-on-destruction transactions, and

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -42,6 +42,12 @@
   against all 53 imported files in CTest, alongside its source revision,
   exported targets/components, JUCE modules, token contract, and default-off
   OpenGL feature gate.
+- A pinned, checksum-verified JUCE 8.0.4 fixture builds and runs an actual
+  `add_subdirectory` consumer against `Orpheus::shmui_juce`, asserts that the
+  OpenGL target and compile definition are absent, and runs in the Ubuntu
+  Release CI leg.
+- The Release Operating Model section is explicitly deferred to a later
+  session; none of its remaining gates are represented as complete here.
 
 ## 1. Decision
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -3,11 +3,38 @@
 # ORP141 — Reliability and Adoption Sprint Plan
 
 **Document type:** Product and engineering sprint plan  
-**Status:** Proposed  
+**Status:** In progress — R0/R1/R2 complete; R3 implementation committed, CI and hardware evidence pending  
 **Scope:** Orpheus SDK core, packages, release artifacts, and SDK-owned conformance fixtures only. No child-app source changes, submodule-pin updates, application CI work, or UI feature work are deliverables of this plan.
 **Related:** [[ORP136 TODO and Incomplete-Feature Triage]] · [[ORP137 Hardening Program Completion and Downstream Follow-ups]] · [[ORP135 LATER Sprint - Platform Leadership Bets]] · [[ORP142 Downstream Consumer Adoption Notes]] · FreqFinder [[FRQ033 Orpheus SDK Release Package Refresh for Analysis Facade]] · FourTrack [[FTR027 SDK Note - Real-Time Sample-Accurate Event Primitive]] · [[FTR028 SDK Note - Routing Matrix Block-Size Ceiling]]
 
 ---
+
+## Implementation checkpoint — 2026-07-14
+
+- Active branch/PR: `feat/orp141-reliability-adoption` / GitHub PR #206.
+- R0 release truth is complete: CMake-sourced version metadata, installed-target
+  manifest, clean-prefix fixtures, package/ABI CI, support matrix, and release
+  checksum/SBOM/provenance generation.
+- R1 correctness is complete: deterministic routing snapshot provenance,
+  stereo metering, atomic scene routing/clip recall, voice-cap refusal events,
+  CoreAudio active-voice telemetry, large-block content checks, and canonical
+  transport event timestamps.
+- R2 media integrity is complete: provider-backed streaming SHA-256, versioned
+  media references, explicit verified/unverified/missing/mismatch outcomes,
+  mismatch refusal, atomic session save/backup recovery, schema migration, and
+  installed-package coverage.
+- R3 implementation is committed: all public factories carry DLL export
+  annotations; WASAPI shared-mode enumeration/playback and negotiated
+  capabilities are implemented; Windows compile/package tests are required;
+  Linux provider boundaries and conformance gates are documented. Hosted CI is
+  not real-device evidence. Promotion of WASAPI remains blocked until the
+  self-hosted `wasapi-hardware-acceptance` workflow publishes a passing record.
+- Local verification observed all 138 configured contracts passing across the
+  full run plus the corrected JSON conformance rerun. Windows CI run
+  `29309941110` is the pending cross-platform checkpoint.
+- Work intentionally pauses before R4. Resume by resolving the Windows CI run
+  and hardware-evidence status; do not begin R4/R5 until that checkpoint is
+  committed and pushed.
 
 ## 1. Decision
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -38,6 +38,10 @@
   coalesced revisioned change sets, rollback-on-destruction transactions, and
   snapshot restore for application-owned undo/redo. Runtime transport and
   application presentation state remain outside the transactional edit domain.
+- The ShmUI-JUCE import manifest now declares its hash algorithm and is checked
+  against all 53 imported files in CTest, alongside its source revision,
+  exported targets/components, JUCE modules, token contract, and default-off
+  OpenGL feature gate.
 
 ## 1. Decision
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -46,6 +46,9 @@
   `add_subdirectory` consumer against `Orpheus::shmui_juce`, asserts that the
   OpenGL target and compile definition are absent, and runs in the Ubuntu
   Release CI leg.
+- Pause checkpoint: transaction and ShmUI work is pushed through `c5a1fc6c`.
+  Resume R4 at the fixed-capacity decimated realtime telemetry contract; no
+  telemetry implementation edits are pending in the working tree.
 - The Release Operating Model section is explicitly deferred to a later
   session; none of its remaining gates are represented as complete here.
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -30,14 +30,17 @@
   not real-device evidence. Promotion of WASAPI remains blocked until the
   self-hosted `wasapi-hardware-acceptance` workflow publishes a passing record.
 - Local verification after R4 observed all 143 configured contracts passing.
-  Latest-commit Windows CI run `29316779217` is queued without job records;
-  WASAPI promotion and the three R3 evidence tasks remain open rather than
-  being inferred from workflow configuration or macOS verification.
-- A direct dispatch of `wasapi-hardware-acceptance.yml` returned GitHub API
-  `404` because that newly added manual workflow is not yet present on the
-  default branch. Real-device evidence therefore requires both the workflow to
-  land on the default branch and a matching self-hosted
-  `[Windows, x64, audio-hardware]` runner; neither condition is inferred here.
+  GitHub reports repository Actions as disabled (`enabled: false`), so
+  latest-commit Windows CI run `29316779217` remains queued without job records.
+  The user elected to keep Actions disabled; hosted Windows package/ABI proof
+  is therefore deferred, not inferred from workflow configuration or macOS
+  verification.
+- GitHub reports zero self-hosted runners for this repository. A direct dispatch
+  of `wasapi-hardware-acceptance.yml` also returned API `404` because that new
+  manual workflow is not yet on the default branch. Real-device evidence
+  requires the workflow to land plus a matching
+  `[Windows, x64, audio-hardware]` runner. The R3 evidence jobs remain
+  incomplete and Windows/WASAPI support is not promoted.
 - R4 is complete. The public `SessionGraph` header now exposes stable
   `SessionId`/`TrackId`/`ClipId` edits, canonical `TimeRange` snapshots,
   coalesced revisioned change sets, rollback-on-destruction transactions, and

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -29,10 +29,10 @@
   Linux provider boundaries and conformance gates are documented. Hosted CI is
   not real-device evidence. Promotion of WASAPI remains blocked until the
   self-hosted `wasapi-hardware-acceptance` workflow publishes a passing record.
-- Local verification observed all 138 configured contracts passing across the
-  full run plus the corrected JSON conformance rerun. Windows CI run
-  `29309941110` remains queued without jobs; WASAPI promotion and the three R3
-  evidence tasks remain open rather than being inferred from hosted CI.
+- Local verification after R4 observed all 143 configured contracts passing.
+  Latest-commit Windows CI run `29316779217` is queued without job records;
+  WASAPI promotion and the three R3 evidence tasks remain open rather than
+  being inferred from workflow configuration or macOS verification.
 - R4 is complete. The public `SessionGraph` header now exposes stable
   `SessionId`/`TrackId`/`ClipId` edits, canonical `TimeRange` snapshots,
   coalesced revisioned change sets, rollback-on-destruction transactions, and
@@ -59,8 +59,10 @@
   clean-prefix `find_package` fixture also compiles and runs the public
   `SessionGraph` transaction/snapshot and `RealtimeTelemetry` APIs, including
   the transport-owned telemetry accessor, without any private header.
-- R5 remains gated on its stated two-consumer evidence and shipped/soaked
-  R1–R4 entry criteria; this checkpoint does not infer that evidence.
+- R5 evidence review found one conditional requirement: FourTrack may consider
+  the one-shot voice utility if R5 lands. ORP142 records no second independent
+  consumer requirement, and R1–R4 have not shipped/soaked together. The R5
+  implementation jobs therefore remain gated and are not started.
 - The Release Operating Model section is explicitly deferred to a later
   session; none of its remaining gates are represented as complete here.
 
@@ -223,6 +225,12 @@ No API is advertised as complete while it returns placeholder values, swallows a
 **Goal:** add the smallest reusable control feature with proven adoption demand.
 
 **Entry criteria:** two independent, existing consumer requirements substantiate a host-neutral contract; R1–R4 have shipped and soaked in at least one release. No consumer migration is part of this sprint.
+
+**Gate review (2026-07-14):** not met. [[ORP142 Downstream Consumer Adoption
+Notes]] records only FourTrack's conditional interest and explicitly creates no
+SDK requirement. No second independent consumer requirement is documented, and
+R1–R4 have not shipped and soaked together. Per the exit rule below, do not add
+the voice primitive, policy surface, tests, or migration API in this checkpoint.
 
 **SDK deliverables**
 

--- a/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
+++ b/docs/orp/ORP141 Reliability and Adoption Sprint Plan.md
@@ -3,7 +3,7 @@
 # ORP141 — Reliability and Adoption Sprint Plan
 
 **Document type:** Product and engineering sprint plan  
-**Status:** In progress — R0/R1/R2 complete; R3 implementation committed with external CI/hardware evidence pending; R4 active
+**Status:** In progress — R0/R1/R2/R4 complete; R3 external CI/hardware evidence pending; R5 entry criteria not yet met
 **Scope:** Orpheus SDK core, packages, release artifacts, and SDK-owned conformance fixtures only. No child-app source changes, submodule-pin updates, application CI work, or UI feature work are deliverables of this plan.
 **Related:** [[ORP136 TODO and Incomplete-Feature Triage]] · [[ORP137 Hardening Program Completion and Downstream Follow-ups]] · [[ORP135 LATER Sprint - Platform Leadership Bets]] · [[ORP142 Downstream Consumer Adoption Notes]] · FreqFinder [[FRQ033 Orpheus SDK Release Package Refresh for Analysis Facade]] · FourTrack [[FTR027 SDK Note - Real-Time Sample-Accurate Event Primitive]] · [[FTR028 SDK Note - Routing Matrix Block-Size Ceiling]]
 
@@ -33,7 +33,7 @@
   full run plus the corrected JSON conformance rerun. Windows CI run
   `29309941110` remains queued without jobs; WASAPI promotion and the three R3
   evidence tasks remain open rather than being inferred from hosted CI.
-- R4 is active. The public `SessionGraph` header now exposes stable
+- R4 is complete. The public `SessionGraph` header now exposes stable
   `SessionId`/`TrackId`/`ClipId` edits, canonical `TimeRange` snapshots,
   coalesced revisioned change sets, rollback-on-destruction transactions, and
   snapshot restore for application-owned undo/redo. Runtime transport and
@@ -46,9 +46,21 @@
   `add_subdirectory` consumer against `Orpheus::shmui_juce`, asserts that the
   OpenGL target and compile definition are absent, and runs in the Ubuntu
   Release CI leg.
-- Pause checkpoint: transaction and ShmUI work is pushed through `c5a1fc6c`.
-  Resume R4 at the fixed-capacity decimated realtime telemetry contract; no
-  telemetry implementation edits are pending in the working tree.
+- The transport now owns a public `RealtimeTelemetry` bridge: a fixed 64-slot
+  SPSC ring with configurable block decimation, monotonic sequence/drop
+  reporting, canonical post-block `TimePoint`, callback/underrun diagnostics,
+  active-voice count, and fixed group/master meters. Full rings drop the newest
+  capture rather than blocking or overwriting unread data.
+- Telemetry is presentation-neutral by contract. FFTs, histories, smoothing,
+  analyzer selection, and UI view models remain message-thread application
+  state; the SDK audio path only records and publishes bounded POD snapshots.
+- Local verification passed four queue/cadence/diagnostic tests, the live
+  transport integration test, and the strict in-repository realtime audit. A
+  clean-prefix `find_package` fixture also compiles and runs the public
+  `SessionGraph` transaction/snapshot and `RealtimeTelemetry` APIs, including
+  the transport-owned telemetry accessor, without any private header.
+- R5 remains gated on its stated two-consumer evidence and shipped/soaked
+  R1–R4 entry criteria; this checkpoint does not infer that evidence.
 - The Release Operating Model section is explicitly deferred to a later
   session; none of its remaining gates are represented as complete here.
 
@@ -226,6 +238,19 @@ No API is advertised as complete while it returns placeholder values, swallows a
 ---
 
 ## 5. Release and adoption operating model
+
+**Execution status:** deferred as a unit to a later session. The following jobs
+are recorded, remain incomplete, and are not prerequisites for closing the
+current R4 implementation checkpoint:
+
+- Enforce the CMake single-source versioning policy.
+- Run installed ABI compatibility and migration checks.
+- Model consumer needs only in SDK-owned fixtures.
+- Preserve the realtime release-blocker suite.
+- Maintain a hardware-backed long-running soak scenario.
+- Gate release supply-chain metadata and dependency audits.
+- Update public contract documentation atomically with API changes.
+- Verify overall installation and truthfulness criteria.
 
 | Practice | Required rule |
 | --- | --- |

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -20,6 +20,7 @@ struct AudioDriverConfig {
   uint32_t sample_rate = 48000; ///< Sample rate in Hz
   uint16_t buffer_size = 512;   ///< Buffer size in frames
   uint16_t num_inputs = 2;      ///< Number of input channels
+  std::string device_id;        ///< Stable backend device ID (empty = default)
   uint16_t num_outputs = 2;     ///< Number of output channels
   std::string device_name;      ///< Device name (empty = default device)
 };
@@ -148,6 +149,11 @@ ORPHEUS_API std::unique_ptr<IAudioDriver> createDummyAudioDriver();
 /// @return New CoreAudio driver instance
 #ifdef __APPLE__
 ORPHEUS_API std::unique_ptr<IAudioDriver> createCoreAudioDriver();
+#endif
+
+#ifdef _WIN32
+/// Factory function for shared-mode WASAPI driver.
+ORPHEUS_API std::unique_ptr<IAudioDriver> createWASAPIAudioDriver();
 #endif
 
 } // namespace orpheus

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -141,12 +142,12 @@ public:
 
 /// Factory function for dummy audio driver (for testing)
 /// @return New dummy audio driver instance
-std::unique_ptr<IAudioDriver> createDummyAudioDriver();
+ORPHEUS_API std::unique_ptr<IAudioDriver> createDummyAudioDriver();
 
 /// Factory function for CoreAudio driver (macOS only)
 /// @return New CoreAudio driver instance
 #ifdef __APPLE__
-std::unique_ptr<IAudioDriver> createCoreAudioDriver();
+ORPHEUS_API std::unique_ptr<IAudioDriver> createCoreAudioDriver();
 #endif
 
 } // namespace orpheus

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -40,8 +40,8 @@ struct AudioDeviceInfo {
 ///
 /// Platform Support:
 /// - macOS: CoreAudio device enumeration
-/// - Windows: WASAPI/ASIO device enumeration (stub in Phase 1)
-/// - Linux: ALSA device enumeration (stub in Phase 1)
+/// - Windows: WASAPI shared-mode device enumeration and playback
+/// - Linux: no released device backend; dummy/offline only
 /// - All platforms: Dummy driver (for testing)
 class IAudioDriverManager {
 public:

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <cstdint>
 #include <functional>
@@ -128,6 +129,6 @@ public:
 /// that enumerates and manages audio devices on the current platform.
 ///
 /// @return Unique pointer to driver manager instance
-std::unique_ptr<IAudioDriverManager> createAudioDriverManager();
+ORPHEUS_API std::unique_ptr<IAudioDriverManager> createAudioDriverManager();
 
 } // namespace orpheus

--- a/include/orpheus/audio_file_reader.h
+++ b/include/orpheus/audio_file_reader.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <cstdint>
 #include <memory>
@@ -151,6 +152,6 @@ public:
 /// Uses libsndfile for decoding (supports WAV, AIFF, FLAC).
 ///
 /// @return Unique pointer to audio file reader
-std::unique_ptr<IAudioFileReader> createAudioFileReader();
+ORPHEUS_API std::unique_ptr<IAudioFileReader> createAudioFileReader();
 
 } // namespace orpheus

--- a/include/orpheus/audio_file_reader_extended.h
+++ b/include/orpheus/audio_file_reader_extended.h
@@ -151,6 +151,6 @@ public:
 ///     // Render waveform in UI
 /// }
 /// @endcode
-std::unique_ptr<IAudioFileReaderExtended> createAudioFileReaderExtended();
+ORPHEUS_API std::unique_ptr<IAudioFileReaderExtended> createAudioFileReaderExtended();
 
 } // namespace orpheus

--- a/include/orpheus/audio_file_writer.h
+++ b/include/orpheus/audio_file_writer.h
@@ -3,6 +3,7 @@
 
 #include <orpheus/audio_file_reader.h> // AudioFileFormat, AudioFileMetadata
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <cstdint>
 #include <memory>
@@ -90,6 +91,6 @@ public:
 ///
 /// Uses libsndfile for encoding (WAV/AIFF/FLAC). Returns nullptr when the
 /// SDK was built without libsndfile — callers must check.
-std::unique_ptr<IAudioFileWriter> createAudioFileWriter();
+ORPHEUS_API std::unique_ptr<IAudioFileWriter> createAudioFileWriter();
 
 } // namespace orpheus

--- a/include/orpheus/audio_input.h
+++ b/include/orpheus/audio_input.h
@@ -22,6 +22,7 @@
 // punch in/out, latency compensation, arming semantics, file naming.
 
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <atomic>
 #include <cstddef>
@@ -127,6 +128,7 @@ public:
 };
 
 /// Create the SDK's ring-backed input stream.
-std::unique_ptr<IAudioInputStream> createAudioInputStream(const AudioInputStreamConfig& config);
+ORPHEUS_API std::unique_ptr<IAudioInputStream>
+createAudioInputStream(const AudioInputStreamConfig& config);
 
 } // namespace orpheus

--- a/include/orpheus/clip_routing.h
+++ b/include/orpheus/clip_routing.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <orpheus/export.h>
 #include <orpheus/transport_controller.h> // For ClipHandle, SessionGraphError
 
 namespace orpheus {
@@ -161,7 +162,7 @@ public:
 /// @param sessionGraph Session graph containing clip metadata
 /// @param sampleRate Audio sample rate (e.g., 48000)
 /// @return Unique pointer to clip routing matrix
-std::unique_ptr<IClipRoutingMatrix> createClipRoutingMatrix(core::SessionGraph* sessionGraph,
-                                                            uint32_t sampleRate);
+ORPHEUS_API std::unique_ptr<IClipRoutingMatrix>
+createClipRoutingMatrix(core::SessionGraph* sessionGraph, uint32_t sampleRate);
 
 } // namespace orpheus

--- a/include/orpheus/identity.h
+++ b/include/orpheus/identity.h
@@ -3,12 +3,9 @@
 
 // ORP134 G2: stable identity primitives.
 //
-// The existing session graph identifies Clip/Track objects by POINTER
-// (session_graph.h) — fine in-memory, but useless for serialization, undo,
-// cross-process references, or takes/comping (ORP135 B2). These strong ID
-// types are ADDITIVE: they live alongside the pointer-based graph (which is
-// deliberately NOT rewritten — see ORP134 §7 "Do Not Touch Yet"); new code
-// and serialization should prefer IDs.
+// SessionGraph now uses these IDs for its public transaction/snapshot contract.
+// Pointer-returning methods remain control-thread conveniences for the legacy C
+// ABI, while persistence, undo, and cross-thread handoff use stable IDs.
 //
 // Properties:
 //  * Opaque strong typedefs over uint64_t — SessionId and ClipId do not

--- a/include/orpheus/realtime_telemetry.h
+++ b/include/orpheus/realtime_telemetry.h
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <orpheus/export.h>
+#include <orpheus/realtime_diagnostics.h>
+#include <orpheus/routing_matrix.h>
+#include <orpheus/time_domain.h>
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace orpheus {
+
+/// Stable schema version for RealtimeTelemetrySnapshot.
+inline constexpr uint32_t kRealtimeTelemetrySchemaVersion = 1;
+
+/// Default cadence: retain one snapshot after every eight audio callbacks.
+inline constexpr uint32_t kRealtimeTelemetryDefaultDecimationBlocks = 8;
+/// Maximum routing groups carried by one telemetry snapshot.
+inline constexpr size_t kRealtimeTelemetryMaxGroups = 16;
+
+/// Number of snapshots retained by RealtimeTelemetry before new captures drop.
+inline constexpr size_t kRealtimeTelemetryCapacity = 64;
+
+/// Fixed-size transport, routing, and callback-health observation.
+///
+/// This is deliberately presentation-neutral. Hosts may build meter histories,
+/// FFT analyzers, view models, and smoothing on the message thread after
+/// tryRead(); none of that application state belongs in the realtime bridge.
+struct RealtimeTelemetrySnapshot {
+  uint32_t schema_version{kRealtimeTelemetrySchemaVersion};
+  uint64_t sequence{0}; ///< Monotonic capture attempt; gaps identify dropped snapshots.
+  TimePoint position{}; ///< Canonical post-block transport position.
+  RealtimeDiagnosticsSnapshot diagnostics{};
+  uint32_t active_voice_count{0};
+  uint8_t group_count{0};
+  std::array<AudioMeter, kRealtimeTelemetryMaxGroups> group_meters{};
+  AudioMeter master_meter{};
+};
+
+static_assert(std::is_trivially_copyable_v<RealtimeTelemetrySnapshot>);
+
+/// Fixed-capacity single-producer/single-consumer realtime telemetry bridge.
+///
+/// Thread and lifetime contract:
+/// - Exactly one realtime producer calls beginRealtimeBlock(),
+///   reportUnderrunFromRealtime(), and publishFromRealtime().
+/// - Exactly one message-thread consumer calls tryRead().
+/// - setDecimationBlocks() and the const queries may be called from any thread.
+/// - The bridge must outlive both producer and consumer; callers must stop both
+///   threads before destroying it.
+///
+/// The producer never allocates, locks, blocks, performs I/O, or overwrites an
+/// unread slot. A full ring drops the new snapshot and increments the drop
+/// count. The consumer owns all work performed after tryRead().
+class ORPHEUS_API RealtimeTelemetry {
+public:
+  explicit RealtimeTelemetry(
+      uint32_t decimationBlocks = kRealtimeTelemetryDefaultDecimationBlocks) noexcept;
+
+  RealtimeTelemetry(const RealtimeTelemetry&) = delete;
+  RealtimeTelemetry& operator=(const RealtimeTelemetry&) = delete;
+
+  /// Record one callback and return true when this block should be captured.
+  /// Call once per realtime callback, before publishFromRealtime().
+  [[nodiscard]] bool beginRealtimeBlock(uint32_t bufferFrames, uint32_t sampleRate) noexcept;
+
+  /// Add one source/cache underrun to the next diagnostics snapshot.
+  void reportUnderrunFromRealtime() noexcept;
+
+  /// Publish a due snapshot. Returns false when the fixed ring is full.
+  /// The bridge stamps schema_version, sequence, and diagnostics.
+  [[nodiscard]] bool publishFromRealtime(RealtimeTelemetrySnapshot snapshot) noexcept;
+
+  /// Read the oldest retained snapshot on the single consumer thread.
+  [[nodiscard]] bool tryRead(RealtimeTelemetrySnapshot& snapshot) noexcept;
+
+  /// Capture one snapshot after each N callbacks. Zero is clamped to one.
+  void setDecimationBlocks(uint32_t blocks) noexcept;
+  [[nodiscard]] uint32_t decimationBlocks() const noexcept;
+
+  [[nodiscard]] uint64_t droppedSnapshotCount() const noexcept;
+  [[nodiscard]] size_t pendingSnapshotCount() const noexcept;
+
+private:
+  std::array<RealtimeTelemetrySnapshot, kRealtimeTelemetryCapacity> snapshots_{};
+  std::atomic<uint64_t> write_index_{0};
+  std::atomic<uint64_t> read_index_{0};
+  std::atomic<uint64_t> dropped_snapshot_count_{0};
+  std::atomic<uint32_t> decimation_blocks_{kRealtimeTelemetryDefaultDecimationBlocks};
+
+  RealtimeDiagnostics diagnostics_{};
+  uint32_t blocks_since_snapshot_{0}; // Producer thread only.
+  uint64_t next_sequence_{1};         // Producer thread only.
+};
+
+} // namespace orpheus

--- a/include/orpheus/routing_matrix.h
+++ b/include/orpheus/routing_matrix.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <orpheus/export.h>
 #include <orpheus/time_domain.h>
 
 #include <cstdint>
@@ -484,6 +485,6 @@ public:
 
 /// Create routing matrix instance
 /// @return Unique pointer to routing matrix
-std::unique_ptr<IRoutingMatrix> createRoutingMatrix();
+ORPHEUS_API std::unique_ptr<IRoutingMatrix> createRoutingMatrix();
 
 } // namespace orpheus

--- a/include/orpheus/session_graph.h
+++ b/include/orpheus/session_graph.h
@@ -10,19 +10,18 @@
 #include <vector>
 
 #include "orpheus/export.h"
+#include "orpheus/identity.h"
+#include "orpheus/time_domain.h"
 
 namespace orpheus::core {
 
 class Clip {
 public:
-  ORPHEUS_API Clip(std::string name, double start_beats, double length_beats,
-                   std::uint32_t scene_index = 0u);
   ORPHEUS_API ~Clip();
 
-  ORPHEUS_API void set_start(double start_beats);
-  ORPHEUS_API void set_length(double length_beats);
-  ORPHEUS_API void set_scene_index(std::uint32_t scene_index);
-
+  [[nodiscard]] ClipId id() const {
+    return id_;
+  }
   [[nodiscard]] double start() const {
     return start_beats_;
   }
@@ -37,15 +36,24 @@ public:
   }
 
 private:
+  Clip(ClipId id, std::string name, double start_beats, double length_beats,
+       std::uint32_t scene_index);
+  void set_start(double start_beats);
+  void set_length(double length_beats);
+  void set_scene_index(std::uint32_t scene_index);
+
+  ClipId id_{};
   std::string name_;
   double start_beats_;
   double length_beats_;
   std::uint32_t scene_index_;
+
+  friend class Track;
+  friend class SessionGraph;
 };
 
 class Track {
 public:
-  ORPHEUS_API explicit Track(std::string name);
   ORPHEUS_API ~Track();
 
   Track(const Track&) = delete;
@@ -56,11 +64,9 @@ public:
   [[nodiscard]] const std::string& name() const {
     return name_;
   }
-
-  [[nodiscard]] ORPHEUS_API Clip* add_clip(std::string name, double start_beats,
-                                           double length_beats, std::uint32_t scene_index = 0u);
-  [[nodiscard]] ORPHEUS_API bool remove_clip(const Clip* clip);
-  [[nodiscard]] ORPHEUS_API Clip* find_clip(const Clip* clip);
+  [[nodiscard]] TrackId id() const {
+    return id_;
+  }
 
   [[nodiscard]] const std::vector<std::unique_ptr<Clip>>& clips() const {
     return clips_;
@@ -74,11 +80,16 @@ public:
     return clips_.end();
   }
 
-  ORPHEUS_API void sort_clips();
-
 private:
+  Track(TrackId id, std::string name);
+  [[nodiscard]] Clip* add_clip(ClipId id, std::string name, double start_beats, double length_beats,
+                               std::uint32_t scene_index);
+  [[nodiscard]] bool remove_clip(const Clip* clip);
+  [[nodiscard]] Clip* find_clip(const Clip* clip);
+  void sort_clips();
   void validate_clip_layout() const;
 
+  TrackId id_{};
   std::string name_;
   std::vector<std::unique_ptr<Clip>> clips_;
 
@@ -156,10 +167,100 @@ struct ORPHEUS_API CommittedClip {
   double arranged_start_beats{0.0};
   double arranged_length_beats{0.0};
 };
+enum class SessionChangeFlags : std::uint32_t {
+  None = 0u,
+  Metadata = 1u << 0u,
+  Structure = 1u << 1u,
+  Timing = 1u << 2u,
+  ClipAssignments = 1u << 3u,
+  RenderSettings = 1u << 4u,
+};
+
+[[nodiscard]] constexpr SessionChangeFlags operator|(SessionChangeFlags lhs,
+                                                     SessionChangeFlags rhs) {
+  return static_cast<SessionChangeFlags>(static_cast<std::uint32_t>(lhs) |
+                                         static_cast<std::uint32_t>(rhs));
+}
+
+constexpr SessionChangeFlags& operator|=(SessionChangeFlags& lhs, SessionChangeFlags rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+[[nodiscard]] constexpr bool has_change(SessionChangeFlags value, SessionChangeFlags flag) {
+  return (static_cast<std::uint32_t>(value) & static_cast<std::uint32_t>(flag)) != 0u;
+}
+
+struct SessionGraphChangeSet {
+  std::uint64_t base_revision{0u};
+  std::uint64_t revision{0u};
+  SessionChangeFlags changes{SessionChangeFlags::None};
+
+  [[nodiscard]] bool empty() const {
+    return changes == SessionChangeFlags::None;
+  }
+};
+
+struct SessionClipSnapshot {
+  ClipId id{};
+  TrackId track_id{};
+  std::string name;
+  TimeRange range{};
+  std::uint32_t scene_index{0u};
+};
+
+struct SessionTrackSnapshot {
+  TrackId id{};
+  std::string name;
+  std::vector<SessionClipSnapshot> clips;
+};
+
+/// Pointer-free state for persistence, undo/redo, and cross-thread handoff.
+///
+/// Time values are canonical sample-domain values at render_sample_rate_hz.
+/// Runtime transport, scene-trigger, marker, and playlist state are deliberately
+/// excluded from the transactional edit domain.
+struct SessionGraphSnapshot {
+  static constexpr std::uint32_t kSchemaVersion = 1u;
+
+  std::uint32_t schema_version{kSchemaVersion};
+  SessionId session_id{};
+  std::uint64_t revision{0u};
+  std::string name;
+  double tempo_bpm{120.0};
+  std::uint32_t render_sample_rate_hz{48000u};
+  std::uint16_t render_bit_depth_bits{24u};
+  bool render_dither_enabled{true};
+  TimeRange session_range{};
+  std::vector<SessionTrackSnapshot> tracks;
+  std::vector<ClipId> clip_assignments;
+};
 
 class SessionGraph {
 public:
+  class Transaction {
+  public:
+    Transaction(const Transaction&) = delete;
+    Transaction& operator=(const Transaction&) = delete;
+    ORPHEUS_API Transaction(Transaction&& other) noexcept;
+    ORPHEUS_API Transaction& operator=(Transaction&& other) noexcept;
+    ORPHEUS_API ~Transaction();
+
+    [[nodiscard]] ORPHEUS_API SessionGraphChangeSet commit();
+    ORPHEUS_API void rollback() noexcept;
+
+  private:
+    friend class SessionGraph;
+    Transaction(SessionGraph& graph, SessionGraphSnapshot before);
+
+    SessionGraph* graph_{nullptr};
+    SessionGraphSnapshot before_{};
+    SessionGraphChangeSet before_change_{};
+    std::uint64_t base_revision_{0u};
+  };
+
   ORPHEUS_API SessionGraph();
+  ORPHEUS_API explicit SessionGraph(SessionId session_id);
   ORPHEUS_API ~SessionGraph();
 
   SessionGraph(const SessionGraph&) = delete;
@@ -171,6 +272,28 @@ public:
   [[nodiscard]] const std::string& name() const {
     return name_;
   }
+
+  [[nodiscard]] SessionId id() const {
+    return session_id_;
+  }
+  [[nodiscard]] std::uint64_t revision() const {
+    return revision_;
+  }
+  [[nodiscard]] const SessionGraphChangeSet& last_change() const {
+    return last_change_;
+  }
+
+  [[nodiscard]] ORPHEUS_API Transaction begin_transaction();
+  [[nodiscard]] ORPHEUS_API SessionGraphSnapshot snapshot() const;
+  ORPHEUS_API void restore(const SessionGraphSnapshot& snapshot);
+
+  [[nodiscard]] ORPHEUS_API TrackId create_track(std::string name);
+  [[nodiscard]] ORPHEUS_API bool remove_track(TrackId track_id);
+  [[nodiscard]] ORPHEUS_API ClipId create_clip(TrackId track_id, std::string name, TimeRange range,
+                                               std::uint32_t scene_index = 0u);
+  [[nodiscard]] ORPHEUS_API bool remove_clip(ClipId clip_id);
+  ORPHEUS_API void set_clip_range(ClipId clip_id, TimeRange range);
+  ORPHEUS_API void set_clip_scene(ClipId clip_id, std::uint32_t scene_index);
 
   [[nodiscard]] ORPHEUS_API Track* add_track(std::string name);
   [[nodiscard]] ORPHEUS_API bool remove_track(const Track* track);
@@ -231,6 +354,8 @@ public:
   }
 
   ORPHEUS_API void set_clip_assignments(std::vector<std::uint64_t> assignments);
+  [[nodiscard]] ORPHEUS_API std::vector<ClipId> clip_assignment_ids() const;
+  ORPHEUS_API void set_clip_assignment_ids(std::vector<ClipId> assignments);
 
   [[nodiscard]] const std::vector<std::unique_ptr<Track>>& tracks() const {
     return tracks_;
@@ -274,6 +399,10 @@ private:
   Track* find_track(const Track* track);
   Track* find_clip_track(const Clip* clip);
   Clip* find_clip(const Clip* clip);
+  Track* find_track(TrackId track_id);
+  Clip* find_clip(ClipId clip_id);
+  void record_change(SessionChangeFlags changes);
+  void restore_unchecked(const SessionGraphSnapshot& snapshot);
   void mark_clip_grid_dirty() {
     clip_grid_dirty_ = true;
   }
@@ -296,6 +425,13 @@ private:
     std::size_t timeline_index{0};
   };
 
+  SessionId session_id_{SessionId::fromRaw(1u)};
+  IdAllocator<TrackId> track_ids_{};
+  IdAllocator<ClipId> clip_ids_{};
+  std::uint64_t revision_{0u};
+  SessionGraphChangeSet last_change_{};
+  SessionChangeFlags pending_changes_{SessionChangeFlags::None};
+  bool transaction_active_{false};
   double tempo_bpm_{120.0};
   double transport_position_beats_{0.0};
   bool transport_is_playing_{false};

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <orpheus/errors.h>
+#include <orpheus/export.h>
 
 #include <cstdint>
 #include <memory>
@@ -766,7 +767,7 @@ public:
 /// @param sessionGraph The session graph containing clip metadata
 /// @param sampleRate Audio sample rate (e.g., 48000)
 /// @return Unique pointer to transport controller
-std::unique_ptr<ITransportController> createTransportController(core::SessionGraph* sessionGraph,
-                                                                uint32_t sampleRate);
+ORPHEUS_API std::unique_ptr<ITransportController>
+createTransportController(core::SessionGraph* sessionGraph, uint32_t sampleRate);
 
 } // namespace orpheus

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -3,6 +3,7 @@
 
 #include <orpheus/errors.h>
 #include <orpheus/export.h>
+#include <orpheus/realtime_telemetry.h>
 
 #include <cstdint>
 #include <memory>
@@ -760,6 +761,14 @@ public:
   ///
   /// @see addCuePoint(), getCuePoints()
   virtual SessionGraphError removeCuePoint(ClipHandle handle, uint32_t cueIndex) = 0;
+
+  /// Access the fixed-capacity realtime telemetry bridge.
+  ///
+  /// The transport owns the returned object for its lifetime. Exactly one
+  /// message-thread consumer may configure its decimation and drain snapshots
+  /// with RealtimeTelemetry::tryRead(). The audio callback is the sole producer.
+  /// Hosts must not retain the pointer after destroying the controller.
+  virtual RealtimeTelemetry* getRealtimeTelemetry() noexcept = 0;
 };
 
 /// Create a transport controller instance

--- a/packages/shmui-juce/CMakeLists.txt
+++ b/packages/shmui-juce/CMakeLists.txt
@@ -5,9 +5,9 @@
 # Shmui Audio Visualization & UI Components (v2.1)
 # Icons, Buttons, Visualizers, and Controls for Orpheus SDK audio applications.
 #
-# This is the SOURCE OF TRUTH for the shmui-juce build. It is synced (verbatim,
-# including this file adapted for the flattened layout) into the Orpheus SDK at
-# packages/shmui-juce/ by scripts/sync-juce.sh. Edit here, not there.
+# This is the SDK-imported package described by shmui-juce-import.json.
+# Update imported content and its manifest hash together with
+# tools/shmui_juce_manifest.py --sync.
 #
 # TARGETS
 #   orpheus_shmui_juce        core: Icons, Controls, Audio, non-GL Components.

--- a/packages/shmui-juce/ShmUI.h
+++ b/packages/shmui-juce/ShmUI.h
@@ -48,10 +48,10 @@
     - UI components should be used on the message thread
     - Use juce::MessageManager::callAsync for cross-thread updates
 
-    Sync to Orpheus SDK:
-    scripts/sync-juce.sh   (mirrors juce/Source/ → packages/shmui-juce/,
-                            formats to the SDK clang-format, regenerates the
-                            package CMakeLists; --check verifies no drift)
+    Sync contract:
+    packages/shmui-juce/shmui-juce-import.json records the source revision,
+    exported components, JUCE modules, feature gates, token contract, and the
+    imported content hash. tools/shmui_juce_manifest.py verifies drift.
 
   ==============================================================================
 */

--- a/packages/shmui-juce/shmui-juce-import.json
+++ b/packages/shmui-juce/shmui-juce-import.json
@@ -4,7 +4,8 @@
     "repository": "shmui",
     "path": "juce/Source",
     "revision": "a6e6b990631ed9fa64153d6f873d760da60b57e9",
-    "content_sha256": "950c6d2d677d2429b5a128a11714121da10ae084274989d2c550cbc97f16f1a8"
+    "content_sha256": "327d8923e2f6ebefce673137295ca51abf5045339840917fcad8d320ccd5f056",
+    "content_hash_algorithm": "sha256-path-nul-content-v1"
   },
   "design_token_contract_version": "0.2.0",
   "targets": {
@@ -39,8 +40,12 @@
       ]
     },
     "Orpheus::shmui_juce_gl": {
-      "components": ["OrbVisualizer"],
-      "required_juce_modules": ["juce_opengl"],
+      "components": [
+        "OrbVisualizer"
+      ],
+      "required_juce_modules": [
+        "juce_opengl"
+      ],
       "feature_flag": "SHMUI_JUCE_ENABLE_OPENGL",
       "default_enabled": false
     }

--- a/packages/shmui-juce/shmui-juce-import.json
+++ b/packages/shmui-juce/shmui-juce-import.json
@@ -4,7 +4,7 @@
     "repository": "shmui",
     "path": "juce/Source",
     "revision": "a6e6b990631ed9fa64153d6f873d760da60b57e9",
-    "content_sha256": "327d8923e2f6ebefce673137295ca51abf5045339840917fcad8d320ccd5f056",
+    "content_sha256": "54781822bd39994f2b700b7caa8d70395c51f698862de073f0cf51be00c872a7",
     "content_hash_algorithm": "sha256-path-nul-content-v1"
   },
   "design_token_contract_version": "0.2.0",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,9 +85,9 @@ foreach(target ${ORPHEUS_CORE_TARGETS})
   set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endforeach()
 
-# performance_monitor.cpp (in orpheus_diagnostics_objects) includes
-# session/session_graph.h and holds a core::SessionGraph*, so it emits references
-# to SessionGraph's member destructors (Clip/Track/MarkerSet/PlaylistLane). Bundle
+# performance_monitor.cpp (in orpheus_diagnostics_objects) holds a public
+# core::SessionGraph pointer, so it emits references to SessionGraph's member
+# destructors (Clip/Track/MarkerSet/PlaylistLane). Bundle
 # orpheus_core_runtime's objects so orpheus_diagnostics is genuinely self-contained
 # — the standalone link check (verify_diagnostics_standalone) requires it, and
 # MSVC's strict archive resolution fails to link without it (LNK2019).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 add_library(orpheus_diagnostics_objects OBJECT
   core/common/performance_monitor.cpp
   core/common/realtime_diagnostics.cpp
+  core/common/realtime_telemetry.cpp
 )
 
 target_compile_features(orpheus_diagnostics_objects PUBLIC cxx_std_20)

--- a/src/core/abi/abi_internal.h
+++ b/src/core/abi/abi_internal.h
@@ -3,7 +3,7 @@
 
 #include "orpheus/abi.h"
 
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <filesystem>
 #include <ios>

--- a/src/core/common/performance_monitor.cpp
+++ b/src/core/common/performance_monitor.cpp
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <cmath>
 
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 namespace orpheus {
 

--- a/src/core/common/realtime_telemetry.cpp
+++ b/src/core/common/realtime_telemetry.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/realtime_telemetry.h>
+
+#include <algorithm>
+
+namespace orpheus {
+
+RealtimeTelemetry::RealtimeTelemetry(uint32_t decimationBlocks) noexcept {
+  setDecimationBlocks(decimationBlocks);
+}
+
+bool RealtimeTelemetry::beginRealtimeBlock(uint32_t bufferFrames, uint32_t sampleRate) noexcept {
+  diagnostics_.recordCallback(bufferFrames, sampleRate);
+
+  ++blocks_since_snapshot_;
+  const uint32_t blocks = decimation_blocks_.load(std::memory_order_relaxed);
+  if (blocks_since_snapshot_ < blocks) {
+    return false;
+  }
+
+  blocks_since_snapshot_ = 0;
+  return true;
+}
+
+void RealtimeTelemetry::reportUnderrunFromRealtime() noexcept {
+  diagnostics_.reportUnderrun();
+}
+
+bool RealtimeTelemetry::publishFromRealtime(RealtimeTelemetrySnapshot snapshot) noexcept {
+  snapshot.schema_version = kRealtimeTelemetrySchemaVersion;
+  snapshot.sequence = next_sequence_++;
+  snapshot.diagnostics = diagnostics_.snapshot();
+
+  const uint64_t writeIndex = write_index_.load(std::memory_order_relaxed);
+  const uint64_t readIndex = read_index_.load(std::memory_order_acquire);
+  if ((writeIndex - readIndex) >= kRealtimeTelemetryCapacity) {
+    dropped_snapshot_count_.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+
+  snapshots_[writeIndex % kRealtimeTelemetryCapacity] = snapshot;
+  write_index_.store(writeIndex + 1, std::memory_order_release);
+  return true;
+}
+
+bool RealtimeTelemetry::tryRead(RealtimeTelemetrySnapshot& snapshot) noexcept {
+  const uint64_t readIndex = read_index_.load(std::memory_order_relaxed);
+  const uint64_t writeIndex = write_index_.load(std::memory_order_acquire);
+  if (readIndex == writeIndex) {
+    return false;
+  }
+
+  snapshot = snapshots_[readIndex % kRealtimeTelemetryCapacity];
+  read_index_.store(readIndex + 1, std::memory_order_release);
+  return true;
+}
+
+void RealtimeTelemetry::setDecimationBlocks(uint32_t blocks) noexcept {
+  decimation_blocks_.store(std::max(blocks, uint32_t{1}), std::memory_order_relaxed);
+}
+
+uint32_t RealtimeTelemetry::decimationBlocks() const noexcept {
+  return decimation_blocks_.load(std::memory_order_relaxed);
+}
+
+uint64_t RealtimeTelemetry::droppedSnapshotCount() const noexcept {
+  return dropped_snapshot_count_.load(std::memory_order_relaxed);
+}
+
+size_t RealtimeTelemetry::pendingSnapshotCount() const noexcept {
+  const uint64_t writeIndex = write_index_.load(std::memory_order_acquire);
+  const uint64_t readIndex = read_index_.load(std::memory_order_acquire);
+  return static_cast<size_t>(writeIndex - readIndex);
+}
+
+} // namespace orpheus

--- a/src/core/session/json_io.cpp
+++ b/src/core/session/json_io.cpp
@@ -5,7 +5,9 @@
 #include <cctype>
 #include <cerrno>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -13,6 +15,14 @@
 #include <stdexcept>
 #include <string_view>
 #include <vector>
+
+#if defined(_WIN32)
+#include <io.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 #include "common/json_parser.h"
 
@@ -31,6 +41,87 @@ using ::orpheus::core::json::RequireString;
 using ::orpheus::core::json::WriteIndent;
 
 constexpr double kClipOrderingTolerance = 1e-9;
+
+std::string ReadTextFile(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("Unable to open session: " + path.string());
+  }
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  if (!file.eof() && file.fail()) {
+    throw std::runtime_error("Failed to read session: " + path.string());
+  }
+  return buffer.str();
+}
+
+void SyncFile(std::FILE* file, const std::filesystem::path& path) {
+  if (std::fflush(file) != 0) {
+    throw std::runtime_error("Failed to flush session: " + path.string());
+  }
+#if defined(_WIN32)
+  if (_commit(_fileno(file)) != 0) {
+#else
+  if (::fsync(fileno(file)) != 0) {
+#endif
+    throw std::runtime_error("Failed to sync session: " + path.string());
+  }
+}
+
+void WriteDurableFile(const std::filesystem::path& path, const std::string& contents) {
+#if defined(_WIN32)
+  std::FILE* file = _wfopen(path.c_str(), L"wb");
+#else
+  std::FILE* file = std::fopen(path.c_str(), "wb");
+#endif
+  if (file == nullptr) {
+    throw std::runtime_error("Unable to write session: " + path.string());
+  }
+  try {
+    const size_t written = std::fwrite(contents.data(), 1, contents.size(), file);
+    if (written != contents.size()) {
+      throw std::runtime_error("Failed to write session: " + path.string());
+    }
+    SyncFile(file, path);
+  } catch (...) {
+    std::fclose(file);
+    throw;
+  }
+  if (std::fclose(file) != 0) {
+    throw std::runtime_error("Failed to close session: " + path.string());
+  }
+}
+
+void ReplaceFile(const std::filesystem::path& source, const std::filesystem::path& destination) {
+#if defined(_WIN32)
+  if (MoveFileExW(source.c_str(), destination.c_str(),
+                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0) {
+    throw std::runtime_error("Failed to replace session: " + destination.string());
+  }
+#else
+  if (::rename(source.c_str(), destination.c_str()) != 0) {
+    throw std::runtime_error("Failed to replace session: " + destination.string());
+  }
+#endif
+}
+
+void SyncParentDirectory(const std::filesystem::path& path) {
+#if !defined(_WIN32)
+  const std::filesystem::path parent =
+      path.parent_path().empty() ? std::filesystem::path{"."} : path.parent_path();
+  const int directory = ::open(parent.c_str(), O_RDONLY);
+  if (directory < 0) {
+    throw std::runtime_error("Unable to open session directory: " + parent.string());
+  }
+  const int result = ::fsync(directory);
+  ::close(directory);
+  if (result != 0) {
+    throw std::runtime_error("Failed to sync session directory: " + parent.string());
+  }
+#else
+  (void)path;
+#endif
+}
 
 std::string FormatSampleRateTag(std::uint32_t sample_rate_hz) {
   if (sample_rate_hz == 0u) {
@@ -88,6 +179,12 @@ SessionGraph ParseSession(const std::string& json_text) {
   JsonParser parser(json_text);
   const JsonValue root = parser.Parse();
   const JsonValue& object = ExpectObject(root, "session root");
+  if (auto schema_it = object.object.find("schema_version"); schema_it != object.object.end()) {
+    const double version = RequireNumber(schema_it->second, "schema_version");
+    if (version != 0.0 && version != static_cast<double>(kCurrentSessionSchemaVersion)) {
+      throw std::runtime_error("Unsupported session schema_version");
+    }
+  }
 
   SessionGraph session;
   const JsonValue* session_name_field = RequireField(object, "name");
@@ -206,6 +303,8 @@ SessionGraph ParseSession(const std::string& json_text) {
 std::string SerializeSession(const SessionGraph& session) {
   std::ostringstream stream;
   stream << "{\n";
+  WriteIndent(stream, 2);
+  stream << "\"schema_version\": " << kCurrentSessionSchemaVersion << ",\n";
   WriteIndent(stream, 2);
   stream << "\"name\": \"" << EscapeString(session.name()) << "\",\n";
   WriteIndent(stream, 2);
@@ -383,24 +482,48 @@ std::string SerializeSession(const SessionGraph& session) {
   return stream.str();
 }
 
-SessionGraph LoadSessionFromFile(const std::string& path) {
-  std::ifstream file(path);
-  if (!file.is_open()) {
-    throw std::runtime_error("Unable to open session fixture: " + path);
+SessionLoadResult LoadSessionWithRecovery(const std::string& path) {
+  try {
+    return {ParseSession(ReadTextFile(path)), false, path};
+  } catch (const std::exception& primaryError) {
+    const std::filesystem::path backup = std::filesystem::path(path).concat(".bak");
+    try {
+      return {ParseSession(ReadTextFile(backup)), true, backup.string()};
+    } catch (const std::exception& backupError) {
+      throw std::runtime_error("Unable to load session primary (" +
+                               std::string(primaryError.what()) + ") or backup (" +
+                               backupError.what() + ")");
+    }
   }
-  std::ostringstream buffer;
-  buffer << file.rdbuf();
-  return ParseSession(buffer.str());
+}
+
+SessionGraph LoadSessionFromFile(const std::string& path) {
+  return LoadSessionWithRecovery(path).session;
 }
 
 void SaveSessionToFile(const SessionGraph& session, const std::string& path) {
-  std::ofstream file(path);
-  if (!file.is_open()) {
-    throw std::runtime_error("Unable to write session: " + path);
+  if (path.empty()) {
+    throw std::invalid_argument("Session path must not be empty");
   }
-  file << SerializeSession(session);
-  if (!file) {
-    throw std::runtime_error("Failed to write session: " + path);
+  const std::filesystem::path destination(path);
+  const std::filesystem::path temporary = std::filesystem::path(path).concat(".tmp");
+  const std::filesystem::path backup = std::filesystem::path(path).concat(".bak");
+  const std::filesystem::path backupTemporary = std::filesystem::path(path).concat(".bak.tmp");
+  std::error_code cleanupError;
+
+  try {
+    WriteDurableFile(temporary, SerializeSession(session));
+    if (std::filesystem::exists(destination)) {
+      WriteDurableFile(backupTemporary, ReadTextFile(destination));
+      ReplaceFile(backupTemporary, backup);
+    }
+    ReplaceFile(temporary, destination);
+    SyncParentDirectory(destination);
+  } catch (...) {
+    std::filesystem::remove(temporary, cleanupError);
+    cleanupError.clear();
+    std::filesystem::remove(backupTemporary, cleanupError);
+    throw;
   }
 }
 

--- a/src/core/session/json_io.h
+++ b/src/core/session/json_io.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "orpheus/export.h"
-#include "session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <utility>
 namespace orpheus::core::session_json {

--- a/src/core/session/json_io.h
+++ b/src/core/session/json_io.h
@@ -8,12 +8,22 @@
 #include "orpheus/export.h"
 #include "session_graph.h"
 
+#include <utility>
 namespace orpheus::core::session_json {
+
+inline constexpr std::uint32_t kCurrentSessionSchemaVersion = 1;
+
+struct SessionLoadResult {
+  SessionGraph session;
+  bool recoveredFromBackup = false;
+  std::string sourcePath;
+};
 
 ORPHEUS_API SessionGraph ParseSession(const std::string& json_text);
 ORPHEUS_API std::string SerializeSession(const SessionGraph& session);
 
 ORPHEUS_API SessionGraph LoadSessionFromFile(const std::string& path);
+ORPHEUS_API SessionLoadResult LoadSessionWithRecovery(const std::string& path);
 ORPHEUS_API void SaveSessionToFile(const SessionGraph& session, const std::string& path);
 
 ORPHEUS_API std::string MakeRenderStemFilename(const std::string& session_name,

--- a/src/core/session/scene_manager.cpp
+++ b/src/core/session/scene_manager.cpp
@@ -14,7 +14,7 @@
 
 #include "orpheus/json.hpp"
 #include "orpheus/routing_matrix.h"
-#include "session_graph.h"
+#include <orpheus/session_graph.h>
 
 namespace orpheus {
 

--- a/src/core/session/session_graph.cpp
+++ b/src/core/session/session_graph.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-#include "session_graph.h"
+#include "orpheus/session_graph.h"
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 
 namespace orpheus::core {
@@ -12,10 +13,22 @@ namespace orpheus::core {
 namespace {
 constexpr double kMinimumLengthBeats = 1e-6;
 constexpr double kClipOrderingTolerance = 1e-9;
+
+TimeRange RangeFromBeats(double start_beats, double length_beats, double tempo_bpm,
+                         std::uint32_t sample_rate) {
+  const TimePoint start = TimePoint::fromBeats(start_beats, tempo_bpm, sample_rate);
+  const TimePoint end = TimePoint::fromBeats(start_beats + length_beats, tempo_bpm, sample_rate);
+  return TimeRange::fromStartEnd(start, end);
+}
+
+double BeatsFromTime(TimePoint point, double tempo_bpm, std::uint32_t sample_rate) {
+  return point.toBeats(tempo_bpm, sample_rate);
+}
 } // namespace
 
-Clip::Clip(std::string name, double start_beats, double length_beats, std::uint32_t scene_index)
-    : name_(std::move(name)), start_beats_(start_beats),
+Clip::Clip(ClipId id, std::string name, double start_beats, double length_beats,
+           std::uint32_t scene_index)
+    : id_(id), name_(std::move(name)), start_beats_(start_beats),
       length_beats_(std::max(length_beats, kMinimumLengthBeats)), scene_index_(scene_index) {}
 
 Clip::~Clip() = default;
@@ -32,13 +45,14 @@ void Clip::set_scene_index(std::uint32_t scene_index) {
   scene_index_ = scene_index;
 }
 
-Track::Track(std::string name) : name_(std::move(name)) {}
+Track::Track(TrackId id, std::string name) : id_(id), name_(std::move(name)) {}
 
 Track::~Track() = default;
 
-Clip* Track::add_clip(std::string name, double start_beats, double length_beats,
+Clip* Track::add_clip(ClipId id, std::string name, double start_beats, double length_beats,
                       std::uint32_t scene_index) {
-  auto clip = std::make_unique<Clip>(std::move(name), start_beats, length_beats, scene_index);
+  auto clip =
+      std::unique_ptr<Clip>(new Clip(id, std::move(name), start_beats, length_beats, scene_index));
   Clip* raw = clip.get();
   clips_.push_back(std::move(clip));
   sort_clips();
@@ -142,21 +156,308 @@ void PlaylistLane::set_active(bool active) {
   is_active_ = active;
 }
 
-SessionGraph::SessionGraph() : name_("Session") {}
+SessionGraph::SessionGraph() : SessionGraph(SessionId::fromRaw(1u)) {}
+
+SessionGraph::SessionGraph(SessionId session_id) : session_id_(session_id), name_("Session") {
+  if (!session_id.isValid()) {
+    throw std::invalid_argument("Session ID must be valid");
+  }
+}
 
 SessionGraph::~SessionGraph() = default;
 
+SessionGraph::Transaction::Transaction(SessionGraph& graph, SessionGraphSnapshot before)
+    : graph_(&graph), before_(std::move(before)), before_change_(graph.last_change_),
+      base_revision_(graph.revision_) {}
+
+SessionGraph::Transaction::Transaction(Transaction&& other) noexcept
+    : graph_(std::exchange(other.graph_, nullptr)), before_(std::move(other.before_)),
+      before_change_(other.before_change_), base_revision_(other.base_revision_) {}
+
+SessionGraph::Transaction& SessionGraph::Transaction::operator=(Transaction&& other) noexcept {
+  if (this != &other) {
+    rollback();
+    graph_ = std::exchange(other.graph_, nullptr);
+    before_ = std::move(other.before_);
+    before_change_ = other.before_change_;
+    base_revision_ = other.base_revision_;
+  }
+  return *this;
+}
+
+SessionGraph::Transaction::~Transaction() {
+  rollback();
+}
+
+SessionGraphChangeSet SessionGraph::Transaction::commit() {
+  if (graph_ == nullptr || !graph_->transaction_active_) {
+    throw std::logic_error("Session transaction is not active");
+  }
+
+  SessionGraphChangeSet result{base_revision_, base_revision_, graph_->pending_changes_};
+  if (!result.empty()) {
+    result.revision = ++graph_->revision_;
+    graph_->last_change_ = result;
+  }
+  graph_->pending_changes_ = SessionChangeFlags::None;
+  graph_->transaction_active_ = false;
+  graph_ = nullptr;
+  return result;
+}
+
+void SessionGraph::Transaction::rollback() noexcept {
+  if (graph_ == nullptr) {
+    return;
+  }
+  if (graph_->transaction_active_) {
+    graph_->restore_unchecked(before_);
+    graph_->revision_ = base_revision_;
+    graph_->last_change_ = before_change_;
+    graph_->pending_changes_ = SessionChangeFlags::None;
+    graph_->transaction_active_ = false;
+  }
+  graph_ = nullptr;
+}
+
+SessionGraph::Transaction SessionGraph::begin_transaction() {
+  if (transaction_active_) {
+    throw std::logic_error("Nested session transactions are not supported");
+  }
+  auto before = snapshot();
+  transaction_active_ = true;
+  pending_changes_ = SessionChangeFlags::None;
+  return Transaction(*this, std::move(before));
+}
+
+void SessionGraph::record_change(SessionChangeFlags changes) {
+  if (changes == SessionChangeFlags::None) {
+    return;
+  }
+  if (transaction_active_) {
+    pending_changes_ |= changes;
+    return;
+  }
+  const std::uint64_t base = revision_;
+  last_change_ = SessionGraphChangeSet{base, ++revision_, changes};
+}
+
+SessionGraphSnapshot SessionGraph::snapshot() const {
+  SessionGraphSnapshot result;
+  result.session_id = session_id_;
+  result.revision = revision_;
+  result.name = name_;
+  result.tempo_bpm = tempo_bpm_;
+  result.render_sample_rate_hz = render_sample_rate_hz_;
+  result.render_bit_depth_bits = render_bit_depth_bits_;
+  result.render_dither_enabled = render_dither_enabled_;
+  result.session_range =
+      RangeFromBeats(session_start_beats_, session_end_beats_ - session_start_beats_, tempo_bpm_,
+                     render_sample_rate_hz_);
+
+  result.tracks.reserve(tracks_.size());
+  for (const auto& track : tracks_) {
+    SessionTrackSnapshot track_snapshot;
+    track_snapshot.id = track->id();
+    track_snapshot.name = track->name();
+    track_snapshot.clips.reserve(track->clips().size());
+    for (const auto& clip : track->clips()) {
+      track_snapshot.clips.push_back(SessionClipSnapshot{
+          clip->id(), track->id(), clip->name(),
+          RangeFromBeats(clip->start(), clip->length(), tempo_bpm_, render_sample_rate_hz_),
+          clip->scene_index()});
+    }
+    result.tracks.push_back(std::move(track_snapshot));
+  }
+
+  result.clip_assignments = clip_assignment_ids();
+  return result;
+}
+
+void SessionGraph::restore_unchecked(const SessionGraphSnapshot& state) {
+  if (state.schema_version != SessionGraphSnapshot::kSchemaVersion) {
+    throw std::invalid_argument("Unsupported session graph snapshot schema");
+  }
+  if (!state.session_id.isValid() || state.session_id != session_id_) {
+    throw std::invalid_argument("Session graph snapshot belongs to a different session");
+  }
+  if (!(state.tempo_bpm > 0.0) || !std::isfinite(state.tempo_bpm)) {
+    throw std::invalid_argument("Snapshot tempo must be finite and positive");
+  }
+  if (state.render_sample_rate_hz == 0u) {
+    throw std::invalid_argument("Snapshot sample rate must be non-zero");
+  }
+  if (state.render_bit_depth_bits != 16u && state.render_bit_depth_bits != 24u &&
+      state.render_bit_depth_bits != 32u) {
+    throw std::invalid_argument("Snapshot bit depth is unsupported");
+  }
+
+  std::vector<std::unique_ptr<Track>> rebuilt_tracks;
+  rebuilt_tracks.reserve(state.tracks.size());
+  IdAllocator<TrackId> rebuilt_track_ids;
+  IdAllocator<ClipId> rebuilt_clip_ids;
+  std::unordered_set<std::uint64_t> seen_track_ids;
+  std::unordered_set<std::uint64_t> seen_clip_ids;
+
+  for (const auto& track_state : state.tracks) {
+    if (!track_state.id.isValid() || !seen_track_ids.insert(track_state.id.raw()).second) {
+      throw std::invalid_argument("Snapshot contains an invalid or duplicate track ID");
+    }
+    auto track = std::unique_ptr<Track>(new Track(track_state.id, track_state.name));
+    rebuilt_track_ids.reserveThrough(track_state.id);
+    for (const auto& clip_state : track_state.clips) {
+      if (!clip_state.id.isValid() || clip_state.track_id != track_state.id ||
+          !seen_clip_ids.insert(clip_state.id.raw()).second || clip_state.range.empty()) {
+        throw std::invalid_argument("Snapshot contains an invalid clip");
+      }
+      const double start_beats =
+          BeatsFromTime(clip_state.range.start(), state.tempo_bpm, state.render_sample_rate_hz);
+      const double end_beats =
+          BeatsFromTime(clip_state.range.end(), state.tempo_bpm, state.render_sample_rate_hz);
+      static_cast<void>(track->add_clip(clip_state.id, clip_state.name, start_beats,
+                                        end_beats - start_beats, clip_state.scene_index));
+      rebuilt_clip_ids.reserveThrough(clip_state.id);
+    }
+    rebuilt_tracks.push_back(std::move(track));
+  }
+
+  std::vector<std::uint64_t> rebuilt_assignments;
+  rebuilt_assignments.reserve(state.clip_assignments.size());
+  for (const ClipId assignment : state.clip_assignments) {
+    if (!assignment.isValid()) {
+      throw std::invalid_argument("Snapshot contains an invalid clip assignment");
+    }
+    rebuilt_assignments.push_back(assignment.raw());
+  }
+
+  const double session_start =
+      BeatsFromTime(state.session_range.start(), state.tempo_bpm, state.render_sample_rate_hz);
+  const double session_end =
+      BeatsFromTime(state.session_range.end(), state.tempo_bpm, state.render_sample_rate_hz);
+
+  track_ids_ = rebuilt_track_ids;
+  clip_ids_ = rebuilt_clip_ids;
+  name_ = state.name;
+  tempo_bpm_ = state.tempo_bpm;
+  render_sample_rate_hz_ = state.render_sample_rate_hz;
+  render_bit_depth_bits_ = state.render_bit_depth_bits;
+  render_dither_enabled_ = state.render_dither_enabled;
+  session_start_beats_ = session_start;
+  session_end_beats_ = session_end;
+  tracks_ = std::move(rebuilt_tracks);
+  clip_assignments_ = std::move(rebuilt_assignments);
+  clip_grid_dirty_ = false;
+  scene_timeline_.clear();
+  active_scenes_.clear();
+  committed_clips_.clear();
+}
+
+void SessionGraph::restore(const SessionGraphSnapshot& state) {
+  restore_unchecked(state);
+  record_change(SessionChangeFlags::Metadata | SessionChangeFlags::Structure |
+                SessionChangeFlags::Timing | SessionChangeFlags::ClipAssignments |
+                SessionChangeFlags::RenderSettings);
+}
+
+TrackId SessionGraph::create_track(std::string name) {
+  return add_track(std::move(name))->id();
+}
+
+bool SessionGraph::remove_track(TrackId track_id) {
+  Track* track = find_track(track_id);
+  return track != nullptr && remove_track(track);
+}
+
+ClipId SessionGraph::create_clip(TrackId track_id, std::string name, TimeRange range,
+                                 std::uint32_t scene_index) {
+  if (range.empty()) {
+    throw std::invalid_argument("Clip range must not be empty");
+  }
+  Track* track = find_track(track_id);
+  if (track == nullptr) {
+    throw std::invalid_argument("Track ID does not belong to session");
+  }
+  const double start_beats = BeatsFromTime(range.start(), tempo_bpm_, render_sample_rate_hz_);
+  const double end_beats = BeatsFromTime(range.end(), tempo_bpm_, render_sample_rate_hz_);
+  return add_clip(*track, std::move(name), start_beats, end_beats - start_beats, scene_index)->id();
+}
+
+bool SessionGraph::remove_clip(ClipId clip_id) {
+  Clip* clip = find_clip(clip_id);
+  return clip != nullptr && remove_clip(clip);
+}
+
+void SessionGraph::set_clip_range(ClipId clip_id, TimeRange range) {
+  if (range.empty()) {
+    throw std::invalid_argument("Clip range must not be empty");
+  }
+  Clip* target = find_clip(clip_id);
+  Track* owner = find_clip_track(target);
+  if (target == nullptr || owner == nullptr) {
+    throw std::invalid_argument("Clip ID does not belong to session");
+  }
+  const double previous_start = target->start();
+  const double previous_length = target->length();
+  const double start_beats = BeatsFromTime(range.start(), tempo_bpm_, render_sample_rate_hz_);
+  const double end_beats = BeatsFromTime(range.end(), tempo_bpm_, render_sample_rate_hz_);
+  target->set_start(start_beats);
+  target->set_length(end_beats - start_beats);
+  owner->sort_clips();
+  try {
+    owner->validate_clip_layout();
+  } catch (...) {
+    target->set_start(previous_start);
+    target->set_length(previous_length);
+    owner->sort_clips();
+    throw;
+  }
+  mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Timing);
+}
+
+void SessionGraph::set_clip_scene(ClipId clip_id, std::uint32_t scene_index) {
+  Clip* clip = find_clip(clip_id);
+  if (clip == nullptr) {
+    throw std::invalid_argument("Clip ID does not belong to session");
+  }
+  set_clip_scene(*clip, scene_index);
+}
+
 void SessionGraph::set_name(std::string name) {
   name_ = std::move(name);
+  record_change(SessionChangeFlags::Metadata);
 }
 
 void SessionGraph::set_clip_assignments(std::vector<std::uint64_t> assignments) {
   clip_assignments_ = std::move(assignments);
+  record_change(SessionChangeFlags::ClipAssignments);
+}
+
+std::vector<ClipId> SessionGraph::clip_assignment_ids() const {
+  std::vector<ClipId> result;
+  result.reserve(clip_assignments_.size());
+  for (const std::uint64_t raw : clip_assignments_) {
+    result.push_back(ClipId::fromRaw(raw));
+  }
+  return result;
+}
+
+void SessionGraph::set_clip_assignment_ids(std::vector<ClipId> assignments) {
+  std::vector<std::uint64_t> raw;
+  raw.reserve(assignments.size());
+  for (const ClipId assignment : assignments) {
+    if (!assignment.isValid()) {
+      throw std::invalid_argument("Clip assignment ID must be valid");
+    }
+    raw.push_back(assignment.raw());
+  }
+  set_clip_assignments(std::move(raw));
 }
 
 Track* SessionGraph::add_track(std::string name) {
-  auto& slot = tracks_.emplace_back(std::make_unique<Track>(std::move(name)));
+  const TrackId id = track_ids_.allocate();
+  auto& slot = tracks_.emplace_back(std::unique_ptr<Track>(new Track(id, std::move(name))));
   mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Structure);
   return slot.get();
 }
 
@@ -170,6 +471,7 @@ bool SessionGraph::remove_track(const Track* track) {
   }
   tracks_.erase(it);
   mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Structure);
   return true;
 }
 
@@ -185,10 +487,11 @@ PlaylistLane* SessionGraph::add_playlist_lane(std::string name, bool is_active) 
 }
 
 void SessionGraph::set_tempo(double bpm) {
-  if (bpm <= 0.0) {
-    throw std::invalid_argument("Tempo must be positive");
+  if (bpm <= 0.0 || !std::isfinite(bpm)) {
+    throw std::invalid_argument("Tempo must be finite and positive");
   }
   tempo_bpm_ = bpm;
+  record_change(SessionChangeFlags::Timing);
 }
 
 void SessionGraph::set_render_sample_rate(std::uint32_t sample_rate_hz) {
@@ -196,6 +499,7 @@ void SessionGraph::set_render_sample_rate(std::uint32_t sample_rate_hz) {
     throw std::invalid_argument("Sample rate must be non-zero");
   }
   render_sample_rate_hz_ = sample_rate_hz;
+  record_change(SessionChangeFlags::RenderSettings);
 }
 
 void SessionGraph::set_render_bit_depth(std::uint16_t bit_depth_bits) {
@@ -204,6 +508,7 @@ void SessionGraph::set_render_bit_depth(std::uint16_t bit_depth_bits) {
   case 24:
   case 32:
     render_bit_depth_bits_ = bit_depth_bits;
+    record_change(SessionChangeFlags::RenderSettings);
     return;
   default:
     throw std::invalid_argument("Unsupported bit depth");
@@ -212,6 +517,7 @@ void SessionGraph::set_render_bit_depth(std::uint16_t bit_depth_bits) {
 
 void SessionGraph::set_render_dither(bool enabled) {
   render_dither_enabled_ = enabled;
+  record_change(SessionChangeFlags::RenderSettings);
 }
 
 TransportState SessionGraph::transport_state() const {
@@ -228,6 +534,7 @@ void SessionGraph::set_session_range(double start_beats, double end_beats) {
   }
   session_start_beats_ = start_beats;
   session_end_beats_ = end_beats;
+  record_change(SessionChangeFlags::Timing);
 }
 
 Clip* SessionGraph::add_clip(Track& track, std::string name, double start_beats,
@@ -236,14 +543,18 @@ Clip* SessionGraph::add_clip(Track& track, std::string name, double start_beats,
   if (target == nullptr) {
     throw std::invalid_argument("Track does not belong to session");
   }
+  Clip* clip = target->add_clip(clip_ids_.allocate(), std::move(name), start_beats, length_beats,
+                                scene_index);
   mark_clip_grid_dirty();
-  return target->add_clip(std::move(name), start_beats, length_beats, scene_index);
+  record_change(SessionChangeFlags::Structure);
+  return clip;
 }
 
 bool SessionGraph::remove_clip(const Clip* clip) {
   for (const auto& track : tracks_) {
     if (track->remove_clip(clip)) {
       mark_clip_grid_dirty();
+      record_change(SessionChangeFlags::Structure);
       return true;
     }
   }
@@ -267,6 +578,7 @@ void SessionGraph::set_clip_start(Clip& clip, double start_beats) {
     throw;
   }
   mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Timing);
 }
 
 void SessionGraph::set_clip_length(Clip& clip, double length_beats) {
@@ -284,6 +596,7 @@ void SessionGraph::set_clip_length(Clip& clip, double length_beats) {
     throw;
   }
   mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Timing);
 }
 
 void SessionGraph::set_clip_scene(Clip& clip, std::uint32_t scene_index) {
@@ -293,6 +606,7 @@ void SessionGraph::set_clip_scene(Clip& clip, std::uint32_t scene_index) {
   }
   target->set_scene_index(scene_index);
   mark_clip_grid_dirty();
+  record_change(SessionChangeFlags::Metadata);
 }
 
 void SessionGraph::commit_clip_grid() {
@@ -462,6 +776,14 @@ Track* SessionGraph::find_track(const Track* track) {
   return it->get();
 }
 
+Track* SessionGraph::find_track(TrackId track_id) {
+  const auto it =
+      std::find_if(tracks_.begin(), tracks_.end(), [&](const std::unique_ptr<Track>& candidate) {
+        return candidate->id() == track_id;
+      });
+  return it == tracks_.end() ? nullptr : it->get();
+}
+
 Track* SessionGraph::find_clip_track(const Clip* clip) {
   for (const auto& track : tracks_) {
     if (track->find_clip(clip) != nullptr) {
@@ -477,6 +799,18 @@ Clip* SessionGraph::find_clip(const Clip* clip) {
     return nullptr;
   }
   return owner->find_clip(clip);
+}
+
+Clip* SessionGraph::find_clip(ClipId clip_id) {
+  for (const auto& track : tracks_) {
+    const auto it = std::find_if(
+        track->clips().begin(), track->clips().end(),
+        [&](const std::unique_ptr<Clip>& candidate) { return candidate->id() == clip_id; });
+    if (it != track->clips().end()) {
+      return it->get();
+    }
+  }
+  return nullptr;
 }
 
 } // namespace orpheus::core

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -319,6 +319,9 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
   // Clamp frames to max buffer size
   numFrames = std::min(numFrames, MAX_BUFFER_FRAMES);
 
+  const bool publishTelemetry =
+      m_realtimeTelemetry.beginRealtimeBlock(static_cast<uint32_t>(numFrames), m_sampleRate);
+
   // ORP121 A-01: Clear all clip channel buffers (stereo - 2 per clip)
   static constexpr size_t MAX_ROUTING_CHANNELS = MAX_ACTIVE_CLIPS * 2;
   for (size_t i = 0; i < MAX_ROUTING_CHANNELS; ++i) {
@@ -453,6 +456,7 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
       event.voiceId = clip.voiceId;
       event.position = getCurrentPosition();
       postTransportEvent(event);
+      m_realtimeTelemetry.reportUnderrunFromRealtime();
 
       clip.source->setDemand(clip.currentSample);
       clip.currentSample += static_cast<int64_t>(framesToRead);
@@ -686,6 +690,22 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
 
   // ORP127 G1: Publish the post-render voice state for lock-free UI queries.
   publishVoiceSnapshot();
+
+  if (publishTelemetry) {
+    RealtimeTelemetrySnapshot snapshot;
+    snapshot.position = TimePoint::fromSamples(newSample);
+    snapshot.active_voice_count = static_cast<uint32_t>(m_activeClipCount);
+
+    const RoutingConfig routingConfig = m_routingMatrix->getConfig();
+    snapshot.group_count = static_cast<uint8_t>(
+        std::min<size_t>(routingConfig.num_groups, kRealtimeTelemetryMaxGroups));
+    for (uint8_t group = 0; group < snapshot.group_count; ++group) {
+      snapshot.group_meters[group] = m_routingMatrix->getGroupMeter(group);
+    }
+    snapshot.master_meter = m_routingMatrix->getMasterMeter();
+
+    (void)m_realtimeTelemetry.publishFromRealtime(snapshot);
+  }
 }
 
 void TransportController::processCommands() {

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -2,11 +2,11 @@
 #include "transport_controller.h"
 
 #include "audio_io/resampling_audio_file_reader.h" // ORP127 G6: SRC decorator
-#include "session/session_graph.h"                 // For SessionGraph
 #include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <orpheus/session_graph.h> // For SessionGraph
 
 // MSVC and some platforms don't define M_PI_2 by default
 #ifndef M_PI_2

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -312,6 +312,10 @@ public:
     return m_routingMatrix.get();
   }
 
+  RealtimeTelemetry* getRealtimeTelemetry() noexcept override {
+    return &m_realtimeTelemetry;
+  }
+
   /// ORP134 G1 test hook: clips whose engine-rate length exceeds this many
   /// frames stream from a page ring instead of being fully decoded to memory.
   /// Control thread only; affects sources prepared after the call.
@@ -509,6 +513,9 @@ private:
 
   // Routing matrix for final mix (audio thread processes, UI thread configures)
   std::unique_ptr<IRoutingMatrix> m_routingMatrix;
+
+  // Fixed-capacity audio-thread → message-thread telemetry bridge.
+  RealtimeTelemetry m_realtimeTelemetry{};
 
   // ORP134 G1: streaming-source machinery. The worker thread is created
   // lazily when the first streaming source is prepared (short-clip-only hosts

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 # Build options
 option(ORPHEUS_ENABLE_COREAUDIO "Build CoreAudio driver (macOS)" ${APPLE})
-option(ORPHEUS_ENABLE_WASAPI "Build WASAPI driver (Windows)" OFF)  # Not yet implemented
+option(ORPHEUS_ENABLE_WASAPI "Build WASAPI driver (Windows)" ${WIN32})
 option(ORPHEUS_ENABLE_ASIO "Build ASIO driver (Windows, requires ASIO SDK)" OFF)
 
 # Note: Dummy driver is built in core/audio_io alongside audio file reader
@@ -131,6 +131,8 @@ if(ORPHEUS_ENABLE_WASAPI)
     orpheus_enable_sanitizers(orpheus_audio_driver_wasapi)
 
     message(STATUS "Orpheus: WASAPI driver enabled")
+    target_link_libraries(orpheus_audio_driver_manager
+        PUBLIC orpheus_audio_driver_wasapi)
 endif()
 
 # ASIO driver (Windows, optional)

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -3,12 +3,25 @@
 #include <orpheus/audio_driver_manager.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <cwchar>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 #ifdef __APPLE__
 #include <CoreAudio/CoreAudio.h>
+#endif
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <audioclient.h>
+#include <functiondiscoverykeys_devpkey.h>
+#include <mmdeviceapi.h>
+#include <windows.h>
 #endif
 
 namespace orpheus {
@@ -24,6 +37,37 @@ bool isSampleRateSupported(const std::vector<uint32_t>& supported, uint32_t rate
 bool isBufferSizeSupported(const std::vector<uint32_t>& supported, uint32_t size) {
   return std::find(supported.begin(), supported.end(), size) != supported.end();
 }
+
+#ifdef _WIN32
+std::string wideToUtf8(const wchar_t* value) {
+  if (value == nullptr || *value == L'\0') {
+    return {};
+  }
+  const int size =
+      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, value, -1, nullptr, 0, nullptr, nullptr);
+  if (size <= 1) {
+    return {};
+  }
+  std::string result(static_cast<size_t>(size), '\0');
+  WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, value, -1, result.data(), size, nullptr,
+                      nullptr);
+  result.pop_back();
+  return result;
+}
+
+template <typename T> void releaseCom(T*& object) {
+  if (object != nullptr) {
+    object->Release();
+    object = nullptr;
+  }
+}
+
+void appendUnique(std::vector<uint32_t>& values, uint32_t value) {
+  if (value > 0 && std::find(values.begin(), values.end(), value) == values.end()) {
+    values.push_back(value);
+  }
+}
+#endif
 
 } // anonymous namespace
 
@@ -182,6 +226,7 @@ SessionGraphError AudioDriverManager::setActiveDevice(const std::string& deviceI
   config.buffer_size = static_cast<uint16_t>(bufferSize);
   config.num_inputs = 0;  // Output only for now
   config.num_outputs = 2; // Stereo output
+  config.device_id = (deviceId == "dummy") ? "" : deviceId;
   config.device_name = (deviceId == "dummy") ? "" : deviceInfo->name;
 
   SessionGraphError initResult = newDriver->initialize(config);
@@ -192,8 +237,8 @@ SessionGraphError AudioDriverManager::setActiveDevice(const std::string& deviceI
   // Step 5: Store new driver (audio callback restart happens in RealTimeEngine)
   m_activeDriver = std::move(newDriver);
   m_currentDeviceId = deviceId;
-  m_currentSampleRate = sampleRate;
-  m_currentBufferSize = bufferSize;
+  m_currentSampleRate = m_activeDriver->getConfig().sample_rate;
+  m_currentBufferSize = m_activeDriver->getConfig().buffer_size;
 
   // Step 6: Notify via callback
   if (m_deviceChangeCallback) {
@@ -383,9 +428,133 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateCoreAudioDevices() {
 
 #ifdef _WIN32
 std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
-  // Phase 1: Stub implementation
-  // Phase 2: Implement WASAPI device enumeration using IMMDeviceEnumerator
-  return {};
+  std::vector<AudioDeviceInfo> devices;
+  const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  const bool uninitialize = SUCCEEDED(comResult);
+  if (FAILED(comResult) && comResult != RPC_E_CHANGED_MODE) {
+    return devices;
+  }
+
+  IMMDeviceEnumerator* enumerator = nullptr;
+  IMMDeviceCollection* collection = nullptr;
+  IMMDevice* defaultDevice = nullptr;
+  LPWSTR defaultId = nullptr;
+  if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                              __uuidof(IMMDeviceEnumerator),
+                              reinterpret_cast<void**>(&enumerator))) ||
+      FAILED(enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &collection))) {
+    releaseCom(collection);
+    releaseCom(enumerator);
+    if (uninitialize) {
+      CoUninitialize();
+    }
+    return devices;
+  }
+  if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &defaultDevice))) {
+    defaultDevice->GetId(&defaultId);
+  }
+
+  UINT count = 0;
+  collection->GetCount(&count);
+  for (UINT index = 0; index < count; ++index) {
+    IMMDevice* device = nullptr;
+    IPropertyStore* properties = nullptr;
+    IAudioClient* client = nullptr;
+    LPWSTR id = nullptr;
+    WAVEFORMATEX* mixFormat = nullptr;
+    PROPVARIANT name;
+    PropVariantInit(&name);
+
+    if (FAILED(collection->Item(index, &device)) || FAILED(device->GetId(&id)) ||
+        FAILED(device->OpenPropertyStore(STGM_READ, &properties)) ||
+        FAILED(properties->GetValue(PKEY_Device_FriendlyName, &name)) ||
+        FAILED(device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                reinterpret_cast<void**>(&client))) ||
+        FAILED(client->GetMixFormat(&mixFormat)) || mixFormat == nullptr) {
+      PropVariantClear(&name);
+      CoTaskMemFree(id);
+      CoTaskMemFree(mixFormat);
+      releaseCom(client);
+      releaseCom(properties);
+      releaseCom(device);
+      continue;
+    }
+
+    AudioDeviceInfo info{};
+    const std::string rawId = wideToUtf8(id);
+    info.deviceId = "wasapi:" + rawId;
+    info.name = name.vt == VT_LPWSTR ? wideToUtf8(name.pwszVal) : rawId;
+    info.driverType = "WASAPI";
+    info.minChannels = mixFormat->nChannels;
+    info.maxChannels = mixFormat->nChannels;
+    info.isDefaultDevice = defaultId != nullptr && std::wcscmp(id, defaultId) == 0;
+
+    constexpr std::array<uint32_t, 6> sampleRates = {44100, 48000, 88200, 96000, 176400, 192000};
+    const size_t formatBytes = sizeof(WAVEFORMATEX) + mixFormat->cbSize;
+    for (const uint32_t sampleRate : sampleRates) {
+      std::vector<unsigned char> candidateBytes(reinterpret_cast<const unsigned char*>(mixFormat),
+                                                reinterpret_cast<const unsigned char*>(mixFormat) +
+                                                    formatBytes);
+      auto* candidate = reinterpret_cast<WAVEFORMATEX*>(candidateBytes.data());
+      candidate->nSamplesPerSec = sampleRate;
+      candidate->nAvgBytesPerSec = sampleRate * candidate->nBlockAlign;
+      WAVEFORMATEX* closest = nullptr;
+      if (client->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, candidate, &closest) == S_OK) {
+        appendUnique(info.supportedSampleRates, sampleRate);
+      }
+      CoTaskMemFree(closest);
+    }
+    appendUnique(info.supportedSampleRates, mixFormat->nSamplesPerSec);
+    std::sort(info.supportedSampleRates.begin(), info.supportedSampleRates.end());
+
+    IAudioClient3* client3 = nullptr;
+    if (SUCCEEDED(
+            client->QueryInterface(__uuidof(IAudioClient3), reinterpret_cast<void**>(&client3)))) {
+      UINT32 defaultFrames = 0;
+      UINT32 fundamentalFrames = 0;
+      UINT32 minimumFrames = 0;
+      UINT32 maximumFrames = 0;
+      if (SUCCEEDED(client3->GetSharedModeEnginePeriod(
+              mixFormat, &defaultFrames, &fundamentalFrames, &minimumFrames, &maximumFrames))) {
+        appendUnique(info.supportedBufferSizes, minimumFrames);
+        appendUnique(info.supportedBufferSizes, defaultFrames);
+        appendUnique(info.supportedBufferSizes, maximumFrames);
+      }
+      releaseCom(client3);
+    }
+    if (info.supportedBufferSizes.empty()) {
+      REFERENCE_TIME defaultPeriod = 0;
+      REFERENCE_TIME minimumPeriod = 0;
+      if (SUCCEEDED(client->GetDevicePeriod(&defaultPeriod, &minimumPeriod))) {
+        appendUnique(info.supportedBufferSizes,
+                     static_cast<uint32_t>(
+                         (static_cast<uint64_t>(minimumPeriod) * mixFormat->nSamplesPerSec) /
+                         10'000'000ULL));
+        appendUnique(info.supportedBufferSizes,
+                     static_cast<uint32_t>(
+                         (static_cast<uint64_t>(defaultPeriod) * mixFormat->nSamplesPerSec) /
+                         10'000'000ULL));
+      }
+    }
+    std::sort(info.supportedBufferSizes.begin(), info.supportedBufferSizes.end());
+    devices.push_back(std::move(info));
+
+    PropVariantClear(&name);
+    CoTaskMemFree(id);
+    CoTaskMemFree(mixFormat);
+    releaseCom(client);
+    releaseCom(properties);
+    releaseCom(device);
+  }
+
+  CoTaskMemFree(defaultId);
+  releaseCom(defaultDevice);
+  releaseCom(collection);
+  releaseCom(enumerator);
+  if (uninitialize) {
+    CoUninitialize();
+  }
+  return devices;
 }
 #endif
 
@@ -408,6 +577,12 @@ AudioDriverManager::createDriverForDevice(const std::string& deviceId) {
     // Extract device ID from string (e.g., "coreaudio:123" -> 123)
     // For now, use the default CoreAudio driver with device_name set
     return createCoreAudioDriver();
+  }
+#endif
+
+#if defined(_WIN32) && defined(ORPHEUS_ENABLE_WASAPI)
+  if (deviceId.rfind("wasapi:", 0) == 0) {
+    return createWASAPIAudioDriver();
   }
 #endif
 

--- a/src/platform/audio_drivers/wasapi/wasapi_driver.cpp
+++ b/src/platform/audio_drivers/wasapi/wasapi_driver.cpp
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+#ifdef _WIN32
+
+#include <orpheus/audio_driver.h>
+#include <orpheus/performance_monitor.h>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <audioclient.h>
+#include <avrt.h>
+#include <ksmedia.h>
+#include <mmdeviceapi.h>
+#include <windows.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+std::wstring utf8ToWide(const std::string& value) {
+  if (value.empty()) {
+    return {};
+  }
+  const int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                                       static_cast<int>(value.size()), nullptr, 0);
+  if (size <= 0) {
+    return {};
+  }
+  std::wstring result(static_cast<size_t>(size), L'\0');
+  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(), static_cast<int>(value.size()),
+                      result.data(), size);
+  return result;
+}
+
+bool isFloatFormat(const WAVEFORMATEX* format) {
+  if (format->wFormatTag == WAVE_FORMAT_IEEE_FLOAT) {
+    return format->wBitsPerSample == 32;
+  }
+  if (format->wFormatTag != WAVE_FORMAT_EXTENSIBLE ||
+      format->cbSize < sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)) {
+    return false;
+  }
+  const auto* extensible = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(format);
+  return extensible->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT && format->wBitsPerSample == 32;
+}
+
+bool isPcm16Format(const WAVEFORMATEX* format) {
+  if (format->wFormatTag == WAVE_FORMAT_PCM) {
+    return format->wBitsPerSample == 16;
+  }
+  if (format->wFormatTag != WAVE_FORMAT_EXTENSIBLE ||
+      format->cbSize < sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)) {
+    return false;
+  }
+  const auto* extensible = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(format);
+  return extensible->SubFormat == KSDATAFORMAT_SUBTYPE_PCM && format->wBitsPerSample == 16;
+}
+
+class WASAPIAudioDriver final : public IAudioDriver {
+public:
+  ~WASAPIAudioDriver() override {
+    stop();
+    cleanup();
+  }
+
+  SessionGraphError initialize(const AudioDriverConfig& requested) override {
+    if (running_.load(std::memory_order_acquire) || requested.sample_rate == 0 ||
+        requested.buffer_size == 0 || requested.num_outputs == 0) {
+      return SessionGraphError::InvalidParameter;
+    }
+    cleanup();
+
+    const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (SUCCEEDED(comResult)) {
+      comInitialized_ = true;
+    } else if (comResult != RPC_E_CHANGED_MODE) {
+      return SessionGraphError::InternalError;
+    }
+
+    if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                __uuidof(IMMDeviceEnumerator),
+                                reinterpret_cast<void**>(&enumerator_)))) {
+      cleanup();
+      return SessionGraphError::InternalError;
+    }
+
+    HRESULT result = E_FAIL;
+    if (requested.device_id.rfind("wasapi:", 0) == 0) {
+      const std::wstring id = utf8ToWide(requested.device_id.substr(7));
+      result = id.empty() ? E_INVALIDARG : enumerator_->GetDevice(id.c_str(), &device_);
+    } else {
+      result = enumerator_->GetDefaultAudioEndpoint(eRender, eConsole, &device_);
+    }
+    if (FAILED(result) || device_ == nullptr ||
+        FAILED(device_->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                 reinterpret_cast<void**>(&client_)))) {
+      cleanup();
+      return SessionGraphError::NotReady;
+    }
+
+    WAVEFORMATEX* mixFormat = nullptr;
+    if (FAILED(client_->GetMixFormat(&mixFormat)) || mixFormat == nullptr) {
+      cleanup();
+      return SessionGraphError::InternalError;
+    }
+
+    const size_t mixFormatBytes = sizeof(WAVEFORMATEX) + mixFormat->cbSize;
+    std::vector<std::byte> requestedBytes(reinterpret_cast<const std::byte*>(mixFormat),
+                                          reinterpret_cast<const std::byte*>(mixFormat) +
+                                              mixFormatBytes);
+    auto* requestedFormat = reinterpret_cast<WAVEFORMATEX*>(requestedBytes.data());
+    requestedFormat->nSamplesPerSec = requested.sample_rate;
+    requestedFormat->nAvgBytesPerSec =
+        requestedFormat->nSamplesPerSec * requestedFormat->nBlockAlign;
+    WAVEFORMATEX* closest = nullptr;
+    const HRESULT support =
+        client_->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, requestedFormat, &closest);
+    if (support == S_OK) {
+      formatBytes_ = std::move(requestedBytes);
+    } else if (closest != nullptr) {
+      const size_t bytes = sizeof(WAVEFORMATEX) + closest->cbSize;
+      formatBytes_.assign(reinterpret_cast<const std::byte*>(closest),
+                          reinterpret_cast<const std::byte*>(closest) + bytes);
+    } else {
+      const size_t bytes = sizeof(WAVEFORMATEX) + mixFormat->cbSize;
+      formatBytes_.assign(reinterpret_cast<const std::byte*>(mixFormat),
+                          reinterpret_cast<const std::byte*>(mixFormat) + bytes);
+    }
+    CoTaskMemFree(closest);
+    CoTaskMemFree(mixFormat);
+    format_ = reinterpret_cast<WAVEFORMATEX*>(formatBytes_.data());
+
+    if (!isFloatFormat(format_) && !isPcm16Format(format_)) {
+      cleanup();
+      return SessionGraphError::InvalidParameter;
+    }
+
+    const REFERENCE_TIME requestedDuration = static_cast<REFERENCE_TIME>(
+        (10'000'000ULL * requested.buffer_size) / format_->nSamplesPerSec);
+    if (FAILED(
+            client_->Initialize(AUDCLNT_SHAREMODE_SHARED,
+                                AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
+                                requestedDuration, 0, format_, nullptr)) ||
+        FAILED(client_->GetBufferSize(&bufferFrames_)) || bufferFrames_ == 0 ||
+        FAILED(client_->GetService(__uuidof(IAudioRenderClient),
+                                   reinterpret_cast<void**>(&renderClient_)))) {
+      cleanup();
+      return SessionGraphError::NotReady;
+    }
+
+    event_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (event_ == nullptr || FAILED(client_->SetEventHandle(event_))) {
+      cleanup();
+      return SessionGraphError::InternalError;
+    }
+
+    config_ = requested;
+    config_.sample_rate = format_->nSamplesPerSec;
+    config_.buffer_size = static_cast<uint16_t>(
+        std::min<UINT32>(bufferFrames_, std::numeric_limits<uint16_t>::max()));
+    config_.num_inputs = 0;
+    config_.num_outputs = format_->nChannels;
+    planarStorage_.assign(static_cast<size_t>(format_->nChannels) * bufferFrames_, 0.0f);
+    planarPointers_.resize(format_->nChannels);
+    for (size_t channel = 0; channel < planarPointers_.size(); ++channel) {
+      planarPointers_[channel] = planarStorage_.data() + channel * bufferFrames_;
+    }
+    initialized_ = true;
+    return SessionGraphError::OK;
+  }
+
+  SessionGraphError start(IAudioCallback* callback) override {
+    if (!initialized_ || callback == nullptr || running_.exchange(true)) {
+      return SessionGraphError::NotReady;
+    }
+    callback_.store(callback, std::memory_order_release);
+    if (FAILED(client_->Start())) {
+      callback_.store(nullptr, std::memory_order_release);
+      running_.store(false, std::memory_order_release);
+      return SessionGraphError::InternalError;
+    }
+    thread_ = std::thread([this] { audioLoop(); });
+    return SessionGraphError::OK;
+  }
+
+  SessionGraphError stop() override {
+    if (!running_.exchange(false, std::memory_order_acq_rel)) {
+      return SessionGraphError::OK;
+    }
+    if (event_ != nullptr) {
+      SetEvent(event_);
+    }
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+    callback_.store(nullptr, std::memory_order_release);
+    return client_ != nullptr && FAILED(client_->Stop()) ? SessionGraphError::InternalError
+                                                         : SessionGraphError::OK;
+  }
+
+  bool isRunning() const override {
+    return running_.load(std::memory_order_acquire);
+  }
+  const AudioDriverConfig& getConfig() const override {
+    return config_;
+  }
+  std::string getDriverName() const override {
+    return "WASAPI";
+  }
+
+  uint32_t getLatencySamples() const override {
+    if (client_ == nullptr || config_.sample_rate == 0) {
+      return 0;
+    }
+    REFERENCE_TIME latency = 0;
+    if (FAILED(client_->GetStreamLatency(&latency))) {
+      return 0;
+    }
+    return static_cast<uint32_t>((static_cast<uint64_t>(latency) * config_.sample_rate) /
+                                 10'000'000ULL);
+  }
+
+  AudioDriverCapabilities getCapabilities() const override {
+    AudioDriverCapabilities capabilities;
+    capabilities.backend = AudioBackend::WASAPI;
+    capabilities.platform = AudioPlatform::Windows;
+    capabilities.supports_exclusive_mode = false;
+    capabilities.supports_shared_mode = true;
+    capabilities.supports_device_hot_swap = false;
+    capabilities.supports_input = false;
+    capabilities.supports_multichannel_output = config_.num_outputs > 2;
+    capabilities.reports_hardware_latency = getLatencySamples() > 0;
+    capabilities.max_input_channels = 0;
+    capabilities.max_output_channels = config_.num_outputs;
+    if (initialized_) {
+      capabilities.native_sample_rates.push_back(config_.sample_rate);
+      capabilities.native_buffer_sizes.push_back(config_.buffer_size);
+    }
+    return capabilities;
+  }
+
+  void setPerformanceMonitor(IPerformanceMonitor* monitor) override {
+    monitor_.store(monitor, std::memory_order_release);
+  }
+
+private:
+  void audioLoop() {
+    const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    const bool uninitialize = SUCCEEDED(comResult);
+    DWORD taskIndex = 0;
+    HANDLE task = AvSetMmThreadCharacteristicsW(L"Pro Audio", &taskIndex);
+
+    while (running_.load(std::memory_order_acquire)) {
+      if (WaitForSingleObject(event_, 2000) != WAIT_OBJECT_0 ||
+          !running_.load(std::memory_order_acquire)) {
+        continue;
+      }
+      UINT32 padding = 0;
+      if (FAILED(client_->GetCurrentPadding(&padding)) || padding >= bufferFrames_) {
+        continue;
+      }
+      const UINT32 frames = bufferFrames_ - padding;
+      BYTE* deviceBuffer = nullptr;
+      if (FAILED(renderClient_->GetBuffer(frames, &deviceBuffer))) {
+        continue;
+      }
+
+      for (float* channel : planarPointers_) {
+        std::fill_n(channel, frames, 0.0f);
+      }
+      IAudioCallback* callback = callback_.load(std::memory_order_acquire);
+      const auto started = std::chrono::steady_clock::now();
+      uint32_t activeClips = 0;
+      if (callback != nullptr) {
+        callback->processAudio(nullptr, planarPointers_.data(), planarPointers_.size(), frames);
+        activeClips = callback->activeClipCount();
+      }
+
+      if (isFloatFormat(format_)) {
+        auto* output = reinterpret_cast<float*>(deviceBuffer);
+        for (UINT32 frame = 0; frame < frames; ++frame) {
+          for (size_t channel = 0; channel < planarPointers_.size(); ++channel) {
+            output[static_cast<size_t>(frame) * planarPointers_.size() + channel] =
+                planarPointers_[channel][frame];
+          }
+        }
+      } else {
+        auto* output = reinterpret_cast<int16_t*>(deviceBuffer);
+        for (UINT32 frame = 0; frame < frames; ++frame) {
+          for (size_t channel = 0; channel < planarPointers_.size(); ++channel) {
+            const float sample = std::clamp(planarPointers_[channel][frame], -1.0f, 1.0f);
+            output[static_cast<size_t>(frame) * planarPointers_.size() + channel] =
+                static_cast<int16_t>(std::lrint(sample * 32767.0f));
+          }
+        }
+      }
+      renderClient_->ReleaseBuffer(frames, 0);
+
+      if (IPerformanceMonitor* monitor = monitor_.load(std::memory_order_acquire)) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - started);
+        const uint64_t budget =
+            (static_cast<uint64_t>(frames) * 1'000'000ULL) / config_.sample_rate;
+        monitor->recordAudioCallback(static_cast<uint64_t>(elapsed.count()), budget, activeClips,
+                                     config_.sample_rate, frames);
+      }
+    }
+
+    if (task != nullptr) {
+      AvRevertMmThreadCharacteristics(task);
+    }
+    if (uninitialize) {
+      CoUninitialize();
+    }
+  }
+
+  void cleanup() {
+    initialized_ = false;
+    format_ = nullptr;
+    formatBytes_.clear();
+    planarPointers_.clear();
+    planarStorage_.clear();
+    if (event_ != nullptr) {
+      CloseHandle(event_);
+      event_ = nullptr;
+    }
+    if (renderClient_ != nullptr) {
+      renderClient_->Release();
+      renderClient_ = nullptr;
+    }
+    if (client_ != nullptr) {
+      client_->Release();
+      client_ = nullptr;
+    }
+    if (device_ != nullptr) {
+      device_->Release();
+      device_ = nullptr;
+    }
+    if (enumerator_ != nullptr) {
+      enumerator_->Release();
+      enumerator_ = nullptr;
+    }
+    if (comInitialized_) {
+      CoUninitialize();
+      comInitialized_ = false;
+    }
+  }
+
+  AudioDriverConfig config_{};
+  IMMDeviceEnumerator* enumerator_ = nullptr;
+  IMMDevice* device_ = nullptr;
+  IAudioClient* client_ = nullptr;
+  IAudioRenderClient* renderClient_ = nullptr;
+  HANDLE event_ = nullptr;
+  std::vector<std::byte> formatBytes_;
+  WAVEFORMATEX* format_ = nullptr;
+  UINT32 bufferFrames_ = 0;
+  std::vector<float> planarStorage_;
+  std::vector<float*> planarPointers_;
+  std::thread thread_;
+  std::atomic<IAudioCallback*> callback_{nullptr};
+  std::atomic<IPerformanceMonitor*> monitor_{nullptr};
+  std::atomic<bool> running_{false};
+  bool initialized_ = false;
+  bool comInitialized_ = false;
+};
+
+} // namespace
+
+std::unique_ptr<IAudioDriver> createWASAPIAudioDriver() {
+  return std::make_unique<WASAPIAudioDriver>();
+}
+
+} // namespace orpheus
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,11 @@ if(Python3_Interpreter_FOUND)
     COMMAND ${Python3_EXECUTABLE}
       ${CMAKE_SOURCE_DIR}/tools/version_contract.py
       --check)
+
+  add_test(NAME shmui_juce_manifest
+    COMMAND ${Python3_EXECUTABLE}
+      ${CMAKE_SOURCE_DIR}/tools/shmui_juce_manifest.py
+      --check)
 endif()
 
 # Session tests (including Scene Manager)

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -267,6 +267,15 @@ if(ORPHEUS_ENABLE_COREAUDIO)
     add_test(NAME coreaudio_driver_test COMMAND coreaudio_driver_test)
 endif()
 
+if(WIN32 AND ORPHEUS_ENABLE_WASAPI)
+    add_executable(wasapi_driver_test wasapi_driver_test.cpp)
+    target_link_libraries(wasapi_driver_test
+        PRIVATE orpheus_audio_driver_wasapi orpheus_audio_driver_manager
+                GTest::gtest GTest::gtest_main)
+    target_include_directories(wasapi_driver_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+    add_test(NAME wasapi_driver_test COMMAND wasapi_driver_test)
+endif()
+
 # Audio Driver Manager tests
 add_executable(driver_manager_test
     driver_manager_test.cpp

--- a/tests/audio_io/wasapi_driver_test.cpp
+++ b/tests/audio_io/wasapi_driver_test.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+#ifdef _WIN32
+
+#include <orpheus/audio_driver.h>
+#include <orpheus/audio_driver_manager.h>
+
+#include <gtest/gtest.h>
+
+namespace orpheus {
+namespace {
+
+TEST(WASAPIDriverTest, FactoryReportsTruthfulSharedModeCapabilities) {
+  auto driver = createWASAPIAudioDriver();
+  ASSERT_NE(driver, nullptr);
+  EXPECT_EQ(driver->getDriverName(), "WASAPI");
+  const auto capabilities = driver->getCapabilities();
+  EXPECT_EQ(capabilities.backend, AudioBackend::WASAPI);
+  EXPECT_EQ(capabilities.platform, AudioPlatform::Windows);
+  EXPECT_TRUE(capabilities.supports_shared_mode);
+  EXPECT_FALSE(capabilities.supports_exclusive_mode);
+  EXPECT_FALSE(capabilities.supports_input);
+}
+
+TEST(WASAPIDriverTest, ManagerReportsOnlyQueriedEndpointFormats) {
+  auto manager = createAudioDriverManager();
+  ASSERT_NE(manager, nullptr);
+  const auto devices = manager->enumerateDevices();
+  ASSERT_FALSE(devices.empty());
+  EXPECT_EQ(devices.front().deviceId, "dummy");
+  for (const auto& device : devices) {
+    if (device.driverType != "WASAPI") {
+      continue;
+    }
+    EXPECT_EQ(device.deviceId.rfind("wasapi:", 0), 0u);
+    EXPECT_FALSE(device.name.empty());
+    EXPECT_GT(device.maxChannels, 0u);
+    EXPECT_FALSE(device.supportedSampleRates.empty());
+    EXPECT_FALSE(device.supportedBufferSizes.empty());
+  }
+}
+
+} // namespace
+} // namespace orpheus
+
+#endif

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -55,6 +55,10 @@ add_orpheus_fixture(orpheus_find_package_transport_routing transport_routing.cpp
 target_link_libraries(orpheus_find_package_transport_routing
   PRIVATE Orpheus::transport Orpheus::routing Orpheus::audio_driver_manager)
 
+add_orpheus_fixture(orpheus_find_package_workflow_contracts workflow_contracts.cpp)
+target_link_libraries(orpheus_find_package_workflow_contracts
+  PRIVATE Orpheus::transport)
+
 if(APPLE AND NOT TARGET Orpheus::audio_driver_coreaudio)
   message(FATAL_ERROR "macOS package is missing Orpheus::audio_driver_coreaudio")
 endif()

--- a/tests/cmake/find_package/workflow_contracts.cpp
+++ b/tests/cmake/find_package/workflow_contracts.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/realtime_telemetry.h>
+#include <orpheus/session_graph.h>
+#include <orpheus/transport_controller.h>
+
+int main() {
+  orpheus::core::SessionGraph graph;
+  const orpheus::TimeRange clipRange =
+      orpheus::TimeRange::fromStartLength(orpheus::TimePoint::fromSamples(24000), 48000);
+
+  auto transaction = graph.begin_transaction();
+  const orpheus::TrackId trackId = graph.create_track("Installed consumer track");
+  const orpheus::ClipId clipId =
+      graph.create_clip(trackId, "Installed consumer clip", clipRange, 2);
+  const orpheus::core::SessionGraphChangeSet change = transaction.commit();
+  const orpheus::core::SessionGraphSnapshot graphSnapshot = graph.snapshot();
+  if (!trackId.isValid() || !clipId.isValid() || change.revision != 1 ||
+      graphSnapshot.tracks.size() != 1 || graphSnapshot.tracks.front().clips.size() != 1 ||
+      graphSnapshot.tracks.front().clips.front().id != clipId ||
+      graphSnapshot.tracks.front().clips.front().range != clipRange) {
+    return 1;
+  }
+
+  orpheus::RealtimeTelemetry telemetry(2);
+  if (telemetry.beginRealtimeBlock(128, 48000) || !telemetry.beginRealtimeBlock(128, 48000)) {
+    return 2;
+  }
+
+  orpheus::RealtimeTelemetrySnapshot input;
+  input.position = orpheus::TimePoint::fromSamples(256);
+  input.active_voice_count = 3;
+  if (!telemetry.publishFromRealtime(input)) {
+    return 3;
+  }
+
+  orpheus::RealtimeTelemetrySnapshot output;
+  if (!telemetry.tryRead(output) || output.position.samples() != 256 ||
+      output.active_voice_count != 3 || output.diagnostics.callback_count != 2 ||
+      output.diagnostics.samples_processed != 256) {
+    return 4;
+  }
+
+  auto transport = orpheus::createTransportController(&graph, 48000);
+  if (!transport || !transport->getRealtimeTelemetry()) {
+    return 5;
+  }
+  transport->getRealtimeTelemetry()->setDecimationBlocks(4);
+  return transport->getRealtimeTelemetry()->decimationBlocks() == 4 ? 0 : 6;
+}

--- a/tests/cmake/run_shmui_no_opengl.cmake
+++ b/tests/cmake/run_shmui_no_opengl.cmake
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+if(NOT DEFINED source_dir OR NOT DEFINED binary_dir OR NOT DEFINED shmui_source_dir)
+  message(FATAL_ERROR "Missing variables for ShmUI no-OpenGL smoke test")
+endif()
+
+get_filename_component(source_dir "${source_dir}" ABSOLUTE)
+get_filename_component(binary_dir "${binary_dir}" ABSOLUTE)
+get_filename_component(shmui_source_dir "${shmui_source_dir}" ABSOLUTE)
+
+set(configure_args
+  -S "${source_dir}"
+  -B "${binary_dir}"
+  -DSHMUI_JUCE_SOURCE_DIR:PATH=${shmui_source_dir}
+  -DCMAKE_CXX_STANDARD=20)
+
+if(DEFINED build_type AND NOT build_type STREQUAL "")
+  list(APPEND configure_args -DCMAKE_BUILD_TYPE=${build_type})
+endif()
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  list(APPEND configure_args
+    -DCMAKE_OSX_ARCHITECTURES=arm64
+    -DCMAKE_CXX_FLAGS=-stdlib=libc++
+    -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++)
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${configure_args}
+  RESULT_VARIABLE configure_result)
+if(configure_result)
+  message(FATAL_ERROR "ShmUI no-OpenGL configure failed with code ${configure_result}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" --build "${binary_dir}" --config "${build_type}" --parallel
+  RESULT_VARIABLE build_result)
+if(build_result)
+  message(FATAL_ERROR "ShmUI no-OpenGL build failed with code ${build_result}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_CTEST_COMMAND}" --test-dir "${binary_dir}" --output-on-failure
+    --build-config "${build_type}"
+  RESULT_VARIABLE test_result)
+if(test_result)
+  message(FATAL_ERROR "ShmUI no-OpenGL smoke test failed with code ${test_result}")
+endif()

--- a/tests/cmake/shmui_no_opengl/CMakeLists.txt
+++ b/tests/cmake/shmui_no_opengl/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+cmake_minimum_required(VERSION 3.22)
+
+project(orpheus_shmui_no_opengl_smoke LANGUAGES C CXX)
+
+if(NOT DEFINED SHMUI_JUCE_SOURCE_DIR)
+  message(FATAL_ERROR "SHMUI_JUCE_SOURCE_DIR must point at packages/shmui-juce")
+endif()
+
+include(FetchContent)
+set(JUCE_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(JUCE_BUILD_EXTRAS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+  JUCE
+  URL https://github.com/juce-framework/JUCE/archive/refs/tags/8.0.4.tar.gz
+  URL_HASH SHA256=0effe9823a6fd8a4f98e5c08be7d308350e417b2d15dcf34011e778fefbbf005
+  DOWNLOAD_EXTRACT_TIMESTAMP FALSE)
+FetchContent_MakeAvailable(JUCE)
+
+set(SHMUI_JUCE_ENABLE_OPENGL OFF CACHE BOOL "" FORCE)
+add_subdirectory(${SHMUI_JUCE_SOURCE_DIR} ${CMAKE_BINARY_DIR}/shmui-juce)
+
+if(NOT TARGET Orpheus::shmui_juce)
+  message(FATAL_ERROR "Orpheus::shmui_juce target is missing")
+endif()
+if(TARGET Orpheus::shmui_juce_gl)
+  message(FATAL_ERROR "OpenGL target must not exist when SHMUI_JUCE_ENABLE_OPENGL=OFF")
+endif()
+
+get_target_property(_shmui_links orpheus_shmui_juce LINK_LIBRARIES)
+if("juce::juce_opengl" IN_LIST _shmui_links)
+  message(FATAL_ERROR "Core ShmUI target must not link juce_opengl")
+endif()
+
+add_executable(orpheus_shmui_no_opengl_smoke main.cpp)
+target_link_libraries(orpheus_shmui_no_opengl_smoke PRIVATE Orpheus::shmui_juce)
+target_compile_features(orpheus_shmui_no_opengl_smoke PRIVATE cxx_std_20)
+
+enable_testing()
+add_test(NAME shmui_no_opengl_smoke COMMAND orpheus_shmui_no_opengl_smoke)

--- a/tests/cmake/shmui_no_opengl/main.cpp
+++ b/tests/cmake/shmui_no_opengl/main.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+#include <ShmUI.h>
+
+#if defined(SHMUI_JUCE_ENABLE_OPENGL) && SHMUI_JUCE_ENABLE_OPENGL
+#error "The non-OpenGL ShmUI consumer unexpectedly enabled OpenGL"
+#endif
+
+int main() {
+  shmui::LevelMeter meter(2);
+  meter.setLevel(0, 0.25f);
+  meter.setLevel(1, 0.5f);
+  return shmui::Version::major == 2 ? 0 : 1;
+}

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -49,6 +49,7 @@ add_test(
 
 add_executable(realtime_diagnostics_test
     realtime_diagnostics_test.cpp
+    realtime_telemetry_test.cpp
 )
 
 target_link_libraries(realtime_diagnostics_test

--- a/tests/common/performance_integration_test.cpp
+++ b/tests/common/performance_integration_test.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
 #include <gtest/gtest.h>
 #include <orpheus/performance_monitor.h>
+#include <orpheus/session_graph.h>
 #include <orpheus/transport_controller.h>
 
 #include <chrono>

--- a/tests/common/performance_monitor_test.cpp
+++ b/tests/common/performance_monitor_test.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
 #include <gtest/gtest.h>
 #include <orpheus/performance_monitor.h>
+#include <orpheus/session_graph.h>
 
 #include <chrono>
 #include <cmath>

--- a/tests/common/realtime_telemetry_test.cpp
+++ b/tests/common/realtime_telemetry_test.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+#include <gtest/gtest.h>
+#include <orpheus/realtime_telemetry.h>
+
+using namespace orpheus;
+
+TEST(RealtimeTelemetryTest, CapturesAtExactBlockCadence) {
+  RealtimeTelemetry telemetry(3);
+
+  EXPECT_FALSE(telemetry.beginRealtimeBlock(128, 48000));
+  EXPECT_FALSE(telemetry.beginRealtimeBlock(128, 48000));
+  EXPECT_TRUE(telemetry.beginRealtimeBlock(128, 48000));
+
+  RealtimeTelemetrySnapshot input;
+  input.position = TimePoint::fromSamples(384);
+  ASSERT_TRUE(telemetry.publishFromRealtime(input));
+
+  RealtimeTelemetrySnapshot output;
+  ASSERT_TRUE(telemetry.tryRead(output));
+  EXPECT_EQ(output.sequence, 1u);
+  EXPECT_EQ(output.position.samples(), 384);
+  EXPECT_EQ(output.diagnostics.callback_count, 3u);
+  EXPECT_EQ(output.diagnostics.samples_processed, 384u);
+  EXPECT_EQ(output.diagnostics.last_buffer_frames, 128u);
+  EXPECT_EQ(output.diagnostics.last_sample_rate, 48000u);
+  EXPECT_FALSE(telemetry.tryRead(output));
+}
+
+TEST(RealtimeTelemetryTest, RetainsFixedCapacityAndDropsNewestSnapshots) {
+  RealtimeTelemetry telemetry(1);
+
+  for (size_t i = 0; i < kRealtimeTelemetryCapacity; ++i) {
+    ASSERT_TRUE(telemetry.beginRealtimeBlock(64, 48000));
+    RealtimeTelemetrySnapshot snapshot;
+    snapshot.position = TimePoint::fromSamples(static_cast<int64_t>(i * 64));
+    ASSERT_TRUE(telemetry.publishFromRealtime(snapshot));
+  }
+
+  ASSERT_TRUE(telemetry.beginRealtimeBlock(64, 48000));
+  RealtimeTelemetrySnapshot dropped;
+  dropped.position = TimePoint::fromSamples(9999);
+  EXPECT_FALSE(telemetry.publishFromRealtime(dropped));
+  EXPECT_EQ(telemetry.pendingSnapshotCount(), kRealtimeTelemetryCapacity);
+  EXPECT_EQ(telemetry.droppedSnapshotCount(), 1u);
+
+  for (size_t i = 0; i < kRealtimeTelemetryCapacity; ++i) {
+    RealtimeTelemetrySnapshot output;
+    ASSERT_TRUE(telemetry.tryRead(output));
+    EXPECT_EQ(output.sequence, i + 1);
+    EXPECT_EQ(output.position.samples(), static_cast<int64_t>(i * 64));
+  }
+
+  RealtimeTelemetrySnapshot output;
+  EXPECT_FALSE(telemetry.tryRead(output));
+}
+
+TEST(RealtimeTelemetryTest, ReusesDrainedSlotsWithoutReordering) {
+  RealtimeTelemetry telemetry(1);
+
+  for (size_t cycle = 0; cycle < 3; ++cycle) {
+    for (size_t i = 0; i < kRealtimeTelemetryCapacity; ++i) {
+      ASSERT_TRUE(telemetry.beginRealtimeBlock(32, 44100));
+      RealtimeTelemetrySnapshot input;
+      input.active_voice_count = static_cast<uint32_t>(cycle * kRealtimeTelemetryCapacity + i);
+      ASSERT_TRUE(telemetry.publishFromRealtime(input));
+    }
+
+    for (size_t i = 0; i < kRealtimeTelemetryCapacity; ++i) {
+      RealtimeTelemetrySnapshot output;
+      ASSERT_TRUE(telemetry.tryRead(output));
+      EXPECT_EQ(output.active_voice_count, cycle * kRealtimeTelemetryCapacity + i);
+    }
+  }
+
+  EXPECT_EQ(telemetry.droppedSnapshotCount(), 0u);
+}
+
+TEST(RealtimeTelemetryTest, ClampsDecimationAndPublishesUnderrunDiagnostics) {
+  RealtimeTelemetry telemetry(0);
+  EXPECT_EQ(telemetry.decimationBlocks(), 1u);
+
+  telemetry.reportUnderrunFromRealtime();
+  ASSERT_TRUE(telemetry.beginRealtimeBlock(256, 96000));
+  ASSERT_TRUE(telemetry.publishFromRealtime({}));
+
+  RealtimeTelemetrySnapshot output;
+  ASSERT_TRUE(telemetry.tryRead(output));
+  EXPECT_EQ(output.schema_version, kRealtimeTelemetrySchemaVersion);
+  EXPECT_EQ(output.diagnostics.underrun_count, 1u);
+}

--- a/tests/fixtures/session/loop_grid.json
+++ b/tests/fixtures/session/loop_grid.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Loop Grid",
   "tempo_bpm": 128,
   "start_beats": 0,

--- a/tests/fixtures/session/solo_click.json
+++ b/tests/fixtures/session/solo_click.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Solo Click",
   "tempo_bpm": 120,
   "start_beats": 0,

--- a/tests/fixtures/session/two_tracks.json
+++ b/tests/fixtures/session/two_tracks.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Two Tracks",
   "tempo_bpm": 100,
   "start_beats": 0,

--- a/tests/render_tracks.cpp
+++ b/tests/render_tracks.cpp
@@ -2,7 +2,7 @@
 #include "orpheus/abi.h"
 
 #include "session/json_io.h"
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <algorithm>
 #include <chrono>

--- a/tests/session/scene_manager_test.cpp
+++ b/tests/session/scene_manager_test.cpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <thread>
 
-#include "../../src/core/session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 using namespace orpheus;
 

--- a/tests/session/scene_routing_test.cpp
+++ b/tests/session/scene_routing_test.cpp
@@ -10,7 +10,7 @@
 #include <orpheus/routing_matrix.h>
 #include <orpheus/scene_manager.h>
 
-#include "session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <gtest/gtest.h>
 #include <memory>

--- a/tests/session_graph_invariants.cpp
+++ b/tests/session_graph_invariants.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <gtest/gtest.h>
 
@@ -98,6 +98,93 @@ TEST(SessionGraphInvariants, RejectsOverlappingClips) {
 
   EXPECT_THROW(session.set_clip_length(*second, 10.0), std::invalid_argument);
   EXPECT_DOUBLE_EQ(second->length(), 4.0);
+}
+
+TEST(SessionGraphTransactions, CoalescesStableIdEditsIntoOneRevision) {
+  SessionGraph session;
+  const std::uint64_t base_revision = session.revision();
+
+  auto transaction = session.begin_transaction();
+  const TrackId track_id = session.create_track("Music");
+  const TimeRange range = TimeRange::fromStartLength(TimePoint::fromSamples(48000), 96000);
+  const ClipId clip_id = session.create_clip(track_id, "Intro", range, 3u);
+  session.set_name("Edited");
+  session.set_clip_assignment_ids({clip_id});
+  const SessionGraphChangeSet change = transaction.commit();
+
+  EXPECT_EQ(change.base_revision, base_revision);
+  EXPECT_EQ(change.revision, base_revision + 1u);
+  EXPECT_EQ(session.revision(), change.revision);
+  EXPECT_TRUE(has_change(change.changes, SessionChangeFlags::Metadata));
+  EXPECT_TRUE(has_change(change.changes, SessionChangeFlags::Structure));
+  EXPECT_TRUE(has_change(change.changes, SessionChangeFlags::ClipAssignments));
+
+  const SessionGraphSnapshot snapshot = session.snapshot();
+  ASSERT_EQ(snapshot.tracks.size(), 1u);
+  ASSERT_EQ(snapshot.tracks[0].clips.size(), 1u);
+  EXPECT_EQ(snapshot.tracks[0].id, track_id);
+  EXPECT_EQ(snapshot.tracks[0].clips[0].id, clip_id);
+  EXPECT_EQ(snapshot.tracks[0].clips[0].track_id, track_id);
+  EXPECT_EQ(snapshot.tracks[0].clips[0].range, range);
+  EXPECT_EQ(snapshot.clip_assignments, (std::vector<ClipId>{clip_id}));
+}
+
+TEST(SessionGraphTransactions, DestructionRollsBackStateAndIdWatermarks) {
+  SessionGraph session;
+  const TrackId first_id = session.create_track("Existing");
+  const std::uint64_t base_revision = session.revision();
+  TrackId rolled_back_id;
+
+  {
+    auto transaction = session.begin_transaction();
+    rolled_back_id = session.create_track("Temporary");
+    session.set_name("Temporary name");
+  }
+
+  EXPECT_EQ(session.revision(), base_revision);
+  EXPECT_EQ(session.name(), "Session");
+  ASSERT_EQ(session.tracks().size(), 1u);
+  EXPECT_EQ(session.tracks()[0]->id(), first_id);
+  EXPECT_EQ(session.create_track("Replacement"), rolled_back_id);
+}
+
+TEST(SessionGraphTransactions, RestoreProvidesUndoRedoWithoutReusingOldRevision) {
+  SessionGraph session;
+  const TrackId track_id = session.create_track("Track");
+  const ClipId clip_id = session.create_clip(
+      track_id, "Clip", TimeRange::fromStartLength(TimePoint::fromSamples(0), 48000));
+  const SessionGraphSnapshot before = session.snapshot();
+
+  {
+    auto transaction = session.begin_transaction();
+    session.set_name("After");
+    session.set_clip_range(clip_id,
+                           TimeRange::fromStartLength(TimePoint::fromSamples(96000), 24000));
+    static_cast<void>(transaction.commit());
+  }
+  const SessionGraphSnapshot after = session.snapshot();
+  const std::uint64_t edited_revision = session.revision();
+
+  session.restore(before);
+  EXPECT_EQ(session.revision(), edited_revision + 1u);
+  EXPECT_EQ(session.name(), "Session");
+  ASSERT_EQ(session.snapshot().tracks[0].clips.size(), 1u);
+  EXPECT_EQ(session.snapshot().tracks[0].clips[0].id, clip_id);
+  EXPECT_EQ(session.snapshot().tracks[0].clips[0].range,
+            TimeRange::fromStartLength(TimePoint::fromSamples(0), 48000));
+
+  session.restore(after);
+  EXPECT_EQ(session.revision(), edited_revision + 2u);
+  EXPECT_EQ(session.name(), "After");
+  EXPECT_EQ(session.snapshot().tracks[0].clips[0].range,
+            TimeRange::fromStartLength(TimePoint::fromSamples(96000), 24000));
+}
+
+TEST(SessionGraphTransactions, RejectsNestedTransactions) {
+  SessionGraph session;
+  auto transaction = session.begin_transaction();
+  EXPECT_THROW(static_cast<void>(session.begin_transaction()), std::logic_error);
+  transaction.rollback();
 }
 
 } // namespace orpheus::core::tests

--- a/tests/session_graph_ownership.cpp
+++ b/tests/session_graph_ownership.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/session_graph_scenes.cpp
+++ b/tests/session_graph_scenes.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
+#include <orpheus/session_graph.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/session_roundtrip.cpp
+++ b/tests/session_roundtrip.cpp
@@ -155,6 +155,55 @@ TEST(SessionRoundTrip, GoldenFixturesAreStableAndDeterministic) {
   }
 }
 
+TEST(SessionRoundTrip, MigratesLegacySchemaAndRejectsFutureSchema) {
+  const std::string original = LoadFixtureText(FixturesRoot() / "solo_click.json");
+  const std::string schemaLine = "  \"schema_version\": 1,\n";
+  std::string legacy = original;
+  const size_t schemaPosition = legacy.find(schemaLine);
+  ASSERT_NE(schemaPosition, std::string::npos);
+  legacy.erase(schemaPosition, schemaLine.size());
+
+  const SessionGraph migrated = ParseSession(legacy);
+  EXPECT_NE(SerializeSession(migrated).find(schemaLine), std::string::npos);
+
+  std::string future = original;
+  const size_t versionPosition = future.find("\"schema_version\": 1");
+  ASSERT_NE(versionPosition, std::string::npos);
+  future.replace(versionPosition, std::string("\"schema_version\": 1").size(),
+                 "\"schema_version\": 999");
+  EXPECT_THROW(ParseSession(future), std::runtime_error);
+}
+
+TEST(SessionRoundTrip, AtomicSaveKeepsBackupAndRecoversCorruptPrimary) {
+  const fs::path root = fs::temp_directory_path() / "orpheus_session_atomic_test";
+  fs::remove_all(root);
+  fs::create_directories(root);
+  const fs::path path = root / "session.json";
+
+  SessionGraph session;
+  session.set_name("First");
+  session.set_session_range(0.0, 8.0);
+  SaveSessionToFile(session, path.string());
+  EXPECT_TRUE(fs::is_regular_file(path));
+  EXPECT_FALSE(fs::exists(path.string() + ".tmp"));
+
+  session.set_name("Second");
+  SaveSessionToFile(session, path.string());
+  EXPECT_EQ(LoadSessionFromFile(path.string()).name(), "Second");
+  EXPECT_EQ(LoadSessionFromFile(path.string() + ".bak").name(), "First");
+  EXPECT_FALSE(fs::exists(path.string() + ".bak.tmp"));
+
+  {
+    std::ofstream corrupt(path, std::ios::trunc);
+    corrupt << "{not valid json";
+  }
+  SessionLoadResult recovered = LoadSessionWithRecovery(path.string());
+  EXPECT_TRUE(recovered.recoveredFromBackup);
+  EXPECT_EQ(recovered.sourcePath, path.string() + ".bak");
+  EXPECT_EQ(recovered.session.name(), "First");
+  fs::remove_all(root);
+}
+
 TEST(SessionRoundTrip, RejectsOverlappingClips) {
   const std::string invalid = R"({
     "name": "Invalid",

--- a/tests/transport/clip_restart_test.cpp
+++ b/tests/transport/clip_restart_test.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "../../src/core/session/session_graph.h"
 #include <gtest/gtest.h>
+#include <orpheus/session_graph.h>
 
 #include "../../src/core/transport/transport_controller.h"
 #include <filesystem>

--- a/tests/transport/clip_seek_test.cpp
+++ b/tests/transport/clip_seek_test.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "../../src/core/session/session_graph.h"
 #include <gtest/gtest.h>
+#include <orpheus/session_graph.h>
 
 #include "../../src/core/transport/transport_controller.h"
 #include <filesystem>

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "session/session_graph.h"
 #include <gtest/gtest.h>
+#include <orpheus/session_graph.h>
 #include <orpheus/transport_controller.h>
 
 // FTR027 §1: concrete controller access for processAudio()/processCallbacks()

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -199,6 +199,38 @@ TEST_F(TransportControllerTest, StartClipTwice) {
   EXPECT_EQ(m_transport->startClip(handle), SessionGraphError::OK);
 }
 
+TEST_F(TransportControllerTest, PublishesDecimatedPostRenderTelemetry) {
+  auto* concrete = dynamic_cast<TransportController*>(m_transport.get());
+  ASSERT_NE(concrete, nullptr);
+
+  RealtimeTelemetry* telemetry = m_transport->getRealtimeTelemetry();
+  ASSERT_NE(telemetry, nullptr);
+  telemetry->setDecimationBlocks(2);
+
+  constexpr size_t kBlockFrames = 256;
+  std::vector<float> left(kBlockFrames, 0.0f);
+  std::vector<float> right(kBlockFrames, 0.0f);
+  float* buffers[2] = {left.data(), right.data()};
+
+  concrete->processAudio(buffers, 2, kBlockFrames);
+  EXPECT_EQ(telemetry->pendingSnapshotCount(), 0u);
+
+  concrete->processAudio(buffers, 2, kBlockFrames);
+  ASSERT_EQ(telemetry->pendingSnapshotCount(), 1u);
+
+  RealtimeTelemetrySnapshot snapshot;
+  ASSERT_TRUE(telemetry->tryRead(snapshot));
+  EXPECT_EQ(snapshot.position.samples(), 512);
+  EXPECT_EQ(snapshot.diagnostics.callback_count, 2u);
+  EXPECT_EQ(snapshot.diagnostics.samples_processed, 512u);
+  EXPECT_EQ(snapshot.diagnostics.last_buffer_frames, kBlockFrames);
+  EXPECT_EQ(snapshot.diagnostics.last_sample_rate, 48000u);
+  EXPECT_EQ(snapshot.active_voice_count, 0u);
+  EXPECT_EQ(snapshot.group_count, 4u);
+  EXPECT_FLOAT_EQ(snapshot.master_meter.peak_db, -100.0f);
+  EXPECT_FALSE(telemetry->tryRead(snapshot));
+}
+
 // TODO: Add more comprehensive tests:
 // - Sample-accurate timing (±1 sample)
 // - Multi-clip playback (16 simultaneous)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,3 +5,12 @@ endif()
 
 add_subdirectory(perf)
 add_subdirectory(cli)
+
+if(WIN32 AND ORPHEUS_ENABLE_WASAPI)
+  add_executable(orpheus_wasapi_hardware_acceptance
+    wasapi_hardware_acceptance.cpp)
+  target_compile_features(orpheus_wasapi_hardware_acceptance PRIVATE cxx_std_20)
+  target_link_libraries(orpheus_wasapi_hardware_acceptance
+    PRIVATE orpheus_audio_driver_manager)
+  orpheus_enable_warnings(orpheus_wasapi_hardware_acceptance)
+endif()

--- a/tools/fixtures/loop_grid.json
+++ b/tools/fixtures/loop_grid.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Loop Grid",
   "tempo_bpm": 128,
   "start_beats": 0,

--- a/tools/fixtures/solo_click.json
+++ b/tools/fixtures/solo_click.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Solo Click",
   "tempo_bpm": 120,
   "start_beats": 0,

--- a/tools/fixtures/two_tracks.json
+++ b/tools/fixtures/two_tracks.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "name": "Two Tracks",
   "tempo_bpm": 100,
   "start_beats": 0,

--- a/tools/shmui_juce_manifest.py
+++ b/tools/shmui_juce_manifest.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Synchronize and verify the vendored ShmUI-JUCE import manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "shmui-juce"
+MANIFEST = PACKAGE / "shmui-juce-import.json"
+HASH_ALGORITHM = "sha256-path-nul-content-v1"
+EXPECTED_TARGETS = {"Orpheus::shmui_juce", "Orpheus::shmui_juce_gl"}
+
+
+def imported_files() -> list[pathlib.Path]:
+    return sorted(
+        path
+        for path in PACKAGE.rglob("*")
+        if path.is_file() and path != MANIFEST and not path.name.startswith(".")
+    )
+
+
+def content_hash() -> str:
+    digest = hashlib.sha256()
+    for path in imported_files():
+        relative = path.relative_to(PACKAGE).as_posix().encode("utf-8")
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def load_manifest() -> dict[str, Any]:
+    value = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError("manifest root must be an object")
+    return value
+
+
+def structural_failures(manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if manifest.get("schema_version") != 1:
+        failures.append("schema_version must be 1")
+
+    source = manifest.get("source")
+    if not isinstance(source, dict):
+        failures.append("source must be an object")
+        source = {}
+    revision = source.get("revision")
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        failures.append("source.revision must be a full lowercase Git SHA")
+    if source.get("content_hash_algorithm") != HASH_ALGORITHM:
+        failures.append(f"source.content_hash_algorithm must be {HASH_ALGORITHM}")
+    if not isinstance(manifest.get("design_token_contract_version"), str):
+        failures.append("design_token_contract_version must be a string")
+
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict) or set(targets) != EXPECTED_TARGETS:
+        failures.append("targets must declare exactly the core and OpenGL ShmUI targets")
+        return failures
+
+    core = targets["Orpheus::shmui_juce"]
+    gl = targets["Orpheus::shmui_juce_gl"]
+    if not isinstance(core.get("components"), list) or not core["components"]:
+        failures.append("core target must list exported components")
+    core_modules = core.get("required_juce_modules")
+    if not isinstance(core_modules, list) or not core_modules:
+        failures.append("core target must list required JUCE modules")
+    elif "juce_opengl" in core_modules:
+        failures.append("core target must not require juce_opengl")
+    if gl.get("feature_flag") != "SHMUI_JUCE_ENABLE_OPENGL":
+        failures.append("OpenGL target feature_flag is incorrect")
+    if gl.get("default_enabled") is not False:
+        failures.append("OpenGL target must default to disabled")
+    if gl.get("required_juce_modules") != ["juce_opengl"]:
+        failures.append("OpenGL target must declare only its incremental juce_opengl requirement")
+    return failures
+
+
+def check() -> int:
+    manifest = load_manifest()
+    failures = structural_failures(manifest)
+    source = manifest.get("source", {})
+    expected_hash = content_hash()
+    if source.get("content_sha256") != expected_hash:
+        failures.append("source.content_sha256 does not match imported package content")
+
+    if failures:
+        for failure in failures:
+            print(f"ShmUI-JUCE manifest error: {failure}", file=sys.stderr)
+        print("run: python3 tools/shmui_juce_manifest.py --sync", file=sys.stderr)
+        return 1
+
+    print(
+        "ShmUI-JUCE manifest is consistent: "
+        f"{len(imported_files())} files, sha256 {expected_hash}"
+    )
+    return 0
+
+
+def sync() -> int:
+    manifest = load_manifest()
+    source = manifest.setdefault("source", {})
+    source["content_hash_algorithm"] = HASH_ALGORITHM
+    source["content_sha256"] = content_hash()
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--sync", action="store_true")
+    args = parser.parse_args()
+    return check() if args.check else sync()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wasapi_hardware_acceptance.cpp
+++ b/tools/wasapi_hardware_acceptance.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+#ifdef _WIN32
+
+#include <orpheus/audio_driver.h>
+#include <orpheus/audio_driver_manager.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace {
+
+class AcceptanceCallback final : public orpheus::IAudioCallback {
+public:
+  void processAudio(const float**, float** outputs, size_t channels, size_t frames) override {
+    for (size_t channel = 0; channel < channels; ++channel) {
+      std::fill_n(outputs[channel], frames, 0.0f);
+    }
+    callbacks_.fetch_add(1, std::memory_order_relaxed);
+    frames_.fetch_add(frames, std::memory_order_relaxed);
+  }
+
+  uint64_t callbacks() const {
+    return callbacks_.load(std::memory_order_relaxed);
+  }
+  uint64_t frames() const {
+    return frames_.load(std::memory_order_relaxed);
+  }
+
+private:
+  std::atomic<uint64_t> callbacks_{0};
+  std::atomic<uint64_t> frames_{0};
+};
+
+} // namespace
+
+int main() {
+  auto manager = orpheus::createAudioDriverManager();
+  const auto devices = manager->enumerateDevices();
+  auto selected = std::find_if(devices.begin(), devices.end(), [](const auto& device) {
+    return device.driverType == "WASAPI" && device.isDefaultDevice;
+  });
+  if (selected == devices.end()) {
+    selected = std::find_if(devices.begin(), devices.end(),
+                            [](const auto& device) { return device.driverType == "WASAPI"; });
+  }
+  if (selected == devices.end() || selected->supportedSampleRates.empty() ||
+      selected->supportedBufferSizes.empty()) {
+    std::cout << "{\"status\":\"failed\",\"reason\":\"no-active-wasapi-endpoint\"}\n";
+    return 1;
+  }
+
+  const uint32_t sampleRate =
+      std::find(selected->supportedSampleRates.begin(), selected->supportedSampleRates.end(),
+                48000u) != selected->supportedSampleRates.end()
+          ? 48000u
+          : selected->supportedSampleRates.front();
+  const uint32_t bufferSize = selected->supportedBufferSizes.front();
+  if (manager->setActiveDevice(selected->deviceId, sampleRate, bufferSize) !=
+      orpheus::SessionGraphError::OK) {
+    std::cout << "{\"status\":\"failed\",\"reason\":\"device-initialize\"}\n";
+    return 2;
+  }
+
+  orpheus::IAudioDriver* driver = manager->getActiveDriver();
+  AcceptanceCallback callback;
+  if (driver == nullptr || driver->start(&callback) != orpheus::SessionGraphError::OK) {
+    std::cout << "{\"status\":\"failed\",\"reason\":\"callback-start\"}\n";
+    return 3;
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+  const auto stopResult = driver->stop();
+  const auto& negotiated = driver->getConfig();
+  const bool passed = stopResult == orpheus::SessionGraphError::OK && callback.callbacks() > 0;
+
+  std::cout << "{\"status\":\"" << (passed ? "passed" : "failed")
+            << "\",\"backend\":\"WASAPI\",\"sampleRate\":" << negotiated.sample_rate
+            << ",\"bufferFrames\":" << negotiated.buffer_size
+            << ",\"channels\":" << negotiated.num_outputs
+            << ",\"callbacks\":" << callback.callbacks() << ",\"frames\":" << callback.frames()
+            << "}\n";
+  return passed ? 0 : 4;
+}
+
+#endif


### PR DESCRIPTION
Implements ORP141 reliability and adoption contracts on `feat/orp141-reliability-adoption`.

Completed:
- R0 release/package truth
- R1 correctness and routing/time regressions
- R2 media integrity and recoverable sessions
- R4 public SessionGraph transactions, ShmUI-JUCE manifest/non-OpenGL consumer, and fixed-capacity decimated realtime telemetry

Verification:
- Full configured suite: 143/143 passed
- Installed `find_package` workflow fixture passed
- Strict realtime audit passed

Explicitly deferred/incomplete:
- Windows hosted package/ABI proof: repository Actions reports `enabled: false`; the user elected to keep it disabled. Run 29316779217 remains queued without jobs.
- WASAPI real-device proof: repository reports zero self-hosted runners; the manual workflow also cannot dispatch until it exists on the default branch.
- R5 voice utility: gate review found only FourTrack's conditional interest, not two independent consumer requirements, and R1-R4 have not shipped/soaked together.
- The Release Operating Model: deferred as a unit; all jobs are recorded in ORP141.

Do not promote Windows/WASAPI support or merge under a green-CI policy without later evidence.