### PR TITLE
chore(release): prepare SDK v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-14
+
+Release for downstream ORP141 adoption. This is the first tagged package that
+combines generated release/version metadata, stable installed CMake target
+aliases, media SHA-256 references, routing-snapshot provenance, scene-recall
+transport stop semantics, fixed-capacity active-voice diagnostics, CoreAudio
+performance-monitor attachment, and the merged realtime reliability fixes.
+
+### Added
+
+- `ITransportController::getTotalActiveVoiceCount()` and
+  `ITransportCallback::onActiveClipLimitReached()` expose bounded voice-pool
+  admission truth without allocations or locks on the audio thread.
+- `MediaFingerprint`, `sha256File()`, and `resolveMediaReference()` provide one
+  verified media-identity and relative-path security contract.
+- Generated `orpheus/version.h`, package inventory JSON, stable
+  `Orpheus::*` installed-target aliases, and release-artifact metadata.
+- A self-contained `createSceneManager()` factory lets installed-package
+  consumers exercise scene capture/recall without private `SessionGraph`
+  headers.
+
+### Changed
+
+- Scene recall stops attached transport before applying captured routing/session
+  state, and routing snapshots retain optional control-time/audio-position
+  provenance.
+- CoreAudio reports total active voices and callback timing through an attached
+  performance monitor.
+- Realtime command/callback, transport snapshot, and routing reliability
+  contracts now fail explicitly instead of publishing partial state.
+
 ## [0.3.1] - 2026-07-10
 
 Release tag cut for Clip Composer's submodule bump (OCC155 Ask #1). Rolls up all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.3.2 LANGUAGES CXX)
+project(orpheus VERSION 0.3.3 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.3.2 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.3.3 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -4,7 +4,7 @@ This index catalogs public entry points exposed by the Orpheus SDK workspace. Up
 notable APIs are added.
 
 **Last Updated:** 2026-07-09 (ORP133 truth pass)
-**SDK Version:** 0.3.2 — the authoritative version is `project(orpheus VERSION ...)`
+**SDK Version:** 0.3.3 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.2
+**SDK Version:** 0.3.3
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.2
+**SDK Version:** 0.3.3

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.2
+**SDK Version:** 0.3.3

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.2
+**SDK Version:** 0.3.3


### PR DESCRIPTION
## Release contents
- merged ORP141 release/package, media-integrity, routing/scene, active-voice, CoreAudio, and reliability work
- package-safe scene-manager factory from #207
- synchronized generated/public version truth at 0.3.3

## Verification
- full SDK CTest: 136 passed, 1 disabled
- version contract and installed find_package: passed
- Clip Composer package compatibility smoke: passed

This release is the OCC164 adoption baseline.