### PR TITLE
feat(scene): expose package-safe scene manager

### DIFF
--- a/include/orpheus/scene_manager.h
+++ b/include/orpheus/scene_manager.h
@@ -234,6 +234,14 @@ public:
 // Factory Function
 // ============================================================================
 
+/// Create a self-contained scene manager for installed-package consumers.
+///
+/// The manager owns an empty session graph internally. This is the preferred
+/// factory when the host does not build against SDK-private SessionGraph
+/// headers; routing and transport may then be attached through the public
+/// ISceneManager wiring methods.
+ORPHEUS_API std::unique_ptr<ISceneManager> createSceneManager();
+
 /// Create scene manager instance
 ///
 /// @param sessionGraph The session graph containing clip metadata

--- a/src/core/session/scene_manager.cpp
+++ b/src/core/session/scene_manager.cpp
@@ -197,6 +197,10 @@ SceneSnapshot deserializeSceneFromJson(const json::JsonValue& root) {
 
 class SceneManager : public ISceneManager {
 public:
+  SceneManager()
+      : ownedSessionGraph_(std::make_unique<core::SessionGraph>()),
+        sessionGraph_(ownedSessionGraph_.get()), routingMatrix_(nullptr), transport_(nullptr) {}
+
   explicit SceneManager(core::SessionGraph* sessionGraph)
       : sessionGraph_(sessionGraph), routingMatrix_(nullptr), transport_(nullptr) {
     if (!sessionGraph) {
@@ -451,7 +455,8 @@ public:
   }
 
 private:
-  [[maybe_unused]] core::SessionGraph* sessionGraph_; // Not owned
+  std::unique_ptr<core::SessionGraph> ownedSessionGraph_;
+  core::SessionGraph* sessionGraph_; // Owned by this manager or supplied by caller
   IRoutingMatrix* routingMatrix_;                     // Not owned (optional)
   ITransportController* transport_;                   // Not owned (required for recall)
   mutable std::mutex mutex_;                          // Protects scenes_
@@ -461,6 +466,10 @@ private:
 // ============================================================================
 // Factory Function
 // ============================================================================
+
+std::unique_ptr<ISceneManager> createSceneManager() {
+  return std::make_unique<SceneManager>();
+}
 
 std::unique_ptr<ISceneManager> createSceneManager(core::SessionGraph* sessionGraph) {
   return std::make_unique<SceneManager>(sessionGraph);

--- a/tests/session/scene_manager_test.cpp
+++ b/tests/session/scene_manager_test.cpp
@@ -123,6 +123,21 @@ TEST_F(SceneManagerTest, CaptureSceneTimestampIncreases) {
 // Scene Recall Tests
 // ============================================================================
 
+TEST(SceneManagerPackageContract, SelfContainedFactoryCanCaptureAndRecall) {
+  auto manager = createSceneManager();
+  auto packageTransport = createTransportController(nullptr, 48000);
+  ASSERT_NE(manager, nullptr);
+  ASSERT_NE(packageTransport, nullptr);
+  ASSERT_NE(packageTransport->getRoutingMatrix(), nullptr);
+
+  manager->setTransportController(packageTransport.get());
+  manager->setRoutingMatrix(packageTransport->getRoutingMatrix());
+  const auto sceneId = manager->captureScene("Installed Package Scene");
+
+  ASSERT_FALSE(sceneId.empty());
+  EXPECT_EQ(manager->recallScene(sceneId), SessionGraphError::OK);
+}
+
 TEST_F(SceneManagerTest, RecallSceneSucceeds) {
   std::string sceneId = sceneManager->captureScene("Test Scene");
 


### PR DESCRIPTION
## Summary
- add a self-contained public scene-manager factory for installed-package consumers
- preserve the existing caller-owned SessionGraph factory
- verify capture and recall through public SDK interfaces only

## Verification
- focused SceneManagerPackageContract: 1 passed
- full SDK CTest: 136 passed, 1 disabled
- Release install + downstream find_package smoke: passed

Required by the Clip Composer OCC164 package-adoption gate.