### PR TITLE
feat(transport): expose public runtime contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,14 @@ acknowledges the source migration required for interface implementers.
   `getRenderConfig() const noexcept`, `processAudio(float**, size_t, size_t)
   noexcept`, and `processCallbacks()`. This implementer source break is why the
   pre-1.0 minor version advances to `0.4.0`.
+- The new virtual methods are appended after every pre-`0.4.0` interface slot,
+  preserving the existing vtable entry order for factory consumers.
 - The transport's routing topology remains fixed after construction in this
   release. Hosts must not call `getRoutingMatrix()->initialize(...)` on a live
   transport; doing so would discard the transport's stereo channel layout.
-- Installed package version matching now uses `SameMinorVersion`: pre-1.0 patch
-  releases remain compatible within a minor line, while `0.4.x` is not selected
-  for a consumer requesting source-incompatible `0.3.x`.
+- Installed package version matching uses `SameMinorVersion` while the SDK is
+  pre-1.0, so `0.4.x` is not selected for a source-incompatible `0.3.x`
+  request. Stable major releases use `SameMajorVersion`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-14
+
+Release of the public transport-rendering contract required by host applications
+that must not depend on SDK-private transport headers. The minor version
+acknowledges the source migration required for interface implementers.
+
+### Added
+
+- `TransportRenderConfig` and
+  `ITransportController::{getRenderConfig(), processAudio(), processCallbacks()}`
+  publish the renderer configuration, audio-thread render entry point, and
+  control-thread event/tempo pump through `<orpheus/transport_controller.h>`.
+- `getRenderConfig()` reports the constructor sample rate, the routing matrix's
+  current output count, and the concrete renderer's hard maximum block size.
+
+### Changed
+
+- Factory callers remain source-compatible after recompilation, but custom
+  `ITransportController` subclasses and test doubles must implement
+  `getRenderConfig() const noexcept`, `processAudio(float**, size_t, size_t)
+  noexcept`, and `processCallbacks()`. This implementer source break is why the
+  pre-1.0 minor version advances to `0.4.0`.
+- The transport's routing topology remains fixed after construction in this
+  release. Hosts must not call `getRoutingMatrix()->initialize(...)` on a live
+  transport; doing so would discard the transport's stereo channel layout.
+- Installed package version matching now uses `SameMinorVersion`: pre-1.0 patch
+  releases remain compatible within a minor line, while `0.4.x` is not selected
+  for a consumer requesting source-incompatible `0.3.x`.
+
+### Fixed
+
+- The realtime allocation-guard self-test now calls the replaceable allocation
+  functions explicitly, so optimized Release builds cannot elide its deliberate
+  violation and produce a false detector failure.
+
+### Integration contract
+
+- `processAudio()` is non-reentrant, is called by exactly one audio thread, and
+  is the sole consumer of the control-to-audio SPSC command ring. Its realtime
+  path permits no allocation, locks, blocking, I/O, or host callback dispatch.
+- `processCallbacks()` is called by exactly one control/message thread and is
+  the sole consumer of the audio-to-control event ring. It must run even without
+  a callback object because it also republishes session tempo.
+- Source-tree tests exercise the complete runtime contract through
+  `ITransportController`, and an installed-package CTest configures, builds, and
+  runs a public-header-only consumer linked only to `Orpheus::transport`.
+- Clip Composer adoption remains downstream work: it must own the factory result
+  as `std::unique_ptr<orpheus::ITransportController>`, render and pump callbacks
+  through that interface, and remove its SDK-private transport header include
+  and concrete-controller downcast. This release preparation does not claim that
+  application migration has occurred.
+
 ## [0.3.3] - 2026-07-14
 
 Release for downstream ORP141 adoption. This is the first tagged package that

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,10 +312,16 @@ configure_package_config_file(
   ${CMAKE_CURRENT_BINARY_DIR}/OrpheusSDKConfig.cmake
   INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
 
+if(PROJECT_VERSION_MAJOR EQUAL 0)
+  set(ORPHEUS_PACKAGE_COMPATIBILITY SameMinorVersion)
+else()
+  set(ORPHEUS_PACKAGE_COMPATIBILITY SameMajorVersion)
+endif()
+
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/OrpheusSDKConfigVersion.cmake
   VERSION ${PROJECT_VERSION}
-  COMPATIBILITY SameMinorVersion)
+  COMPATIBILITY ${ORPHEUS_PACKAGE_COMPATIBILITY})
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/OrpheusSDKConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.3.3 LANGUAGES CXX)
+project(orpheus VERSION 0.4.0 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)
@@ -315,7 +315,7 @@ configure_package_config_file(
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/OrpheusSDKConfigVersion.cmake
   VERSION ${PROJECT_VERSION}
-  COMPATIBILITY AnyNewerVersion)
+  COMPATIBILITY SameMinorVersion)
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/OrpheusSDKConfig.cmake

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.3.3 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.4.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -4,7 +4,7 @@ This index catalogs public entry points exposed by the Orpheus SDK workspace. Up
 notable APIs are added.
 
 **Last Updated:** 2026-07-09 (ORP133 truth pass)
-**SDK Version:** 0.3.3 — the authoritative version is `project(orpheus VERSION ...)`
+**SDK Version:** 0.4.0 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)

--- a/docs/orp/ORP143 Reliability and Adoption Sprint Completion and Child-App Handoff.md
+++ b/docs/orp/ORP143 Reliability and Adoption Sprint Completion and Child-App Handoff.md
@@ -1,0 +1,171 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP143 — Reliability and Adoption Sprint Completion and Child-App Handoff
+
+**Document type:** SDK release-candidate completion record and downstream handoff  
+**Version target:** `0.4.0`  
+**Status:** SDK release candidate verified; tag/publication and child-app adoption pending  
+**Date:** 2026-07-14
+
+---
+
+## 1. Scope and release truth
+
+Version `0.4.0` adds a host-neutral public rendering boundary to the existing
+transport controller. The factory still returns
+`std::unique_ptr<ITransportController>`, so factory callers need only recompile.
+The new methods are pure virtual, however: custom interface implementations and
+test doubles must implement all three runtime methods. The pre-1.0 minor version
+records that implementer source migration explicitly.
+
+The root CMake project now supplies `0.4.0` to the generated version header,
+release JSON, package-version file, and CPack metadata. Those artifacts consume
+`PROJECT_VERSION`; their templates do not contain an independent version literal
+and require no separate version edit.
+
+This document does **not** claim that `v0.4.0` has been tagged, published, or
+adopted by Clip Composer. The Release package candidate was built and inspected;
+publication and downstream migration remain pending.
+
+---
+
+## 2. Public transport runtime contract
+
+### 2.1 Renderer configuration
+
+```cpp
+struct TransportRenderConfig {
+  uint32_t sampleRate = 0;
+  uint32_t outputChannels = 0;
+  uint32_t maxBlockFrames = 0;
+};
+
+virtual TransportRenderConfig getRenderConfig() const noexcept = 0;
+```
+
+`getRenderConfig()` is a control-thread query returning a value copy. Its fields
+report:
+
+- `sampleRate`: the sample rate supplied when the concrete controller was
+  constructed;
+- `outputChannels`: the transport's configured output count; its routing
+  topology is fixed after construction in this release; and
+- `maxBlockFrames`: the concrete renderer's hard per-call block limit.
+
+No concrete transport type or private transport header is needed to query this
+shape.
+
+Hosts must not call `getRoutingMatrix()->initialize(...)` on a live transport in
+`0.4.0`. Routing-matrix initialization rebuilds channel state, while the
+transport's stereo channel layout is established during construction. A later
+typed routing-configuration API must own that transition rather than exposing an
+apparently safe partial reconfiguration.
+
+### 2.2 Audio render entry point
+
+```cpp
+virtual void processAudio(float** outputBuffers,
+                          size_t numChannels,
+                          size_t numFrames) noexcept = 0;
+```
+
+`processAudio()` is the host's public planar-output render entry point. The host
+supplies exactly `getRenderConfig().outputChannels` writable buffers and no more
+than `getRenderConfig().maxBlockFrames` frames per call.
+
+The method is non-reentrant and belongs to exactly one audio thread. It is the
+sole consumer of the control-to-audio SPSC command ring. Its realtime contract
+forbids allocation, locks, blocking, file or network I/O, and host callback
+dispatch. Control sources must continue to funnel all transport mutations
+through exactly one producer thread; UI, MIDI, OSC, or other producers may not
+call the SPSC producer side concurrently.
+
+### 2.3 Control-thread callback and tempo pump
+
+```cpp
+virtual void processCallbacks() = 0;
+```
+
+`processCallbacks()` belongs to exactly one control/message thread and is the
+sole consumer of the audio-to-control SPSC event ring. It must not run
+concurrently with `setCallback()`. Hosts must pump it even when no callback
+object is installed because the same pump republishes `SessionGraph` tempo for
+lock-free transport-position beat queries.
+
+---
+
+## 3. Source and installed-package compatibility status
+
+| Consumer path | Repository evidence | Status for `0.4.0` |
+| --- | --- | --- |
+| Public source include | `include/orpheus/transport_controller.h` declares `TransportRenderConfig`, all three interface methods, and `createTransportController()`. | Verified through `transport_controller_test`; no concrete transport include remains in that test target. |
+| Source-tree CMake target | `src/core/transport/CMakeLists.txt` gives `orpheus_transport` a public build include path and defines the `Orpheus::transport` alias. | Focused build and 14/14 transport tests passed. |
+| Installed headers and target | Root `CMakeLists.txt` installs `include/orpheus`, exports `orpheus_transport`, and installs package configuration; `cmake/OrpheusSDKConfig.cmake.in` creates the stable `Orpheus::transport` alias. | `cmake_package_runtime_consumer` installed to a clean prefix, resolved the candidate package, linked only `Orpheus::transport`, built, and ran successfully. |
+| Release metadata | Root `project(orpheus VERSION 0.4.0)` feeds the generated header, release JSON, CMake package version, and CPack fields. | CPack produced `orpheus-sdk-0.4.0-Darwin-arm64.zip` plus SHA-256; the archived metadata and public transport header report the expected candidate. |
+
+The installed package uses CMake `SameMinorVersion` compatibility. The positive
+consumer resolves `0.4.0`, while `cmake_package_rejects_previous_minor` proves
+the same package is rejected for a `0.3.0` request rather than advertising a
+source-incompatible interface to a `0.3.x` consumer.
+
+The source-tree regression and installed consumer both create the transport
+through its public factory, query the render config, render a bounded block, and
+drain callbacks through `ITransportController`. The installed fixture includes
+only `<orpheus/transport_controller.h>` from the clean prefix; its compiler flags
+contain no SDK source-tree include path.
+
+---
+
+## 4. Clip Composer handoff
+
+Clip Composer must perform a clean public-interface cutover in its own repository:
+
+1. Store the factory result as
+   `std::unique_ptr<orpheus::ITransportController>` rather than a pointer to the
+   concrete SDK transport class.
+2. Delete its include of the SDK-internal transport header.
+3. Delete the concrete-controller downcast used to reach rendering or callback
+   methods.
+4. Query `getRenderConfig()` when attaching/reconfiguring its audio driver and
+   honor the published channel count and maximum block size.
+5. Call `processAudio()` only from its single audio callback thread.
+6. Call `processCallbacks()` from exactly one message/control-thread pump,
+   including when no transport callback object is installed.
+7. Keep all transport mutations serialized onto one control producer so the
+   SDK's SPSC ownership contract is not violated.
+8. Validate both the source-submodule target and a clean installed-package
+   `find_package` path before advancing the app's SDK pin.
+
+This handoff records required downstream work only. No Clip Composer header,
+ownership model, downcast, package pin, build, or runtime validation is claimed
+as changed by ORP143.
+
+---
+
+## 5. Release evidence and remaining gates
+
+Verified candidate checks:
+
+- Debug CTest: **139/139 passed**;
+- Release CTest: **139/139 passed**;
+- focused `transport_controller_test`: **14/14 passed**;
+- public runtime contract filter: **2/2 passed**;
+- clean-prefix `cmake_package_runtime_consumer`: install/configure/build/run
+  passed against `OrpheusSDK 0.4.0`;
+- clean-prefix `cmake_package_rejects_previous_minor`: `0.4.0` correctly rejected
+  a `0.3.0` package request;
+- CPack produced `orpheus-sdk-0.4.0-Darwin-arm64.zip` and its SHA-256 file; and
+- archive inspection confirmed metadata version `0.4.0` and the public runtime
+  declarations in the packaged transport header.
+
+`RealtimeHarnessTest.FileBackedRenderDoesNoFileIO` remains skipped on macOS
+because `/proc/self/io` is unavailable; the containing CTest target passes and
+the static realtime audit remains green.
+
+Remaining gates:
+
+- create and publish the `v0.4.0` tag; and
+- migrate Clip Composer to the public interface and run its build/test/smoke and
+  installed-package gates.
+
+The accurate state is **SDK-verified/downstream-pending**.

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.3
+**SDK Version:** 0.4.0
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.3
+**SDK Version:** 0.4.0

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.3
+**SDK Version:** 0.4.0

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.3.3
+**SDK Version:** 0.4.0

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -3,6 +3,7 @@
 
 #include <orpheus/errors.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -66,6 +67,18 @@ struct TransportPosition {
   int64_t samples; ///< Absolute position in samples (authoritative)
   double seconds;  ///< Derived: samples / sample_rate
   double beats;    ///< Derived: seconds * session tempo (SessionGraph::tempo) / 60.0
+};
+
+/// Immutable capacities and current output shape for the transport renderer.
+///
+/// Hosts query this on the control thread before attaching an audio driver.
+/// sampleRate and maxBlockFrames are fixed for the controller lifetime.
+/// outputChannels is the controller's configured output count and must match the
+/// number of writable output buffers supplied to processAudio().
+struct TransportRenderConfig {
+  uint32_t sampleRate = 0;
+  uint32_t outputChannels = 0;
+  uint32_t maxBlockFrames = 0;
 };
 
 /// Clip metadata for batch updates
@@ -186,6 +199,35 @@ public:
 class ITransportController {
 public:
   virtual ~ITransportController() = default;
+
+  /// Query the public audio-render contract.
+  ///
+  /// Control-thread query. The returned value is a copy; no SDK-owned storage
+  /// escapes. In v0.4.0 the transport's routing topology is fixed after
+  /// construction: hosts must not reinitialize the matrix returned by
+  /// getRoutingMatrix() while this controller is in use.
+  virtual TransportRenderConfig getRenderConfig() const noexcept = 0;
+
+  /// Render one transport block into planar output buffers.
+  ///
+  /// This is the audio-thread entry point and the sole consumer of the
+  /// control-to-audio SPSC command ring. It is non-reentrant and must be called
+  /// by exactly one audio thread. The host must supply exactly
+  /// getRenderConfig().outputChannels writable buffers and no more than
+  /// getRenderConfig().maxBlockFrames frames per call.
+  ///
+  /// Real-time contract: no allocation, locks, blocking, I/O, or host callbacks.
+  virtual void processAudio(float** outputBuffers, size_t numChannels,
+                            size_t numFrames) noexcept = 0;
+
+  /// Drain pending transport events on the control/message thread.
+  ///
+  /// This is the sole consumer of the audio-to-control SPSC event ring. Call
+  /// from exactly one control thread, never concurrently with setCallback().
+  /// The pump also republishes SessionGraph tempo changes for lock-free
+  /// TransportPosition::beats queries, so hosts must call it even when no
+  /// callback object is installed.
+  virtual void processCallbacks() = 0;
 
   /// Start playback of a specific clip
   ///

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -202,35 +202,6 @@ class ITransportController {
 public:
   virtual ~ITransportController() = default;
 
-  /// Query the public audio-render contract.
-  ///
-  /// Control-thread query. The returned value is a copy; no SDK-owned storage
-  /// escapes. In v0.4.0 the transport's routing topology is fixed after
-  /// construction: hosts must not reinitialize the matrix returned by
-  /// getRoutingMatrix() while this controller is in use.
-  virtual TransportRenderConfig getRenderConfig() const noexcept = 0;
-
-  /// Render one transport block into planar output buffers.
-  ///
-  /// This is the audio-thread entry point and the sole consumer of the
-  /// control-to-audio SPSC command ring. It is non-reentrant and must be called
-  /// by exactly one audio thread. The host must supply exactly
-  /// getRenderConfig().outputChannels writable buffers and no more than
-  /// getRenderConfig().maxBlockFrames frames per call.
-  ///
-  /// Real-time contract: no allocation, locks, blocking, I/O, or host callbacks.
-  virtual void processAudio(float** outputBuffers, size_t numChannels,
-                            size_t numFrames) noexcept = 0;
-
-  /// Drain pending transport events on the control/message thread.
-  ///
-  /// This is the sole consumer of the audio-to-control SPSC event ring. Call
-  /// from exactly one control thread, never concurrently with setCallback().
-  /// The pump also republishes SessionGraph tempo changes for lock-free
-  /// TransportPosition::beats queries, so hosts must call it even when no
-  /// callback object is installed.
-  virtual void processCallbacks() = 0;
-
   /// Start playback of a specific clip
   ///
   /// This function is thread-safe and can be called from the UI thread.
@@ -811,6 +782,35 @@ public:
   /// with RealtimeTelemetry::tryRead(). The audio callback is the sole producer.
   /// Hosts must not retain the pointer after destroying the controller.
   virtual RealtimeTelemetry* getRealtimeTelemetry() noexcept = 0;
+
+  /// Query the public audio-render contract.
+  ///
+  /// Control-thread query. The returned value is a copy; no SDK-owned storage
+  /// escapes. In v0.4.0 the transport's routing topology is fixed after
+  /// construction: hosts must not reinitialize the matrix returned by
+  /// getRoutingMatrix() while this controller is in use.
+  virtual TransportRenderConfig getRenderConfig() const noexcept = 0;
+
+  /// Render one transport block into planar output buffers.
+  ///
+  /// This is the audio-thread entry point and the sole consumer of the
+  /// control-to-audio SPSC command ring. It is non-reentrant and must be called
+  /// by exactly one audio thread. The host must supply exactly
+  /// getRenderConfig().outputChannels writable buffers and no more than
+  /// getRenderConfig().maxBlockFrames frames per call.
+  ///
+  /// Real-time contract: no allocation, locks, blocking, I/O, or host callbacks.
+  virtual void processAudio(float** outputBuffers, size_t numChannels,
+                            size_t numFrames) noexcept = 0;
+
+  /// Drain pending transport events on the control/message thread.
+  ///
+  /// This is the sole consumer of the audio-to-control SPSC event ring. Call
+  /// from exactly one control thread, never concurrently with setCallback().
+  /// The pump also republishes SessionGraph tempo changes for lock-free
+  /// TransportPosition::beats queries, so hosts must call it even when no
+  /// callback object is installed.
+  virtual void processCallbacks() = 0;
 };
 
 /// Create a transport controller instance

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -308,8 +308,18 @@ void TransportController::setCallback(ITransportCallback* callback) {
   m_callback = callback;
 }
 
+TransportRenderConfig TransportController::getRenderConfig() const noexcept {
+  TransportRenderConfig config;
+  config.sampleRate = m_sampleRate;
+  config.maxBlockFrames = static_cast<uint32_t>(MAX_BUFFER_FRAMES);
+  if (m_routingMatrix) {
+    config.outputChannels = m_routingMatrix->getConfig().num_outputs;
+  }
+  return config;
+}
+
 void TransportController::processAudio(float** outputBuffers, size_t numChannels,
-                                       size_t numFrames) {
+                                       size_t numFrames) noexcept {
   // Process pending commands from UI thread
   processCommands();
 

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -234,6 +234,11 @@ public:
   TransportController(core::SessionGraph* sessionGraph, uint32_t sampleRate);
   ~TransportController() override;
 
+  TransportRenderConfig getRenderConfig() const noexcept override;
+  void processAudio(float** outputBuffers, size_t numChannels,
+                    size_t numFrames) noexcept override;
+  void processCallbacks() override;
+
   // ITransportController interface
   SessionGraphError startClip(ClipHandle handle) override;
   SessionGraphError stopClip(ClipHandle handle) override;
@@ -279,15 +284,6 @@ public:
   SessionGraphError seekToCuePoint(ClipHandle handle, uint32_t cueIndex) override;
   SessionGraphError removeCuePoint(ClipHandle handle, uint32_t cueIndex) override;
 
-  /// Process audio (called from audio thread)
-  /// @param outputBuffers Output buffers (one per channel)
-  /// @param numChannels Number of output channels
-  /// @param numFrames Number of frames to process
-  void processAudio(float** outputBuffers, size_t numChannels, size_t numFrames);
-
-  /// Process callbacks on UI thread
-  /// Must be called periodically from UI thread to dispatch transport events
-  void processCallbacks();
 
   /// Register audio file for a clip (UI thread)
   /// @param handle Clip handle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,41 @@ add_test(NAME cmake_find_package
     -Dbinary_dir=${FIND_PACKAGE_BINARY_DIR}
     -P ${CMAKE_SOURCE_DIR}/tests/cmake/run_find_package.cmake)
 
+set(PACKAGE_RUNTIME_SOURCE_DIR ${CMAKE_SOURCE_DIR}/tests/package_runtime_consumer)
+set(PACKAGE_RUNTIME_BINARY_DIR ${CMAKE_BINARY_DIR}/tests/package_runtime_consumer_build)
+set(PACKAGE_RUNTIME_INSTALL_DIR ${CMAKE_BINARY_DIR}/tests/package_runtime_consumer_prefix)
+
+add_test(NAME cmake_package_runtime_consumer
+  COMMAND ${CMAKE_COMMAND}
+    -Dsdk_build_dir=${CMAKE_BINARY_DIR}
+    -Dinstall_prefix=${PACKAGE_RUNTIME_INSTALL_DIR}
+    -Drequired_version=${PROJECT_VERSION}
+    -Dbuild_type=$<CONFIG>
+    -Dsource_dir=${PACKAGE_RUNTIME_SOURCE_DIR}
+    -Dbinary_dir=${PACKAGE_RUNTIME_BINARY_DIR}
+    -P ${CMAKE_SOURCE_DIR}/tests/cmake/run_find_package.cmake)
+
+if(PROJECT_VERSION_MAJOR EQUAL 0 AND PROJECT_VERSION_MINOR GREATER 0)
+  math(EXPR PREVIOUS_MINOR "${PROJECT_VERSION_MINOR} - 1")
+  set(PREVIOUS_MINOR_VERSION
+    "${PROJECT_VERSION_MAJOR}.${PREVIOUS_MINOR}.${PROJECT_VERSION_PATCH}")
+  set(PACKAGE_REJECTION_BINARY_DIR
+    ${CMAKE_BINARY_DIR}/tests/package_runtime_consumer_rejection_build)
+  set(PACKAGE_REJECTION_INSTALL_DIR
+    ${CMAKE_BINARY_DIR}/tests/package_runtime_consumer_rejection_prefix)
+
+  add_test(NAME cmake_package_rejects_previous_minor
+    COMMAND ${CMAKE_COMMAND}
+      -Dsdk_build_dir=${CMAKE_BINARY_DIR}
+      -Dinstall_prefix=${PACKAGE_REJECTION_INSTALL_DIR}
+      -Drequired_version=${PREVIOUS_MINOR_VERSION}
+      -Dbuild_type=$<CONFIG>
+      -Dsource_dir=${PACKAGE_RUNTIME_SOURCE_DIR}
+      -Dbinary_dir=${PACKAGE_REJECTION_BINARY_DIR}
+      -Dexpect_configure_failure=ON
+      -P ${CMAKE_SOURCE_DIR}/tests/cmake/run_find_package.cmake)
+endif()
+
 # ORP127 T10: submodule (add_subdirectory) external-consumer smoke test. Covers
 # the co-development consumption path (FourTrack's choice) whose failure mode
 # differs from find_package — missing add_subdirectory target/alias visibility

--- a/tests/cmake/run_find_package.cmake
+++ b/tests/cmake/run_find_package.cmake
@@ -42,6 +42,14 @@ endif()
 execute_process(
   COMMAND "${CMAKE_COMMAND}" ${configure_args}
   RESULT_VARIABLE configure_result)
+if(DEFINED expect_configure_failure AND expect_configure_failure)
+  if(NOT configure_result)
+    message(FATAL_ERROR
+      "Configure unexpectedly accepted incompatible SDK version ${required_version}")
+  endif()
+  message(STATUS "Configure correctly rejected incompatible SDK version ${required_version}")
+  return()
+endif()
 if(configure_result)
   message(FATAL_ERROR "Configure failed with code ${configure_result}")
 endif()

--- a/tests/cmake/run_find_package.cmake
+++ b/tests/cmake/run_find_package.cmake
@@ -41,17 +41,31 @@ endif()
 
 execute_process(
   COMMAND "${CMAKE_COMMAND}" ${configure_args}
-  RESULT_VARIABLE configure_result)
+  RESULT_VARIABLE configure_result
+  OUTPUT_VARIABLE configure_stdout
+  ERROR_VARIABLE configure_stderr)
+string(CONCAT configure_output "${configure_stdout}" "\n" "${configure_stderr}")
+
 if(DEFINED expect_configure_failure AND expect_configure_failure)
   if(NOT configure_result)
     message(FATAL_ERROR
       "Configure unexpectedly accepted incompatible SDK version ${required_version}")
   endif()
+
+  string(FIND "${configure_output}"
+    "compatible with requested version \"${required_version}\""
+    version_rejection_index)
+  if(version_rejection_index EQUAL -1)
+    message(FATAL_ERROR
+      "Configure failed for an unexpected reason:\n${configure_output}")
+  endif()
+
   message(STATUS "Configure correctly rejected incompatible SDK version ${required_version}")
   return()
 endif()
 if(configure_result)
-  message(FATAL_ERROR "Configure failed with code ${configure_result}")
+  message(FATAL_ERROR
+    "Configure failed with code ${configure_result}:\n${configure_output}")
 endif()
 
 execute_process(

--- a/tests/package_runtime_consumer/CMakeLists.txt
+++ b/tests/package_runtime_consumer/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+cmake_minimum_required(VERSION 3.22)
+
+project(orpheus_package_runtime_consumer LANGUAGES CXX)
+
+if(NOT DEFINED ORPHEUS_REQUIRED_VERSION OR ORPHEUS_REQUIRED_VERSION STREQUAL "")
+  message(FATAL_ERROR "ORPHEUS_REQUIRED_VERSION must name the installed SDK version under test")
+endif()
+
+find_package(OrpheusSDK ${ORPHEUS_REQUIRED_VERSION} CONFIG REQUIRED)
+
+add_executable(orpheus_package_runtime_consumer main.cpp)
+target_compile_features(orpheus_package_runtime_consumer PRIVATE cxx_std_20)
+target_link_libraries(orpheus_package_runtime_consumer PRIVATE Orpheus::transport)
+
+enable_testing()
+add_test(NAME orpheus_package_runtime_consumer COMMAND orpheus_package_runtime_consumer)

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/transport_controller.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+class RecordingCallback final : public orpheus::ITransportCallback {
+public:
+  void onClipStarted(orpheus::ClipHandle handle, orpheus::TransportPosition) override {
+    ++started;
+    lastHandle = handle;
+  }
+
+  void onClipStopped(orpheus::ClipHandle, orpheus::TransportPosition) override {}
+  void onClipLooped(orpheus::ClipHandle, orpheus::TransportPosition) override {}
+  void onBufferUnderrun(orpheus::TransportPosition) override {}
+
+  int started = 0;
+  orpheus::ClipHandle lastHandle = 0;
+};
+
+} // namespace
+
+int main() {
+  constexpr uint32_t kSampleRate = 48000;
+  constexpr orpheus::ClipHandle kHandle = 17;
+  constexpr size_t kFrames = 64;
+
+  auto transport = orpheus::createTransportController(nullptr, kSampleRate);
+  if (!transport) {
+    return 1;
+  }
+
+  const orpheus::TransportRenderConfig config = transport->getRenderConfig();
+  if (config.sampleRate != kSampleRate || config.outputChannels != 2 ||
+      config.maxBlockFrames < kFrames) {
+    return 2;
+  }
+
+  std::vector<std::vector<float>> storage(
+      config.outputChannels, std::vector<float>(kFrames, 1.0f));
+  std::vector<float*> outputs;
+  outputs.reserve(config.outputChannels);
+  for (auto& channel : storage) {
+    outputs.push_back(channel.data());
+  }
+
+  RecordingCallback callback;
+  transport->setCallback(&callback);
+  if (transport->startClip(kHandle) != orpheus::SessionGraphError::OK) {
+    return 3;
+  }
+
+  transport->processAudio(outputs.data(), outputs.size(), kFrames);
+  if (callback.started != 0) {
+    return 4;
+  }
+
+  transport->processCallbacks();
+  if (callback.started != 1 || callback.lastHandle != kHandle) {
+    return 5;
+  }
+
+  for (const auto& channel : storage) {
+    for (float sample : channel) {
+      if (sample != 0.0f) {
+        return 6;
+      }
+    }
+  }
+
+  transport->setCallback(nullptr);
+
+  return 0;
+}

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
+#include <new>
 #include <string>
 #include <thread>
 #include <vector>
@@ -141,8 +142,12 @@ TEST_F(RealtimeHarnessTest, GuardDetectsViolations) {
 
   {
     RtSection section;
-    volatile int* leak = new int(42); // deliberate violation
-    delete leak;                      // second deliberate violation
+    // Use explicit replaceable allocation-function calls rather than a
+    // new-expression: C++ permits new/delete elision in optimized builds even
+    // when the replacement functions have observable side effects.
+    void* allocation = ::operator new(sizeof(int)); // deliberate violation
+    *static_cast<int*>(allocation) = 42;
+    ::operator delete(allocation); // second deliberate violation
   }
 
   EXPECT_EQ(RtGuardState::allocViolations(), 1u) << "operator new inside an RtSection must red";
@@ -151,8 +156,8 @@ TEST_F(RealtimeHarnessTest, GuardDetectsViolations) {
 
   // Outside a section, allocations are not violations.
   RtGuardState::reset();
-  volatile int* fine = new int(7);
-  delete fine;
+  void* allocation = ::operator new(sizeof(int));
+  ::operator delete(allocation);
   EXPECT_EQ(RtGuardState::totalViolations(), 0u);
 }
 

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -180,8 +180,7 @@ TEST_F(TransportControllerTest, PublicInterfaceRendersAndDrainsCallbacks) {
   ASSERT_GE(config.maxBlockFrames, 64u);
 
   constexpr size_t kFrames = 64;
-  std::vector<std::vector<float>> storage(
-      config.outputChannels, std::vector<float>(kFrames, 1.0f));
+  std::vector<std::vector<float>> storage(config.outputChannels, std::vector<float>(kFrames, 1.0f));
   std::vector<float*> outputs;
   outputs.reserve(config.outputChannels);
   for (auto& channel : storage) {

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -3,9 +3,6 @@
 #include <gtest/gtest.h>
 #include <orpheus/transport_controller.h>
 
-// FTR027 §1: concrete controller access for processAudio()/processCallbacks()
-#include "transport/transport_controller.h"
-
 #include <memory>
 #include <vector>
 
@@ -123,7 +120,7 @@ namespace {
 
 // Advance the transport by exactly one second of silence (no active clips —
 // the timeline still moves).
-void advanceOneSecond(TransportController& transport, uint32_t sampleRate) {
+void advanceOneSecond(ITransportController& transport, uint32_t sampleRate) {
   constexpr size_t kBlock = 480;
   std::vector<float> left(kBlock, 0.0f);
   std::vector<float> right(kBlock, 0.0f);
@@ -139,7 +136,7 @@ void advanceOneSecond(TransportController& transport, uint32_t sampleRate) {
 // tempo, not a hardcoded 120 BPM.
 TEST_F(TransportControllerTest, BeatsFollowSessionTempoAtConstruction) {
   m_sessionGraph->set_tempo(90.0);
-  auto transport = std::make_unique<TransportController>(m_sessionGraph.get(), 48000);
+  auto transport = createTransportController(m_sessionGraph.get(), 48000);
 
   advanceOneSecond(*transport, 48000);
 
@@ -153,7 +150,7 @@ TEST_F(TransportControllerTest, BeatsFollowSessionTempoAtConstruction) {
 // FTR027 §1: a set_tempo() change after construction reaches beats on the
 // next processCallbacks() pump.
 TEST_F(TransportControllerTest, BeatsTrackLiveTempoChange) {
-  auto transport = std::make_unique<TransportController>(m_sessionGraph.get(), 48000);
+  auto transport = createTransportController(m_sessionGraph.get(), 48000);
 
   advanceOneSecond(*transport, 48000);
 
@@ -168,6 +165,45 @@ TEST_F(TransportControllerTest, BeatsTrackLiveTempoChange) {
   transport->processCallbacks(); // control-thread pump republishes the tempo
 
   EXPECT_DOUBLE_EQ(transport->getCurrentPosition().beats, 2.5);
+}
+
+TEST_F(TransportControllerTest, PublicInterfaceReportsRenderContract) {
+  const TransportRenderConfig config = m_transport->getRenderConfig();
+  EXPECT_EQ(config.sampleRate, 48000u);
+  EXPECT_EQ(config.outputChannels, 2u);
+  EXPECT_EQ(config.maxBlockFrames, 2048u);
+}
+
+TEST_F(TransportControllerTest, PublicInterfaceRendersAndDrainsCallbacks) {
+  const TransportRenderConfig config = m_transport->getRenderConfig();
+  ASSERT_GE(config.outputChannels, 2u);
+  ASSERT_GE(config.maxBlockFrames, 64u);
+
+  constexpr size_t kFrames = 64;
+  std::vector<std::vector<float>> storage(
+      config.outputChannels, std::vector<float>(kFrames, 1.0f));
+  std::vector<float*> outputs;
+  outputs.reserve(config.outputChannels);
+  for (auto& channel : storage) {
+    outputs.push_back(channel.data());
+  }
+
+  TestCallback callback;
+  m_transport->setCallback(&callback);
+  ASSERT_EQ(m_transport->startClip(42), SessionGraphError::OK);
+
+  m_transport->processAudio(outputs.data(), outputs.size(), kFrames);
+  EXPECT_EQ(callback.startCount, 0);
+  m_transport->processCallbacks();
+
+  EXPECT_EQ(callback.startCount, 1);
+  EXPECT_EQ(callback.lastHandle, 42u);
+  EXPECT_EQ(m_transport->getCurrentPosition().samples, static_cast<int64_t>(kFrames));
+  for (const auto& channel : storage) {
+    for (float sample : channel) {
+      EXPECT_FLOAT_EQ(sample, 0.0f);
+    }
+  }
 }
 
 TEST_F(TransportControllerTest, Callback) {


### PR DESCRIPTION
## Summary
- publish `TransportRenderConfig`, `processAudio`, and `processCallbacks` on `ITransportController`
- remove package-consumer dependence on SDK-private transport headers
- enforce pre-1.0 same-minor installed-package compatibility
- prepare SDK 0.4.0 release metadata and ORP143 downstream handoff

## Verification
- Debug CTest: 139/139 passed
- Release CTest: 139/139 passed
- focused transport/package/version gates passed
- clean-prefix installed consumer configured, built, and ran using only `<orpheus/transport_controller.h>` and `Orpheus::transport`
- CPack archive generated and inspected for 0.4.0 metadata and public declarations
- Codex 5.4 review: no discrete correctness issues