### PR TITLE
feat(routing): add multichannel transport and output buses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-14
+
+Release of the explicit multichannel source, logical group-bus, and physical
+output-routing contracts required by broadcast playout hosts. The pre-1.0 minor
+version advances because public transport/clip metadata structures gained
+source-channel fields and interface implementers must provide the group-bus
+route methods.
+
+### Added
+
+- `TransportConfig` now declares output width, maximum source lanes, block
+  capacity, voice capacity, and the source-channel policy used by the immutable
+  renderer.
+- `ClipMetadata` publishes logical routing group, explicit `ChannelLayout`, and
+  a fixed eight-speaker patch. The transport validates the declared layout
+  against the decoded file before atomically committing metadata.
+- `ITransportController::{setGroupOutputBus(), getGroupOutputBus()}` routes a
+  logical group to one contiguous physical output bus without rebuilding the
+  transport.
+- CoreAudio, WASAPI, and dummy drivers publish and render their configured
+  multichannel output width. Scene snapshots preserve group/output routing and
+  source-channel metadata.
+
+### Changed
+
+- Transport voices render up to eight discrete planar source lanes into the
+  routing matrix instead of forcing every decoded file through a stereo pair.
+  Named group buses can share, isolate, or span physical outputs without a
+  hidden fold-down.
+- Installed-package consumers and examples construct the public
+  `TransportConfig` explicitly and exercise the same transport render contract
+  as source-tree hosts.
+
 ### Fixed
 
+- Channel-solo and group-solo are independent domains. Soloing a group no
+  longer mutes every source channel before group summing, and soloing a channel
+  no longer mutes every logical group after summing.
 - A stopping loop no longer wraps from its OUT point back to IN. Stop fades now
   complete across the loop boundary, so host-level group chokes and Stop All
   cannot leave a looping voice active indefinitely.
+
+### Verification
+
+- The complete 147-test SDK suite passes, including eight-output
+  channel-order/render-hash, group-route, scene, device-swap, driver, and
+  installed-package consumer coverage.
+- Real multichannel CoreAudio hardware remains a downstream release gate; this
+  release does not infer hardware validation from dummy-driver buffers.
 
 ## [0.4.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A stopping loop no longer wraps from its OUT point back to IN. Stop fades now
+  complete across the loop boundary, so host-level group chokes and Stop All
+  cannot leave a looping voice active indefinitely.
+
 ## [0.4.0] - 2026-07-14
 
 Release of the public transport-rendering contract required by host applications

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.4.0 LANGUAGES CXX)
+project(orpheus VERSION 0.5.0 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.4.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.5.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -4,7 +4,7 @@ This index catalogs public entry points exposed by the Orpheus SDK workspace. Up
 notable APIs are added.
 
 **Last Updated:** 2026-07-09 (ORP133 truth pass)
-**SDK Version:** 0.4.0 — the authoritative version is `project(orpheus VERSION ...)`
+**SDK Version:** 0.5.0 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.4.0
+**SDK Version:** 0.5.0
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.4.0
+**SDK Version:** 0.5.0

--- a/examples/multi_clip_trigger/multi_clip_trigger.cpp
+++ b/examples/multi_clip_trigger/multi_clip_trigger.cpp
@@ -21,10 +21,8 @@ public:
   explicit MultiClipAudioCallback(orpheus::ITransportController* transport)
       : transport_(transport) {}
 
-  void processAudio(const float** /*inputs*/, float** outputs, size_t num_channels,
-                    size_t num_frames) override {
-    transport_->processAudio(outputs, static_cast<uint32_t>(num_channels),
-                             static_cast<uint32_t>(num_frames));
+  void processAudio(const orpheus::AudioProcessBlock& block) noexcept override {
+    transport_->processAudio(block.output_buffers, block.num_output_channels, block.num_frames);
   }
 
 private:
@@ -120,7 +118,7 @@ int main(int argc, char** argv) {
   config.buffer_size = 512;
   config.num_outputs = 2;
 
-  auto transport = orpheus::createTransportController(nullptr, config.sample_rate);
+  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(config.sample_rate)});
 
   if (transport->initialize(config) != orpheus::SessionGraphError::OK) {
     std::cerr << "Failed to initialize transport" << std::endl;

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.4.0
+**SDK Version:** 0.5.0

--- a/examples/offline_renderer/offline_renderer.cpp
+++ b/examples/offline_renderer/offline_renderer.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
   double max_duration = 0.0;
 
   // Create transport controller
-  auto transport = orpheus::createTransportController(nullptr, config.sample_rate);
+  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(config.sample_rate)});
 
   orpheus::TransportConfig transport_config;
   transport_config.sample_rate = config.sample_rate;

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.4.0
+**SDK Version:** 0.5.0

--- a/examples/simple_player/simple_player.cpp
+++ b/examples/simple_player/simple_player.cpp
@@ -16,11 +16,8 @@ class SimpleAudioCallback : public orpheus::IAudioCallback {
 public:
   explicit SimpleAudioCallback(orpheus::ITransportController* transport) : transport_(transport) {}
 
-  void processAudio(const float** /*inputs*/, float** outputs, size_t num_channels,
-                    size_t num_frames) override {
-    // Let transport fill the output buffers
-    transport_->processAudio(outputs, static_cast<uint32_t>(num_channels),
-                             static_cast<uint32_t>(num_frames));
+  void processAudio(const orpheus::AudioProcessBlock& block) noexcept override {
+    transport_->processAudio(block.output_buffers, block.num_output_channels, block.num_frames);
   }
 
 private:
@@ -54,7 +51,7 @@ int main(int argc, char** argv) {
   config.buffer_size = 512;
   config.num_outputs = 2;
 
-  auto transport = orpheus::createTransportController(nullptr, config.sample_rate);
+  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(config.sample_rate)});
 
   if (transport->initialize(config) != orpheus::SessionGraphError::OK) {
     std::cerr << "Failed to initialize transport" << std::endl;

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -55,6 +55,8 @@ struct AudioDriverCapabilities {
   uint32_t max_input_channels = 0;
   std::vector<uint32_t> native_sample_rates;
   std::vector<uint32_t> native_buffer_sizes;
+  std::vector<std::string> input_channel_ids;
+  std::vector<std::string> output_channel_ids;
   bool supports_exclusive_mode = false;
   bool supports_shared_mode = true;
   bool supports_device_hot_swap = false;
@@ -63,19 +65,38 @@ struct AudioDriverCapabilities {
   bool reports_hardware_latency = false;
 };
 
+/// One realtime audio callback block.
+///
+/// Channel buffers are planar. Input and output channel counts are independent:
+/// hosts must not infer one from the other. device_sample_position identifies
+/// the first frame in the block on the backend timeline. A value of zero means
+/// the backend cannot provide a position. host_time_nanoseconds is a monotonic
+/// host-clock timestamp for that frame; zero likewise means unavailable.
+/// A discontinuity marks a device reset, gap, or non-contiguous stream position.
+struct AudioProcessBlock {
+  const float* const* input_buffers = nullptr;
+  float* const* output_buffers = nullptr;
+  uint16_t num_input_channels = 0;
+  uint16_t num_output_channels = 0;
+  uint32_t num_frames = 0;
+  uint64_t device_sample_position = 0;
+  uint64_t host_time_nanoseconds = 0;
+  bool discontinuity = false;
+};
+
+
 /// Audio driver callback interface
 /// Called on the audio thread - must be lock-free
 class IAudioCallback {
 public:
   virtual ~IAudioCallback() = default;
 
-  /// Process audio callback (audio thread)
-  /// @param input_buffers Array of input channel buffers (may be nullptr if num_inputs == 0)
-  /// @param output_buffers Array of output channel buffers (never nullptr)
-  /// @param num_channels Number of channels (matches config)
-  /// @param num_frames Number of frames to process
-  virtual void processAudio(const float** input_buffers, float** output_buffers,
-                            size_t num_channels, size_t num_frames) = 0;
+  /// Process one planar audio block on the backend realtime thread.
+  ///
+  /// The block and its pointed-to buffers remain valid only for this call.
+  /// Implementations must not allocate, lock, block, perform I/O, or retain any
+  /// pointer from the block.
+  virtual void processAudio(const AudioProcessBlock& block) noexcept = 0;
 
   /// Realtime-safe active-voice diagnostic supplied by the host callback.
   virtual uint32_t activeClipCount() const noexcept {

--- a/include/orpheus/channel_format.h
+++ b/include/orpheus/channel_format.h
@@ -12,6 +12,7 @@ namespace orpheus {
 /// Standard channel layouts (ST2110/SMPTE aligned)
 /// Values match channel count for bed formats
 enum class ChannelLayout : uint8_t {
+  Unspecified = 0,
   Mono = 1,
   Stereo = 2,
   LCR = 3,          // Left, Center, Right (film/theater)
@@ -22,6 +23,8 @@ enum class ChannelLayout : uint8_t {
   Atmos_5_1_2 = 8,  // 5.1 + 2 height (Ltf, Rtf)
   Atmos_5_1_4 = 10, // 5.1 + 4 height (Ltf, Rtf, Ltb, Rtb)
   Atmos_7_1_4 = 12, // 7.1 + 4 height
+  SMPTE_51_ST = 108, // ST 2110-30 compound order: L, R, C, LFE, Ls, Rs, Lo, Ro
+  SMPTE_51_LTRT = 109, // Matrix-stereo alternative: L, R, C, LFE, Ls, Rs, Lt, Rt
 
   // Scene-based formats (ambisonics)
   Ambisonics_FOA = 4,   // First-order: W, Y, Z, X (ACN/SN3D)
@@ -44,6 +47,12 @@ enum class Speaker : uint8_t {
   // Rear layer (7.1+)
   Lb = 6, // Left Back
   Rb = 7, // Right Back
+
+  // Discrete stereo downmix pair used by SMPTE2110.(51,ST)
+  Lo = 15, // Left only
+  Ro = 16, // Right only
+  Lt = 17, // Left total (matrix-encoded)
+  Rt = 18, // Right total (matrix-encoded)
 
   // Height layer (Atmos/Auro)
   Ltf = 8,  // Left Top Front
@@ -79,6 +88,15 @@ struct ChannelFormat {
   std::array<Speaker, MAX_FORMAT_CHANNELS> channel_map; // Speaker per channel
   std::string name;
 
+  ChannelFormat() : layout(ChannelLayout::Unspecified), num_channels(0), channel_map{}, name() {
+    channel_map.fill(Speaker::None);
+  }
+
+  /// True only after a host or parser has established an explicit layout.
+  [[nodiscard]] bool isSpecified() const {
+    return layout != ChannelLayout::Unspecified && num_channels > 0;
+  }
+
   /// Check if format is bed-based (discrete speaker feeds)
   [[nodiscard]] bool isBedFormat() const {
     return layout != ChannelLayout::Ambisonics_FOA && layout != ChannelLayout::Ambisonics_HOA2 &&
@@ -101,8 +119,12 @@ struct ChannelFormat {
   static ChannelFormat Mono();
   static ChannelFormat Stereo();
   static ChannelFormat LCR();
+  static ChannelFormat Quad();
+  static ChannelFormat Surround50();
   static ChannelFormat Surround51();
   static ChannelFormat Surround71();
+  static ChannelFormat SMPTE51Stereo();
+  static ChannelFormat SMPTE51MatrixStereo();
   static ChannelFormat Atmos714();
   static ChannelFormat Ambisonics(uint8_t order);
   static ChannelFormat Custom(uint8_t numChannels);

--- a/include/orpheus/routing_matrix.h
+++ b/include/orpheus/routing_matrix.h
@@ -23,8 +23,12 @@ class IRoutingCallback;
 // Constants
 // ============================================================================
 
-/// Special value indicating channel is not assigned to any group
-constexpr uint8_t UNASSIGNED_GROUP = 255;
+using RoutingChannelIndex = uint16_t;
+using RoutingGroupIndex = uint16_t;
+using RoutingOutputIndex = uint16_t;
+
+/// Special value indicating channel is not assigned to any group.
+constexpr RoutingGroupIndex UNASSIGNED_GROUP = UINT16_MAX;
 
 /// FTR028: Internal processing-slice size (frames) used by processRouting().
 ///
@@ -105,8 +109,9 @@ enum class DownmixPolicy : uint8_t {
 
 /// Channel strip configuration (like a console channel)
 struct ChannelConfig {
-  std::string name;    ///< Channel name (e.g., "Kick", "Snare", "Music Bed 1")
-  uint8_t group_index; ///< Assigned group (0-15, or 255 for unassigned)
+  std::string name;               ///< Human-readable channel name
+  RoutingGroupIndex group_index;  ///< Assigned group, or UNASSIGNED_GROUP
+  RoutingOutputIndex output_channel; ///< Discrete destination within the group bus
   float gain_db;       ///< Channel gain in dB (-inf to +12 dB)
   float pan;           ///< Pan position (-1.0 = hard left, 0.0 = center, +1.0 = hard right)
   bool mute;           ///< Mute flag
@@ -115,8 +120,8 @@ struct ChannelConfig {
 
   /// Default constructor
   ChannelConfig()
-      : name(""), group_index(0), gain_db(0.0f), pan(0.0f), mute(false), solo(false),
-        color(0xFFFFFFFF) {}
+      : name(""), group_index(0), output_channel(0), gain_db(0.0f), pan(0.0f), mute(false),
+        solo(false), color(0xFFFFFFFF) {}
 };
 
 /// Group (bus) configuration (like a console subgroup)
@@ -125,19 +130,21 @@ struct GroupConfig {
   float gain_db;      ///< Group gain in dB (-inf to +12 dB)
   bool mute;          ///< Mute flag
   bool solo;          ///< Solo flag (groups can be solo'd too)
-  uint8_t output_bus; ///< Output bus assignment (0 = master, 1-15 = aux/submix)
-  uint32_t color;     ///< UI color hint (RGBA)
+  RoutingOutputIndex output_start; ///< First physical output for this logical bus
+  uint16_t output_width;           ///< Number of routed channels in this bus
+  uint32_t color;                  ///< UI color hint (RGBA)
 
   /// Default constructor
   GroupConfig()
-      : name(""), gain_db(0.0f), mute(false), solo(false), output_bus(0), color(0xFFFFFFFF) {}
+      : name(""), gain_db(0.0f), mute(false), solo(false), output_start(0),
+        output_width(2), color(0xFFFFFFFF) {}
 };
 
 /// Routing matrix configuration (complete topology)
 struct RoutingConfig {
-  uint8_t num_channels; ///< Number of input channels (clips) [1-64]
-  uint8_t num_groups;   ///< Number of groups (buses) [1-16]
-  uint8_t num_outputs;  ///< Number of output channels [2-32]
+  RoutingChannelIndex num_channels; ///< Number of input routing lanes [1-256]
+  RoutingGroupIndex num_groups;     ///< Number of logical groups [1-32]
+  RoutingOutputIndex num_outputs;   ///< Number of output channels [1-32]
 
   SoloMode solo_mode;         ///< Solo behavior
   MeteringMode metering_mode; ///< Metering algorithm
@@ -274,43 +281,50 @@ public:
 
   /// Assign channel to group (bus assignment)
   /// @param channel_index Channel index [0, num_channels)
-  /// @param group_index Group index [0, num_groups) or 255 for unassigned
+  /// @param group_index Group index [0, num_groups) or UNASSIGNED_GROUP
   /// @return Error code
   /// @note Lock-free update, takes effect on next audio callback
-  virtual SessionGraphError setChannelGroup(uint8_t channel_index, uint8_t group_index) = 0;
+  virtual SessionGraphError setChannelGroup(RoutingChannelIndex channel_index,
+                                            RoutingGroupIndex group_index) = 0;
+
+  /// Atomically assign one source lane to a logical bus and hardware output.
+  /// Audio-thread-safe: updates fixed-capacity POD routing state only.
+  virtual SessionGraphError setChannelRoute(RoutingChannelIndex channel_index,
+                                            RoutingGroupIndex group_index,
+                                            RoutingOutputIndex output_index) = 0;
 
   /// Set channel gain
   /// @param channel_index Channel index [0, num_channels)
   /// @param gain_db Gain in dB [-inf, +12.0]
   /// @return Error code
   /// @note Smoothed over gain_smoothing_ms to prevent clicks
-  virtual SessionGraphError setChannelGain(uint8_t channel_index, float gain_db) = 0;
+  virtual SessionGraphError setChannelGain(RoutingChannelIndex channel_index, float gain_db) = 0;
 
   /// Set channel pan (stereo positioning)
   /// @param channel_index Channel index [0, num_channels)
   /// @param pan Pan position [-1.0 = hard left, 0.0 = center, +1.0 = hard right]
   /// @return Error code
   /// @note Smoothed pan law: constant-power (-3 dB at center)
-  virtual SessionGraphError setChannelPan(uint8_t channel_index, float pan) = 0;
+  virtual SessionGraphError setChannelPan(RoutingChannelIndex channel_index, float pan) = 0;
 
   /// Set channel mute
   /// @param channel_index Channel index [0, num_channels)
   /// @param mute Mute flag
   /// @return Error code
-  virtual SessionGraphError setChannelMute(uint8_t channel_index, bool mute) = 0;
+  virtual SessionGraphError setChannelMute(RoutingChannelIndex channel_index, bool mute) = 0;
 
   /// Set channel solo
   /// @param channel_index Channel index [0, num_channels)
   /// @param solo Solo flag
   /// @return Error code
   /// @note Behavior depends on solo_mode (SIP, AFL, PFL, Destructive)
-  virtual SessionGraphError setChannelSolo(uint8_t channel_index, bool solo) = 0;
+  virtual SessionGraphError setChannelSolo(RoutingChannelIndex channel_index, bool solo) = 0;
 
   /// Configure channel (batch update for efficiency)
   /// @param channel_index Channel index [0, num_channels)
   /// @param config Channel configuration
   /// @return Error code
-  virtual SessionGraphError configureChannel(uint8_t channel_index,
+  virtual SessionGraphError configureChannel(RoutingChannelIndex channel_index,
                                              const ChannelConfig& config) = 0;
 
   // ========================================================================
@@ -322,25 +336,32 @@ public:
   /// @param gain_db Gain in dB [-inf, +12.0]
   /// @return Error code
   /// @note Smoothed over gain_smoothing_ms
-  virtual SessionGraphError setGroupGain(uint8_t group_index, float gain_db) = 0;
+  virtual SessionGraphError setGroupGain(RoutingGroupIndex group_index, float gain_db) = 0;
 
   /// Set group mute
   /// @param group_index Group index [0, num_groups)
   /// @param mute Mute flag
   /// @return Error code
-  virtual SessionGraphError setGroupMute(uint8_t group_index, bool mute) = 0;
+  virtual SessionGraphError setGroupMute(RoutingGroupIndex group_index, bool mute) = 0;
 
   /// Set group solo
   /// @param group_index Group index [0, num_groups)
   /// @param solo Solo flag
   /// @return Error code
-  virtual SessionGraphError setGroupSolo(uint8_t group_index, bool solo) = 0;
+  virtual SessionGraphError setGroupSolo(RoutingGroupIndex group_index, bool solo) = 0;
 
   /// Configure group (batch update)
   /// @param group_index Group index [0, num_groups)
   /// @param config Group configuration
   /// @return Error code
-  virtual SessionGraphError configureGroup(uint8_t group_index, const GroupConfig& config) = 0;
+  virtual SessionGraphError configureGroup(RoutingGroupIndex group_index,
+                                           const GroupConfig& config) = 0;
+
+  /// Atomically route a logical group bus to a contiguous physical output range.
+  virtual SessionGraphError
+  setGroupOutputRoute(RoutingGroupIndex group_index,
+                      RoutingOutputIndex output_start,
+                      uint16_t output_width) = 0;
 
   // ========================================================================
   // Master Output Configuration (UI Thread, Lock-Free)
@@ -367,22 +388,22 @@ public:
   /// Check if channel is muted (considering solo logic)
   /// @param channel_index Channel index [0, num_channels)
   /// @return True if effectively muted
-  virtual bool isChannelMuted(uint8_t channel_index) const = 0;
+  virtual bool isChannelMuted(RoutingChannelIndex channel_index) const = 0;
 
   /// Check if group is muted (considering solo logic)
   /// @param group_index Group index [0, num_groups)
   /// @return True if effectively muted
-  virtual bool isGroupMuted(uint8_t group_index) const = 0;
+  virtual bool isGroupMuted(RoutingGroupIndex group_index) const = 0;
 
   /// Get channel meter
   /// @param channel_index Channel index [0, num_channels)
   /// @return Audio meter (peak, RMS, clipping)
-  virtual AudioMeter getChannelMeter(uint8_t channel_index) const = 0;
+  virtual AudioMeter getChannelMeter(RoutingChannelIndex channel_index) const = 0;
 
   /// Get group meter
   /// @param group_index Group index [0, num_groups)
   /// @return Audio meter
-  virtual AudioMeter getGroupMeter(uint8_t group_index) const = 0;
+  virtual AudioMeter getGroupMeter(RoutingGroupIndex group_index) const = 0;
 
   /// Get master meter
   /// @return Audio meter
@@ -437,7 +458,7 @@ public:
   ///       without the host needing to cap its render block size. Metering
   ///       reflects the final slice of the call.
   virtual SessionGraphError processRouting(const float* const* channel_inputs,
-                                           float** master_output, uint32_t num_frames) = 0;
+                                           float* const* master_output, uint32_t num_frames) = 0;
 
   /// FTR028: Largest number of frames processed in a single internal slice.
   ///
@@ -462,21 +483,21 @@ public:
   /// Called when channel gain changes
   /// @param channel_index Channel that changed
   /// @param gain_db New gain value
-  virtual void onChannelGainChanged(uint8_t channel_index, float gain_db) = 0;
+  virtual void onChannelGainChanged(RoutingChannelIndex channel_index, float gain_db) = 0;
 
   /// Called when group gain changes
   /// @param group_index Group that changed
   /// @param gain_db New gain value
-  virtual void onGroupGainChanged(uint8_t group_index, float gain_db) = 0;
+  virtual void onGroupGainChanged(RoutingGroupIndex group_index, float gain_db) = 0;
 
   /// Called when solo state changes
   /// @param active True if any channel/group is solo'd
   virtual void onSoloStateChanged(bool active) = 0;
 
   /// Called when clipping detected
-  /// @param channel_index Channel that clipped (255 for master)
+  /// @param channel_index Channel that clipped (UNASSIGNED_GROUP for master)
   /// @param peak_db Peak level in dBFS
-  virtual void onClippingDetected(uint8_t channel_index, float peak_db) = 0;
+  virtual void onClippingDetected(RoutingChannelIndex channel_index, float peak_db) = 0;
 };
 
 // ============================================================================

--- a/include/orpheus/scene_manager.h
+++ b/include/orpheus/scene_manager.h
@@ -44,7 +44,7 @@ struct SceneSnapshot {
   std::vector<ClipHandle> assignedClips; ///< Clip handles per button/position
 
   // Routing configuration (from Feature 1: Routing Matrix)
-  std::vector<uint8_t> clipGroups; ///< Group assignment per clip (0-3, or 255 for unassigned)
+  std::vector<RoutingGroupIndex> clipGroups; ///< Group assignment per clip or UNASSIGNED_GROUP
   std::vector<float> groupGains;   ///< Gain per Clip Group in dB (-inf to +12.0)
 
   /// Default constructor

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -4,7 +4,10 @@
 #include <orpheus/errors.h>
 #include <orpheus/export.h>
 #include <orpheus/realtime_telemetry.h>
+#include <orpheus/channel_format.h>
+#include <orpheus/routing_matrix.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -19,7 +22,6 @@ namespace core {
 class SessionGraph;
 } // namespace core
 
-class IRoutingMatrix; // OCC155 Ask #3: public routing-matrix accessor
 
 using ClipHandle = uint64_t;
 
@@ -71,16 +73,28 @@ struct TransportPosition {
   double beats;    ///< Derived: seconds * session tempo (SessionGraph::tempo) / 60.0
 };
 
-/// Immutable capacities and current output shape for the transport renderer.
+
+/// Immutable construction contract for the transport renderer.
 ///
-/// Hosts query this on the control thread before attaching an audio driver.
-/// sampleRate and maxBlockFrames are fixed for the controller lifetime.
-/// outputChannels is the controller's configured output count and must match the
-/// number of writable output buffers supplied to processAudio().
-struct TransportRenderConfig {
-  uint32_t sampleRate = 0;
-  uint32_t outputChannels = 0;
-  uint32_t maxBlockFrames = 0;
+/// All capacities are validated by createTransportController() and remain fixed
+/// for the controller lifetime. outputChannels is the exact number of writable
+/// planar buffers required by processAudio(). maxSourceChannels is the largest
+/// registered file width accepted by the renderer.
+struct TransportConfig {
+  uint32_t sampleRate = 48000;
+  uint32_t outputChannels = 2;
+  uint32_t maxBlockFrames = 2048;
+  uint32_t maxActiveVoices = 32;
+  uint32_t numGroups = 4;
+  uint32_t maxSourceChannels = 8;
+  SourceChannelPolicy sourceChannelPolicy = SourceChannelPolicy::Discrete;
+};
+
+struct OutputBusRoute {
+  RoutingOutputIndex outputStart = 0;
+  uint16_t channelCount = 2;
+
+  bool operator==(const OutputBusRoute&) const = default;
 };
 
 /// Clip metadata for batch updates
@@ -96,6 +110,12 @@ struct ClipMetadata {
   bool stopOthersOnPlay = false;              ///< true = stop other clips on play
   float gainDb = 0.0f;                        ///< Gain in decibels (0 = unity)
   VoiceMode voiceMode = VoiceMode::Polyphonic; ///< Voice allocation policy (ORP127 G5)
+  RoutingGroupIndex routingGroup = 0;          ///< Logical bus assignment
+  ChannelLayout sourceLayout = ChannelLayout::Unspecified; ///< Explicit source channel meaning
+  uint8_t speakerPatchSize = 0; ///< Number of valid entries in speakerPatch
+  std::array<Speaker, 8> speakerPatch = {
+      Speaker::None, Speaker::None, Speaker::None, Speaker::None,
+      Speaker::None, Speaker::None, Speaker::None, Speaker::None};
 };
 
 /// Session-level default metadata for new clips.
@@ -555,6 +575,14 @@ public:
   /// Thread-safe: Can be called from any thread
   virtual std::optional<ClipMetadata> getClipMetadata(ClipHandle handle) const = 0;
 
+  /// Route one logical clip group to a contiguous physical output bus.
+  virtual SessionGraphError setGroupOutputBus(
+      RoutingGroupIndex group, const OutputBusRoute& route) = 0;
+
+  /// Query the current physical destination of a logical clip group.
+  virtual std::optional<OutputBusRoute>
+  getGroupOutputBus(RoutingGroupIndex group) const = 0;
+
   /// Set session-level default metadata for new clips
   ///
   /// @param defaults Default metadata structure
@@ -783,13 +811,13 @@ public:
   /// Hosts must not retain the pointer after destroying the controller.
   virtual RealtimeTelemetry* getRealtimeTelemetry() noexcept = 0;
 
-  /// Query the public audio-render contract.
+  /// Query the immutable audio-render contract.
   ///
   /// Control-thread query. The returned value is a copy; no SDK-owned storage
-  /// escapes. In v0.4.0 the transport's routing topology is fixed after
-  /// construction: hosts must not reinitialize the matrix returned by
-  /// getRoutingMatrix() while this controller is in use.
-  virtual TransportRenderConfig getRenderConfig() const noexcept = 0;
+  /// escapes. The transport's capacities and routing topology are fixed after
+  /// construction: hosts must not reinitialize the routing matrix while this
+  /// controller is in use.
+  virtual TransportConfig getRenderConfig() const noexcept = 0;
 
   /// Render one transport block into planar output buffers.
   ///
@@ -800,7 +828,7 @@ public:
   /// getRenderConfig().maxBlockFrames frames per call.
   ///
   /// Real-time contract: no allocation, locks, blocking, I/O, or host callbacks.
-  virtual void processAudio(float** outputBuffers, size_t numChannels,
+  virtual void processAudio(float* const* outputBuffers, size_t numChannels,
                             size_t numFrames) noexcept = 0;
 
   /// Drain pending transport events on the control/message thread.
@@ -813,12 +841,12 @@ public:
   virtual void processCallbacks() = 0;
 };
 
-/// Create a transport controller instance
+/// Create a transport controller with an immutable render contract.
 ///
 /// @param sessionGraph The session graph containing clip metadata
-/// @param sampleRate Audio sample rate (e.g., 48000)
-/// @return Unique pointer to transport controller
+/// @param config Validated renderer capacities and output shape
+/// @return Controller, or nullptr when any capacity is unsupported
 ORPHEUS_API std::unique_ptr<ITransportController>
-createTransportController(core::SessionGraph* sessionGraph, uint32_t sampleRate);
+createTransportController(core::SessionGraph* sessionGraph, const TransportConfig& config);
 
 } // namespace orpheus

--- a/src/core/audio_io/dummy_audio_driver.cpp
+++ b/src/core/audio_io/dummy_audio_driver.cpp
@@ -124,6 +124,14 @@ AudioDriverCapabilities DummyAudioDriver::getCapabilities() const {
   caps.max_input_channels = m_config.num_inputs;
   caps.native_sample_rates.push_back(m_config.sample_rate);
   caps.native_buffer_sizes.push_back(m_config.buffer_size);
+  const std::string endpoint =
+      m_config.device_id.empty() ? "dummy:default" : m_config.device_id;
+  for (uint16_t channel = 0; channel < m_config.num_inputs; ++channel) {
+    caps.input_channel_ids.push_back(endpoint + ":input:" + std::to_string(channel));
+  }
+  for (uint16_t channel = 0; channel < m_config.num_outputs; ++channel) {
+    caps.output_channel_ids.push_back(endpoint + ":output:" + std::to_string(channel));
+  }
   caps.supports_exclusive_mode = false;
   caps.supports_shared_mode = true;
   caps.supports_device_hot_swap = false;
@@ -142,6 +150,9 @@ void DummyAudioDriver::audioThreadMain() {
       static_cast<int64_t>(buffer_duration_sec * 1e6 * 0.95) // 95% to account for jitter
   );
 
+  uint64_t stream_position = 0;
+  bool discontinuity = true;
+
   while (!m_should_stop.load(std::memory_order_acquire)) {
     // Clear input buffers (simulate silence from input device)
     for (auto& buffer : m_input_buffer_storage) {
@@ -155,10 +166,20 @@ void DummyAudioDriver::audioThreadMain() {
 
     // Call audio callback (with safety check for shutdown race)
     if (m_callback && m_running.load(std::memory_order_acquire)) {
-      const float** input_ptrs = m_config.num_inputs > 0 ? m_input_ptrs.data() : nullptr;
-
-      m_callback->processAudio(input_ptrs, m_output_ptrs.data(), m_config.num_outputs,
-                               m_config.buffer_size);
+      const auto now = std::chrono::steady_clock::now().time_since_epoch();
+      AudioProcessBlock block;
+      block.input_buffers = m_config.num_inputs > 0 ? m_input_ptrs.data() : nullptr;
+      block.output_buffers = m_output_ptrs.data();
+      block.num_input_channels = m_config.num_inputs;
+      block.num_output_channels = m_config.num_outputs;
+      block.num_frames = m_config.buffer_size;
+      block.device_sample_position = stream_position;
+      block.host_time_nanoseconds =
+          static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+      block.discontinuity = discontinuity;
+      m_callback->processAudio(block);
+      stream_position += m_config.buffer_size;
+      discontinuity = false;
     }
 
     // Sleep to simulate real-time constraints

--- a/src/core/channel_format.cpp
+++ b/src/core/channel_format.cpp
@@ -60,6 +60,31 @@ ChannelFormat ChannelFormat::LCR() {
   return fmt;
 }
 
+ChannelFormat ChannelFormat::Quad() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Quad;
+  fmt.num_channels = 4;
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::Ls;
+  fmt.channel_map[3] = Speaker::Rs;
+  fmt.name = "Quad";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::Surround50() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::Surround_5_0;
+  fmt.num_channels = 5;
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::Ls;
+  fmt.channel_map[4] = Speaker::Rs;
+  fmt.name = "5.0 Surround";
+  return fmt;
+}
+
 ChannelFormat ChannelFormat::Surround51() {
   ChannelFormat fmt{};
   fmt.layout = ChannelLayout::Surround_5_1;
@@ -91,6 +116,40 @@ ChannelFormat ChannelFormat::Surround71() {
   fmt.channel_map[6] = Speaker::Lb;
   fmt.channel_map[7] = Speaker::Rb;
   fmt.name = "7.1 Surround";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::SMPTE51Stereo() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::SMPTE_51_ST;
+  fmt.num_channels = 8;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.channel_map[6] = Speaker::Lo;
+  fmt.channel_map[7] = Speaker::Ro;
+  fmt.name = "SMPTE 5.1 + Lo/Ro";
+  return fmt;
+}
+
+ChannelFormat ChannelFormat::SMPTE51MatrixStereo() {
+  ChannelFormat fmt{};
+  fmt.layout = ChannelLayout::SMPTE_51_LTRT;
+  fmt.num_channels = 8;
+  fmt.channel_map.fill(Speaker::None);
+  fmt.channel_map[0] = Speaker::L;
+  fmt.channel_map[1] = Speaker::R;
+  fmt.channel_map[2] = Speaker::C;
+  fmt.channel_map[3] = Speaker::LFE;
+  fmt.channel_map[4] = Speaker::Ls;
+  fmt.channel_map[5] = Speaker::Rs;
+  fmt.channel_map[6] = Speaker::Lt;
+  fmt.channel_map[7] = Speaker::Rt;
+  fmt.name = "SMPTE 5.1 + Lt/Rt";
   return fmt;
 }
 

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -26,14 +26,9 @@ RoutingMatrix::~RoutingMatrix() {
 // ============================================================================
 
 SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config) {
-  // Validate configuration
-  if (config.num_channels == 0 || config.num_channels > 64) {
-    return SessionGraphError::InvalidParameter;
-  }
-  if (config.num_groups == 0 || config.num_groups > 16) {
-    return SessionGraphError::InvalidParameter;
-  }
-  if (config.num_outputs < 2 || config.num_outputs > 32) {
+  // Validate fixed-capacity realtime bounds.
+  if (config.num_channels == 0 || config.num_channels > 256 || config.num_groups == 0 ||
+      config.num_groups > 32 || config.num_outputs == 0 || config.num_outputs > 32) {
     return SessionGraphError::InvalidParameter;
   }
 
@@ -60,11 +55,11 @@ SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config) {
       std::make_unique<GainSmoother>(config.sample_rate, config.gain_smoothing_ms);
   m_master_gain_smoother->reset(1.0f); // Unity gain
 
-  // ORP121 A-02: Pre-allocate stereo audio processing buffers
+  // Preallocate every logical group at the configured output width.
   m_group_buffers.clear();
   m_group_buffers.resize(config.num_groups);
   for (auto& buffer : m_group_buffers) {
-    buffer.resize(MAX_BUFFER_SIZE); // Allocates both L and R channels
+    buffer.resize(config.num_outputs, MAX_BUFFER_SIZE);
   }
 
   m_temp_buffer.clear();
@@ -97,7 +92,8 @@ void RoutingMatrix::setCallback(IRoutingCallback* callback) {
 // Channel Configuration
 // ============================================================================
 
-SessionGraphError RoutingMatrix::setChannelGroup(uint8_t channel_index, uint8_t group_index) {
+SessionGraphError RoutingMatrix::setChannelGroup(RoutingChannelIndex channel_index,
+                                                 RoutingGroupIndex group_index) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -117,7 +113,28 @@ SessionGraphError RoutingMatrix::setChannelGroup(uint8_t channel_index, uint8_t 
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setChannelGain(uint8_t channel_index, float gain_db) {
+SessionGraphError RoutingMatrix::setChannelRoute(RoutingChannelIndex channel_index,
+                                                 RoutingGroupIndex group_index,
+                                                 RoutingOutputIndex output_index) {
+  if (!m_initialized.load(std::memory_order_acquire) || channel_index >= m_channels.size()) {
+    return SessionGraphError::InvalidParameter;
+  }
+  if (group_index != UNASSIGNED_GROUP && group_index >= m_groups.size()) {
+    return SessionGraphError::InvalidParameter;
+  }
+  const int configIndex = m_active_config_idx.load(std::memory_order_acquire);
+  if (output_index >= m_config_buffers[configIndex].num_outputs) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  auto& channel = m_channels[channel_index];
+  channel.group_index = group_index;
+  channel.config.group_index = group_index;
+  channel.config.output_channel = output_index;
+  return SessionGraphError::OK;
+}
+
+SessionGraphError RoutingMatrix::setChannelGain(RoutingChannelIndex channel_index, float gain_db) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -142,7 +159,7 @@ SessionGraphError RoutingMatrix::setChannelGain(uint8_t channel_index, float gai
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setChannelPan(uint8_t channel_index, float pan) {
+SessionGraphError RoutingMatrix::setChannelPan(RoutingChannelIndex channel_index, float pan) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -162,7 +179,7 @@ SessionGraphError RoutingMatrix::setChannelPan(uint8_t channel_index, float pan)
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setChannelMute(uint8_t channel_index, bool mute) {
+SessionGraphError RoutingMatrix::setChannelMute(RoutingChannelIndex channel_index, bool mute) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -178,7 +195,7 @@ SessionGraphError RoutingMatrix::setChannelMute(uint8_t channel_index, bool mute
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setChannelSolo(uint8_t channel_index, bool solo) {
+SessionGraphError RoutingMatrix::setChannelSolo(RoutingChannelIndex channel_index, bool solo) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -197,7 +214,7 @@ SessionGraphError RoutingMatrix::setChannelSolo(uint8_t channel_index, bool solo
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::configureChannel(uint8_t channel_index,
+SessionGraphError RoutingMatrix::configureChannel(RoutingChannelIndex channel_index,
                                                   const ChannelConfig& config) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
@@ -216,6 +233,7 @@ SessionGraphError RoutingMatrix::configureChannel(uint8_t channel_index,
 
   m_channels[channel_index].config.name = config.name;
   m_channels[channel_index].config.color = config.color;
+  m_channels[channel_index].config.output_channel = config.output_channel;
 
   return SessionGraphError::OK;
 }
@@ -224,7 +242,7 @@ SessionGraphError RoutingMatrix::configureChannel(uint8_t channel_index,
 // Group Configuration
 // ============================================================================
 
-SessionGraphError RoutingMatrix::setGroupGain(uint8_t group_index, float gain_db) {
+SessionGraphError RoutingMatrix::setGroupGain(RoutingGroupIndex group_index, float gain_db) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -249,7 +267,7 @@ SessionGraphError RoutingMatrix::setGroupGain(uint8_t group_index, float gain_db
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setGroupMute(uint8_t group_index, bool mute) {
+SessionGraphError RoutingMatrix::setGroupMute(RoutingGroupIndex group_index, bool mute) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -265,7 +283,7 @@ SessionGraphError RoutingMatrix::setGroupMute(uint8_t group_index, bool mute) {
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::setGroupSolo(uint8_t group_index, bool solo) {
+SessionGraphError RoutingMatrix::setGroupSolo(RoutingGroupIndex group_index, bool solo) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -284,12 +302,20 @@ SessionGraphError RoutingMatrix::setGroupSolo(uint8_t group_index, bool solo) {
   return SessionGraphError::OK;
 }
 
-SessionGraphError RoutingMatrix::configureGroup(uint8_t group_index, const GroupConfig& config) {
+SessionGraphError RoutingMatrix::configureGroup(RoutingGroupIndex group_index,
+                                                const GroupConfig& config) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
 
   if (group_index >= m_groups.size()) {
+    return SessionGraphError::InvalidParameter;
+  }
+  const auto activeConfig =
+      m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
+  if (config.output_width == 0 ||
+      static_cast<uint32_t>(config.output_start) + config.output_width >
+          activeConfig.num_outputs) {
     return SessionGraphError::InvalidParameter;
   }
 
@@ -299,9 +325,34 @@ SessionGraphError RoutingMatrix::configureGroup(uint8_t group_index, const Group
   setGroupSolo(group_index, config.solo);
 
   m_groups[group_index].config.name = config.name;
-  m_groups[group_index].config.output_bus = config.output_bus;
+  setGroupOutputRoute(group_index, config.output_start, config.output_width);
   m_groups[group_index].config.color = config.color;
 
+  return SessionGraphError::OK;
+}
+
+SessionGraphError RoutingMatrix::setGroupOutputRoute(
+    RoutingGroupIndex group_index, RoutingOutputIndex output_start,
+    uint16_t output_width) {
+  if (!m_initialized.load(std::memory_order_acquire)) {
+    return SessionGraphError::NotInitialized;
+  }
+  if (group_index >= m_groups.size()) {
+    return SessionGraphError::InvalidParameter;
+  }
+  const auto& config =
+      m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
+  if (output_width == 0 ||
+      static_cast<uint32_t>(output_start) + output_width >
+          config.num_outputs) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  auto& group = m_groups[group_index];
+  group.output_start.store(output_start, std::memory_order_release);
+  group.output_width.store(output_width, std::memory_order_release);
+  group.config.output_start = output_start;
+  group.config.output_width = output_width;
   return SessionGraphError::OK;
 }
 
@@ -343,14 +394,14 @@ bool RoutingMatrix::isSoloActive() const {
   return m_solo_active.load(std::memory_order_acquire);
 }
 
-bool RoutingMatrix::isChannelMuted(uint8_t channel_index) const {
+bool RoutingMatrix::isChannelMuted(RoutingChannelIndex channel_index) const {
   if (channel_index >= m_channels.size()) {
     return true;
   }
 
   bool is_muted = m_channels[channel_index].mute.load(std::memory_order_acquire);
   bool is_solo = m_channels[channel_index].solo.load(std::memory_order_acquire);
-  bool solo_active = m_solo_active.load(std::memory_order_acquire);
+  bool solo_active = m_channel_solo_active.load(std::memory_order_acquire);
 
   // If solo is active and this channel is not solo'd, it's effectively muted
   if (solo_active && !is_solo) {
@@ -360,14 +411,14 @@ bool RoutingMatrix::isChannelMuted(uint8_t channel_index) const {
   return is_muted;
 }
 
-bool RoutingMatrix::isGroupMuted(uint8_t group_index) const {
+bool RoutingMatrix::isGroupMuted(RoutingGroupIndex group_index) const {
   if (group_index >= m_groups.size()) {
     return true;
   }
 
   bool is_muted = m_groups[group_index].mute.load(std::memory_order_acquire);
   bool is_solo = m_groups[group_index].solo.load(std::memory_order_acquire);
-  bool solo_active = m_solo_active.load(std::memory_order_acquire);
+  bool solo_active = m_group_solo_active.load(std::memory_order_acquire);
 
   // If solo is active and this group is not solo'd, it's effectively muted
   if (solo_active && !is_solo) {
@@ -377,7 +428,7 @@ bool RoutingMatrix::isGroupMuted(uint8_t group_index) const {
   return is_muted;
 }
 
-AudioMeter RoutingMatrix::getChannelMeter(uint8_t channel_index) const {
+AudioMeter RoutingMatrix::getChannelMeter(RoutingChannelIndex channel_index) const {
   AudioMeter meter;
 
   if (channel_index >= m_channels.size()) {
@@ -396,7 +447,7 @@ AudioMeter RoutingMatrix::getChannelMeter(uint8_t channel_index) const {
   return meter;
 }
 
-AudioMeter RoutingMatrix::getGroupMeter(uint8_t group_index) const {
+AudioMeter RoutingMatrix::getGroupMeter(RoutingGroupIndex group_index) const {
   AudioMeter meter;
 
   if (group_index >= m_groups.size()) {
@@ -474,12 +525,12 @@ SessionGraphError RoutingMatrix::loadSnapshot(const RoutingSnapshot& snapshot) {
 
   // Load channel states
   for (size_t i = 0; i < snapshot.channels.size(); ++i) {
-    configureChannel(static_cast<uint8_t>(i), snapshot.channels[i]);
+    configureChannel(static_cast<RoutingChannelIndex>(i), snapshot.channels[i]);
   }
 
   // Load group states
   for (size_t i = 0; i < snapshot.groups.size(); ++i) {
-    configureGroup(static_cast<uint8_t>(i), snapshot.groups[i]);
+    configureGroup(static_cast<RoutingGroupIndex>(i), snapshot.groups[i]);
   }
 
   // Load master state
@@ -497,13 +548,13 @@ SessionGraphError RoutingMatrix::reset() {
   // Reset all channels to default
   for (size_t i = 0; i < m_channels.size(); ++i) {
     ChannelConfig default_config;
-    configureChannel(static_cast<uint8_t>(i), default_config);
+    configureChannel(static_cast<RoutingChannelIndex>(i), default_config);
   }
 
   // Reset all groups to default
   for (size_t i = 0; i < m_groups.size(); ++i) {
     GroupConfig default_config;
-    configureGroup(static_cast<uint8_t>(i), default_config);
+    configureGroup(static_cast<RoutingGroupIndex>(i), default_config);
   }
 
   // Reset master
@@ -522,7 +573,7 @@ uint32_t RoutingMatrix::maxBlockFrames() const {
 }
 
 SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inputs,
-                                                float** master_output, uint32_t num_frames) {
+                                                float* const* master_output, uint32_t num_frames) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
@@ -540,10 +591,8 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
     int cfg_idx = m_active_config_idx.load(std::memory_order_acquire);
     const RoutingConfig& cfg = m_config_buffers[cfg_idx];
 
-    // Stack-resident pointer scratch (no heap allocation). Sized to the ABI
-    // maxima (64 channels, 32 outputs) so a large channel/output count never
-    // allocates on the audio path.
-    const float* input_slice_ptrs[64];
+    // Fixed stack scratch at the validated realtime maxima.
+    const float* input_slice_ptrs[256];
     float* output_slice_ptrs[32];
 
     uint32_t offset = 0;
@@ -551,11 +600,11 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
       const uint32_t slice =
           std::min<uint32_t>(num_frames - offset, static_cast<uint32_t>(MAX_BUFFER_SIZE));
 
-      for (uint8_t ch = 0; ch < cfg.num_channels; ++ch) {
+      for (RoutingChannelIndex ch = 0; ch < cfg.num_channels; ++ch) {
         const float* in = channel_inputs ? channel_inputs[ch] : nullptr;
         input_slice_ptrs[ch] = in ? (in + offset) : nullptr;
       }
-      for (uint8_t out = 0; out < cfg.num_outputs; ++out) {
+      for (RoutingOutputIndex out = 0; out < cfg.num_outputs; ++out) {
         output_slice_ptrs[out] = master_output[out] + offset;
       }
 
@@ -572,239 +621,163 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
 }
 
 SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel_inputs,
-                                                     float** master_output, uint32_t num_frames) {
+                                                     float* const* master_output,
+                                                     uint32_t num_frames) {
   if (num_frames > MAX_BUFFER_SIZE) {
-    // Defensive: processRouting() never hands us a slice larger than this.
     return SessionGraphError::InvalidParameter;
   }
 
-  // Get active config (lock-free read)
-  int config_idx = m_active_config_idx.load(std::memory_order_acquire);
+  const int config_idx = m_active_config_idx.load(std::memory_order_acquire);
   const RoutingConfig& config = m_config_buffers[config_idx];
 
-  // ========================================================================
-  // Step 1: Clear stereo group buffers (ORP121 A-02)
-  // ========================================================================
-  for (uint8_t grp = 0; grp < config.num_groups; ++grp) {
-    m_group_buffers[grp].clear();
+  for (RoutingGroupIndex group = 0; group < config.num_groups; ++group) {
+    m_group_buffers[group].clear();
   }
 
-  // ========================================================================
-  // Step 2: Process channels → groups (ORP121 A-02/C-04: Stereo with pan law)
-  // ========================================================================
-  // Note: Use Instruments/perf for audio thread profiling, not file I/O
+  for (RoutingChannelIndex channel_index = 0; channel_index < config.num_channels;
+       ++channel_index) {
+    auto& channel = m_channels[channel_index];
+    const RoutingGroupIndex group_index = channel.group_index;
 
-  for (uint8_t ch = 0; ch < config.num_channels; ++ch) {
-    auto& channel = m_channels[ch];
-    uint8_t group_idx = channel.group_index;
-
-    // Skip if unassigned or group index invalid
-    if (group_idx == UNASSIGNED_GROUP || group_idx >= config.num_groups) {
+    if (group_index == UNASSIGNED_GROUP || group_index >= config.num_groups) {
       continue;
     }
 
-    // Check if channel is effectively muted (explicit mute or solo)
-    if (isChannelMuted(ch)) {
-      // Still need to advance smoothers to stay in sync
-      for (uint32_t frame = 0; frame < num_frames; ++frame) {
-        channel.gain_smoother->process();
-        channel.pan_left->process();
-        channel.pan_right->process();
-      }
-      continue;
+    const float* input = channel_inputs ? channel_inputs[channel_index] : nullptr;
+    const bool muted = isChannelMuted(channel_index) || input == nullptr;
+    auto& group_buffer = m_group_buffers[group_index];
+
+    RoutingOutputIndex discrete_output = channel.config.output_channel;
+    if (discrete_output >= config.num_outputs) {
+      discrete_output = 0;
     }
 
-    // Get input buffer for this channel
-    const float* input = channel_inputs[ch];
-    if (!input) {
-      // No input for this channel - advance smoothers and skip
-      for (uint32_t frame = 0; frame < num_frames; ++frame) {
-        channel.gain_smoother->process();
-        channel.pan_left->process();
-        channel.pan_right->process();
-      }
-      continue;
-    }
-
-    // Get stereo group buffer (ORP121 A-02)
-    auto& group_buffer = m_group_buffers[group_idx];
-
-    // ORP121 A-02/C-04: Process channel gain + pan → stereo group buffer
-    // Pan law: constant-power (-3 dB at center)
-    // pan_left/pan_right are pre-computed in updatePanLaw()
     for (uint32_t frame = 0; frame < num_frames; ++frame) {
-      // Get smoothed gain and pan values for this sample
-      float channel_gain = channel.gain_smoother->process();
-      float pan_left = channel.pan_left->process();
-      float pan_right = channel.pan_right->process();
+      const float channel_gain = channel.gain_smoother->process();
+      const float pan_left = channel.pan_left->process();
+      const float pan_right = channel.pan_right->process();
+      if (muted) {
+        continue;
+      }
 
-      // Read input sample and apply channel gain
-      float sample = input[frame] * channel_gain;
-
-      // ORP121 C-04: Apply pan law (constant-power stereo positioning)
-      // pan_left/pan_right encode the constant-power coefficients:
-      // - Center (pan=0): L=R=0.707 (-3 dB each, total energy preserved)
-      // - Hard left (pan=-1): L=1.0, R=0.0
-      // - Hard right (pan=+1): L=0.0, R=1.0
-      float sample_L = sample * pan_left;
-      float sample_R = sample * pan_right;
-
-      // Sum into stereo group buffer
-      group_buffer.left[frame] += sample_L;
-      group_buffer.right[frame] += sample_R;
+      const float sample = input[frame] * channel_gain;
+      switch (config.source_channel_policy) {
+      case SourceChannelPolicy::Discrete:
+        group_buffer.channels[discrete_output][frame] += sample;
+        break;
+      case SourceChannelPolicy::StereoPairs:
+        group_buffer.channels[0][frame] += sample * pan_left;
+        if (config.num_outputs > 1) {
+          group_buffer.channels[1][frame] += sample * pan_right;
+        }
+        break;
+      case SourceChannelPolicy::MonoFoldDown:
+        group_buffer.channels[0][frame] += sample;
+        break;
+      }
     }
 
-    // Meter both sides of the stereo contribution.
-    if (config.enable_metering) {
-      processStereoMetering(group_buffer.left.data(), group_buffer.right.data(), num_frames,
+    if (config.enable_metering && !muted) {
+      const float* right =
+          config.num_outputs > 1 ? group_buffer.channels[1].data() : nullptr;
+      processStereoMetering(group_buffer.channels[0].data(), right, num_frames,
                             channel.true_peak_meters, channel.peak_level, channel.rms_level);
-      if (detectClipping(group_buffer.left.data(), num_frames) ||
-          detectClipping(group_buffer.right.data(), num_frames)) {
+      if (detectClipping(group_buffer.channels[discrete_output].data(), num_frames)) {
         channel.clip_count.fetch_add(1, std::memory_order_relaxed);
       }
     }
   }
 
-  // ========================================================================
-  // Step 3: Process groups → master (ORP121 A-02: Stereo groups)
-  // ========================================================================
-  // Clear master output first
-  for (uint8_t out = 0; out < config.num_outputs; ++out) {
-    std::memset(master_output[out], 0, num_frames * sizeof(float));
+  for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
+    std::memset(master_output[output], 0, num_frames * sizeof(float));
   }
 
-  for (uint8_t grp = 0; grp < config.num_groups; ++grp) {
-    auto& group = m_groups[grp];
+  for (RoutingGroupIndex group_index = 0; group_index < config.num_groups; ++group_index) {
+    auto& group = m_groups[group_index];
+    auto& group_buffer = m_group_buffers[group_index];
+    const bool muted = isGroupMuted(group_index);
+    const float headroom = getHeadroomCompensation(group_index);
 
-    // Check if group is effectively muted
-    if (isGroupMuted(grp)) {
-      // Still need to advance gain smoother to stay in sync
-      for (uint32_t frame = 0; frame < num_frames; ++frame) {
-        group.gain_smoother->process();
-      }
-      continue;
-    }
+    const RoutingOutputIndex outputStart =
+        group.output_start.load(std::memory_order_acquire);
+    const uint16_t outputWidth =
+        group.output_width.load(std::memory_order_acquire);
 
-    // Get stereo group buffer (ORP121 A-02)
-    auto& group_buffer = m_group_buffers[grp];
-
-    // ORP121 A-03: Get output bus assignment (stereo pair)
-    // output_bus 0 = channels 0-1 (stereo pair 1)
-    // output_bus 1 = channels 2-3 (stereo pair 2)
-    // etc.
-    uint8_t output_bus = group.config.output_bus;
-    uint8_t out_L = static_cast<uint8_t>(output_bus * 2);
-    uint8_t out_R = static_cast<uint8_t>(output_bus * 2 + 1);
-
-    // Validate output channels exist
-    if (out_R >= config.num_outputs) {
-      // Output bus doesn't exist - route to master (0-1)
-      out_L = 0;
-      out_R = std::min((uint8_t)1, (uint8_t)(config.num_outputs - 1));
-    }
-
-    // ORP121 Q-05: Get headroom compensation for this group (computed once per buffer)
-    float headroom = getHeadroomCompensation(grp);
-
-    // Process group gain + sum into master (ORP121 A-02: stereo)
     for (uint32_t frame = 0; frame < num_frames; ++frame) {
-      // Get smoothed group gain for this sample
-      float group_gain = group.gain_smoother->process();
-
-      // Read stereo group samples and apply gain + headroom compensation (Q-05)
-      float sample_L = group_buffer.left[frame] * group_gain * headroom;
-      float sample_R = group_buffer.right[frame] * group_gain * headroom;
-
-      // Sum into master output at configured output bus
-      master_output[out_L][frame] += sample_L;
-      if (out_L != out_R) { // Only write R if stereo output
-        master_output[out_R][frame] += sample_R;
+      const float group_gain = group.gain_smoother->process();
+      if (muted) {
+        continue;
       }
-    }
 
-    // Meter both sides of the stereo group.
-    if (config.enable_metering) {
-      processStereoMetering(group_buffer.left.data(), group_buffer.right.data(), num_frames,
-                            group.true_peak_meters, group.peak_level, group.rms_level);
-      if (detectClipping(group_buffer.left.data(), num_frames) ||
-          detectClipping(group_buffer.right.data(), num_frames)) {
-        group.clip_count.fetch_add(1, std::memory_order_relaxed);
-      }
-    }
-  }
-
-  // ========================================================================
-  // Step 4: Apply master gain/mute
-  // ========================================================================
-  bool master_muted = m_master_mute.load(std::memory_order_acquire);
-
-  for (uint32_t frame = 0; frame < num_frames; ++frame) {
-    // Get smoothed master gain for this sample
-    float master_gain = m_master_gain_smoother->process();
-
-    // Apply mute
-    if (master_muted) {
-      master_gain = 0.0f;
-    }
-
-    // Apply master gain to all output channels
-    for (uint8_t out = 0; out < config.num_outputs; ++out) {
-      master_output[out][frame] *= master_gain;
-    }
-  }
-
-  // ========================================================================
-  // Step 5: Update master meters (if enabled)
-  // ========================================================================
-  if (config.enable_metering) {
-    processStereoMetering(master_output[0], config.num_outputs > 1 ? master_output[1] : nullptr,
-                          num_frames, m_master_true_peak_meters, m_master_peak, m_master_rms);
-
-    // Check for clipping on any master channel
-    for (uint8_t out = 0; out < config.num_outputs; ++out) {
-      if (detectClipping(master_output[out], num_frames)) {
-        m_master_clip_count.fetch_add(1, std::memory_order_relaxed);
-        break; // Only count once per buffer
-      }
-    }
-  }
-
-  // ========================================================================
-  // Step 6: Apply clipping protection (soft limiter + hard clip)
-  // ========================================================================
-  // Prevents distortion when many voices fade out simultaneously: the soft
-  // limiter tames summed gains that exceed 0 dBFS without audible artifacts.
-  //
-  // ORP121 C-02: Fixed discontinuity in soft-knee limiter
-  // Previous implementation had discontinuity at 0.9 threshold causing audible clicks
-  // New implementation uses continuous soft-knee compression starting at -2 dBFS
-  if (config.enable_clipping_protection) {
-    // Soft-knee limiter constants (ORP121 C-02)
-    static constexpr float THRESHOLD = 0.794f; // -2 dBFS (10^(-2/20))
-    static constexpr float KNEE_WIDTH = 0.3f;  // Soft knee range for gradual compression
-    static constexpr float CEILING = 0.9999f;  // Final hard limit (-0.001 dBFS)
-
-    for (uint8_t out = 0; out < config.num_outputs; ++out) {
-      for (uint32_t frame = 0; frame < num_frames; ++frame) {
-        float sample = master_output[out][frame];
-        float abs_sample = std::abs(sample);
-
-        // ORP121 C-02: Continuous soft-knee limiter
-        // Uses soft-knee compression starting at -2 dBFS with smooth transition
-        // Curve is C1 continuous (no jumps, smooth derivative)
-        //
-        // Mathematical verification:
-        // - At threshold (0.794): excess=0, tanh(0)=0, output=0.794 (continuous)
-        // - At 1.0: excess=0.206, tanh(0.687)=0.596, output=0.794+0.179=0.973
-        // - At 2.0: excess=1.206, tanh(4.02)=0.999, output clamped to 0.9999
-        if (abs_sample > THRESHOLD) {
-          float excess = abs_sample - THRESHOLD;
-          float knee_ratio = excess / KNEE_WIDTH;
-          float compressed = THRESHOLD + std::tanh(knee_ratio) * KNEE_WIDTH;
-          sample = std::copysign(std::min(compressed, CEILING), sample);
+      if (config.source_channel_policy == SourceChannelPolicy::StereoPairs) {
+        if (outputWidth > 0) {
+          master_output[outputStart][frame] +=
+              group_buffer.channels[0][frame] * group_gain * headroom;
         }
+        if (outputWidth > 1) {
+          master_output[outputStart + 1][frame] +=
+              group_buffer.channels[1][frame] * group_gain * headroom;
+        }
+      } else {
+        for (uint16_t lane = 0; lane < outputWidth; ++lane) {
+          master_output[outputStart + lane][frame] +=
+              group_buffer.channels[lane][frame] * group_gain * headroom;
+        }
+      }
+    }
 
-        master_output[out][frame] = sample;
+    if (config.enable_metering) {
+      const float* right =
+          config.num_outputs > 1 ? group_buffer.channels[1].data() : nullptr;
+      processStereoMetering(group_buffer.channels[0].data(), right, num_frames,
+                            group.true_peak_meters, group.peak_level, group.rms_level);
+      for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
+        if (detectClipping(group_buffer.channels[output].data(), num_frames)) {
+          group.clip_count.fetch_add(1, std::memory_order_relaxed);
+          break;
+        }
+      }
+    }
+  }
+
+  const bool master_muted = m_master_mute.load(std::memory_order_acquire);
+  for (uint32_t frame = 0; frame < num_frames; ++frame) {
+    const float master_gain = master_muted ? 0.0f : m_master_gain_smoother->process();
+    if (master_muted) {
+      m_master_gain_smoother->process();
+    }
+    for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
+      master_output[output][frame] *= master_gain;
+    }
+  }
+
+  if (config.enable_metering) {
+    processStereoMetering(master_output[0],
+                          config.num_outputs > 1 ? master_output[1] : nullptr, num_frames,
+                          m_master_true_peak_meters, m_master_peak, m_master_rms);
+    for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
+      if (detectClipping(master_output[output], num_frames)) {
+        m_master_clip_count.fetch_add(1, std::memory_order_relaxed);
+        break;
+      }
+    }
+  }
+
+  if (config.enable_clipping_protection) {
+    static constexpr float threshold = 0.794f;
+    static constexpr float knee_width = 0.3f;
+    static constexpr float ceiling = 0.9999f;
+
+    for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
+      for (uint32_t frame = 0; frame < num_frames; ++frame) {
+        float sample = master_output[output][frame];
+        const float magnitude = std::abs(sample);
+        if (magnitude > threshold) {
+          const float compressed =
+              threshold + std::tanh((magnitude - threshold) / knee_width) * knee_width;
+          sample = std::copysign(std::min(compressed, ceiling), sample);
+        }
+        master_output[output][frame] = sample;
       }
     }
   }
@@ -826,7 +799,7 @@ void RoutingMatrix::initializeChannels() {
   m_channels.clear();
   m_channels.reserve(config.num_channels);
 
-  for (uint8_t i = 0; i < config.num_channels; ++i) {
+  for (RoutingChannelIndex i = 0; i < config.num_channels; ++i) {
     ChannelState channel;
     channel.group_index = 0; // Default to group 0
     channel.gain_smoother = std::make_unique<GainSmoother>(sample_rate, config.gain_smoothing_ms);
@@ -848,6 +821,8 @@ void RoutingMatrix::initializeChannels() {
     // Default config
     channel.config.name = "Channel " + std::to_string(i + 1);
     channel.config.group_index = 0;
+    channel.config.output_channel =
+        static_cast<RoutingOutputIndex>(i % config.num_outputs);
     channel.config.gain_db = 0.0f;
     channel.config.pan = 0.0f;
     channel.config.mute = false;
@@ -868,7 +843,7 @@ void RoutingMatrix::initializeGroups() {
   m_groups.clear();
   m_groups.reserve(config.num_groups);
 
-  for (uint8_t i = 0; i < config.num_groups; ++i) {
+  for (RoutingGroupIndex i = 0; i < config.num_groups; ++i) {
     GroupState group;
     group.gain_smoother = std::make_unique<GainSmoother>(sample_rate, config.gain_smoothing_ms);
     group.gain_smoother->reset(1.0f); // Unity gain
@@ -885,7 +860,10 @@ void RoutingMatrix::initializeGroups() {
     group.config.gain_db = 0.0f;
     group.config.mute = false;
     group.config.solo = false;
-    group.config.output_bus = 0; // Master
+    group.output_start.store(0, std::memory_order_release);
+    group.output_width.store(config.num_outputs, std::memory_order_release);
+    group.config.output_start = 0;
+    group.config.output_width = config.num_outputs;
     group.config.color = 0xFFFFFFFF;
 
     m_groups.push_back(std::move(group));
@@ -893,25 +871,25 @@ void RoutingMatrix::initializeGroups() {
 }
 
 void RoutingMatrix::updateSoloState() {
-  // Check if any channel or group is solo'd
-  bool any_solo = false;
-
+  bool any_channel_solo = false;
   for (const auto& channel : m_channels) {
     if (channel.solo.load(std::memory_order_acquire)) {
-      any_solo = true;
+      any_channel_solo = true;
       break;
     }
   }
 
-  if (!any_solo) {
-    for (const auto& group : m_groups) {
-      if (group.solo.load(std::memory_order_acquire)) {
-        any_solo = true;
-        break;
-      }
+  bool any_group_solo = false;
+  for (const auto& group : m_groups) {
+    if (group.solo.load(std::memory_order_acquire)) {
+      any_group_solo = true;
+      break;
     }
   }
 
+  m_channel_solo_active.store(any_channel_solo, std::memory_order_release);
+  m_group_solo_active.store(any_group_solo, std::memory_order_release);
+  const bool any_solo = any_channel_solo || any_group_solo;
   m_solo_active.store(any_solo, std::memory_order_release);
 
   // Notify callback
@@ -920,7 +898,7 @@ void RoutingMatrix::updateSoloState() {
   }
 }
 
-void RoutingMatrix::updatePanLaw(uint8_t channel_index, float pan) {
+void RoutingMatrix::updatePanLaw(RoutingChannelIndex channel_index, float pan) {
   // Constant-power pan law: L^2 + R^2 = 1
   // Center: -3 dB (0.707) on both channels
   // Hard left: 1.0 L, 0.0 R
@@ -1005,8 +983,8 @@ float RoutingMatrix::linearToDb(float linear) const {
 // ORP121 Q-05: Headroom Management
 // ============================================================================
 
-uint8_t RoutingMatrix::countActiveChannelsInGroup(uint8_t group_index) const {
-  uint8_t count = 0;
+uint32_t RoutingMatrix::countActiveChannelsInGroup(RoutingGroupIndex group_index) const {
+  uint32_t count = 0;
   for (const auto& channel : m_channels) {
     if (channel.group_index == group_index && !channel.mute.load(std::memory_order_acquire)) {
       ++count;
@@ -1015,8 +993,8 @@ uint8_t RoutingMatrix::countActiveChannelsInGroup(uint8_t group_index) const {
   return count;
 }
 
-uint8_t RoutingMatrix::countTotalActiveChannels() const {
-  uint8_t count = 0;
+uint32_t RoutingMatrix::countTotalActiveChannels() const {
+  uint32_t count = 0;
   for (const auto& channel : m_channels) {
     if (channel.group_index != UNASSIGNED_GROUP && !channel.mute.load(std::memory_order_acquire)) {
       ++count;
@@ -1025,7 +1003,7 @@ uint8_t RoutingMatrix::countTotalActiveChannels() const {
   return count;
 }
 
-float RoutingMatrix::getHeadroomCompensation(uint8_t group_index) const {
+float RoutingMatrix::getHeadroomCompensation(RoutingGroupIndex group_index) const {
   // Get active config (lock-free read)
   int config_idx = m_active_config_idx.load(std::memory_order_acquire);
   const RoutingConfig& config = m_config_buffers[config_idx];
@@ -1035,18 +1013,18 @@ float RoutingMatrix::getHeadroomCompensation(uint8_t group_index) const {
     return 1.0f;
 
   case HeadroomMode::PerGroup: {
-    uint8_t active = countActiveChannelsInGroup(group_index);
+    uint32_t active = countActiveChannelsInGroup(group_index);
     return active > 0 ? 1.0f / static_cast<float>(active) : 1.0f;
   }
 
   case HeadroomMode::Global: {
-    uint8_t active = countTotalActiveChannels();
+    uint32_t active = countTotalActiveChannels();
     return active > 0 ? 1.0f / static_cast<float>(active) : 1.0f;
   }
 
   case HeadroomMode::Logarithmic: {
     // -3 dB per doubling of channels: 1/sqrt(n)
-    uint8_t active = countActiveChannelsInGroup(group_index);
+    uint32_t active = countActiveChannelsInGroup(group_index);
     return active > 0 ? 1.0f / std::sqrt(static_cast<float>(active)) : 1.0f;
   }
 

--- a/src/core/routing/routing_matrix.h
+++ b/src/core/routing/routing_matrix.h
@@ -17,7 +17,7 @@ class GainSmoother;
 
 /// Internal channel state (audio thread)
 struct ChannelState {
-  uint8_t group_index;                         ///< Assigned group (255 = unassigned)
+  RoutingGroupIndex group_index;               ///< Assigned group or UNASSIGNED_GROUP
   std::unique_ptr<GainSmoother> gain_smoother; ///< Gain smoothing
   std::unique_ptr<GainSmoother> pan_left;      ///< Left pan gain
   std::unique_ptr<GainSmoother> pan_right;     ///< Right pan gain
@@ -57,6 +57,8 @@ struct GroupState {
   std::unique_ptr<GainSmoother> gain_smoother; ///< Gain smoothing
   std::atomic<bool> mute;
   std::atomic<bool> solo;
+  std::atomic<RoutingOutputIndex> output_start;
+  std::atomic<uint16_t> output_width;
 
   // Metering
   std::atomic<float> peak_level;
@@ -70,14 +72,16 @@ struct GroupState {
   // Move constructor (needed for std::vector with atomics)
   GroupState(GroupState&& other) noexcept
       : gain_smoother(std::move(other.gain_smoother)), mute(other.mute.load()),
-        solo(other.solo.load()), peak_level(other.peak_level.load()),
+        solo(other.solo.load()), output_start(other.output_start.load()),
+        output_width(other.output_width.load()), peak_level(other.peak_level.load()),
         rms_level(other.rms_level.load()), clip_count(other.clip_count.load()),
-        true_peak_meters(std::move(other.true_peak_meters)), config(std::move(other.config)) {}
+        true_peak_meters(std::move(other.true_peak_meters)),
+        config(std::move(other.config)) {}
 
   // Default constructor
   GroupState()
-      : gain_smoother(nullptr), mute(false), solo(false), peak_level(0.0f), rms_level(0.0f),
-        clip_count(0) {}
+      : gain_smoother(nullptr), mute(false), solo(false), output_start(0),
+        output_width(2), peak_level(0.0f), rms_level(0.0f), clip_count(0) {}
 
   // Deleted copy constructor (atomics are not copyable)
   GroupState(const GroupState&) = delete;
@@ -85,20 +89,18 @@ struct GroupState {
   GroupState& operator=(GroupState&&) = delete;
 };
 
-/// ORP121 A-02: Stereo group buffer for true stereo imaging
-/// Each group has L/R channel pair instead of mono
-struct StereoGroupBuffer {
-  std::vector<float> left;  ///< Left channel samples
-  std::vector<float> right; ///< Right channel samples
+/// Preallocated planar buffer for one logical group.
+struct MultichannelGroupBuffer {
+  std::vector<std::vector<float>> channels;
 
-  void resize(size_t frames) {
-    left.resize(frames, 0.0f);
-    right.resize(frames, 0.0f);
+  void resize(size_t channel_count, size_t frames) {
+    channels.assign(channel_count, std::vector<float>(frames, 0.0f));
   }
 
   void clear() {
-    std::fill(left.begin(), left.end(), 0.0f);
-    std::fill(right.begin(), right.end(), 0.0f);
+    for (auto& channel : channels) {
+      std::fill(channel.begin(), channel.end(), 0.0f);
+    }
   }
 };
 
@@ -114,18 +116,28 @@ public:
   void setCallback(IRoutingCallback* callback) override;
 
   // Channel configuration
-  SessionGraphError setChannelGroup(uint8_t channel_index, uint8_t group_index) override;
-  SessionGraphError setChannelGain(uint8_t channel_index, float gain_db) override;
-  SessionGraphError setChannelPan(uint8_t channel_index, float pan) override;
-  SessionGraphError setChannelMute(uint8_t channel_index, bool mute) override;
-  SessionGraphError setChannelSolo(uint8_t channel_index, bool solo) override;
-  SessionGraphError configureChannel(uint8_t channel_index, const ChannelConfig& config) override;
+  SessionGraphError setChannelGroup(RoutingChannelIndex channel_index,
+                                    RoutingGroupIndex group_index) override;
+  SessionGraphError setChannelRoute(RoutingChannelIndex channel_index,
+                                    RoutingGroupIndex group_index,
+                                    RoutingOutputIndex output_index) override;
+  SessionGraphError setChannelGain(RoutingChannelIndex channel_index, float gain_db) override;
+  SessionGraphError setChannelPan(RoutingChannelIndex channel_index, float pan) override;
+  SessionGraphError setChannelMute(RoutingChannelIndex channel_index, bool mute) override;
+  SessionGraphError setChannelSolo(RoutingChannelIndex channel_index, bool solo) override;
+  SessionGraphError configureChannel(RoutingChannelIndex channel_index,
+                                     const ChannelConfig& config) override;
 
   // Group configuration
-  SessionGraphError setGroupGain(uint8_t group_index, float gain_db) override;
-  SessionGraphError setGroupMute(uint8_t group_index, bool mute) override;
-  SessionGraphError setGroupSolo(uint8_t group_index, bool solo) override;
-  SessionGraphError configureGroup(uint8_t group_index, const GroupConfig& config) override;
+  SessionGraphError setGroupGain(RoutingGroupIndex group_index, float gain_db) override;
+  SessionGraphError setGroupMute(RoutingGroupIndex group_index, bool mute) override;
+  SessionGraphError setGroupSolo(RoutingGroupIndex group_index, bool solo) override;
+  SessionGraphError configureGroup(RoutingGroupIndex group_index,
+                                   const GroupConfig& config) override;
+
+  SessionGraphError setGroupOutputRoute(
+      RoutingGroupIndex group_index, RoutingOutputIndex output_start,
+      uint16_t output_width) override;
 
   // Master configuration
   SessionGraphError setMasterGain(float gain_db) override;
@@ -133,10 +145,10 @@ public:
 
   // State queries
   bool isSoloActive() const override;
-  bool isChannelMuted(uint8_t channel_index) const override;
-  bool isGroupMuted(uint8_t group_index) const override;
-  AudioMeter getChannelMeter(uint8_t channel_index) const override;
-  AudioMeter getGroupMeter(uint8_t group_index) const override;
+  bool isChannelMuted(RoutingChannelIndex channel_index) const override;
+  bool isGroupMuted(RoutingGroupIndex group_index) const override;
+  AudioMeter getChannelMeter(RoutingChannelIndex channel_index) const override;
+  AudioMeter getGroupMeter(RoutingGroupIndex group_index) const override;
   AudioMeter getMasterMeter() const override;
 
   // Snapshots
@@ -146,8 +158,8 @@ public:
   SessionGraphError reset() override;
 
   // Audio processing
-  SessionGraphError processRouting(const float* const* channel_inputs, float** master_output,
-                                   uint32_t num_frames) override;
+  SessionGraphError processRouting(const float* const* channel_inputs,
+                                   float* const* master_output, uint32_t num_frames) override;
   uint32_t maxBlockFrames() const override;
 
 private:
@@ -155,8 +167,8 @@ private:
   // public processRouting() loops over this for arbitrarily large blocks;
   // this stays allocation-free and lock-free (operates on pre-allocated
   // scratch), so large offline blocks incur no audio-thread allocation.
-  SessionGraphError processRoutingBlock(const float* const* channel_inputs, float** master_output,
-                                        uint32_t num_frames);
+  SessionGraphError processRoutingBlock(const float* const* channel_inputs,
+                                        float* const* master_output, uint32_t num_frames);
 
   // Internal helpers
   void initializeChannels();
@@ -165,15 +177,15 @@ private:
   void cleanupGroups();
 
   void updateSoloState();
-  void updatePanLaw(uint8_t channel_index, float pan);
+  void updatePanLaw(RoutingChannelIndex channel_index, float pan);
 
   float dbToLinear(float db) const;
   float linearToDb(float linear) const;
 
   // ORP121 Q-05: Headroom compensation
-  float getHeadroomCompensation(uint8_t group_index) const;
-  uint8_t countActiveChannelsInGroup(uint8_t group_index) const;
-  uint8_t countTotalActiveChannels() const;
+  float getHeadroomCompensation(RoutingGroupIndex group_index) const;
+  uint32_t countActiveChannelsInGroup(RoutingGroupIndex group_index) const;
+  uint32_t countTotalActiveChannels() const;
 
   void processStereoMetering(const float* left, const float* right, size_t num_frames,
                              std::array<TruePeakMeter, 2>& true_peak_meters,
@@ -197,22 +209,26 @@ private:
   std::atomic<uint32_t> m_master_clip_count;
   std::array<TruePeakMeter, 2> m_master_true_peak_meters;
 
-  // Solo state
-  std::atomic<bool> m_solo_active;
+  // Solo domains are independent: a group solo must not mute every source
+  // channel before group summing, and a channel solo must not mute every
+  // logical group after summing. m_solo_active is their public union.
+  std::atomic<bool> m_channel_solo_active{false};
+  std::atomic<bool> m_group_solo_active{false};
+  std::atomic<bool> m_solo_active{false};
   std::atomic<uint64_t> m_snapshot_revision{0};
 
   // Callback
   IRoutingCallback* m_callback;
 
-  // ORP121 A-02: Audio processing buffers (pre-allocated, stereo)
-  std::vector<StereoGroupBuffer> m_group_buffers; // [num_groups] stereo L/R pairs
-  std::vector<float> m_temp_buffer;               // Temp buffer for processing
+  // Audio processing buffers, allocated once during initialize().
+  std::vector<MultichannelGroupBuffer> m_group_buffers;
+  std::vector<float> m_temp_buffer;
 
   // FTR028: Internal slice size. Kept in lock-step with the public
   // orpheus::kRoutingSliceFrames contract so hosts and the implementation
   // agree on the chunking granularity.
   static constexpr size_t MAX_BUFFER_SIZE = kRoutingSliceFrames;
-  static constexpr uint8_t UNASSIGNED_GROUP = 255;
+  static constexpr RoutingGroupIndex UNASSIGNED_GROUP = orpheus::UNASSIGNED_GROUP;
 };
 
 } // namespace orpheus

--- a/src/core/session/scene_manager.cpp
+++ b/src/core/session/scene_manager.cpp
@@ -61,10 +61,10 @@ json::JsonValue serializeSceneToJson(const SceneSnapshot& scene) {
     root.object["assignedClips"].array.push_back(clip);
   }
 
-  // Clip groups (array of uint8_t)
+  // Clip groups
   root.object["clipGroups"] = json::JsonValue{};
   root.object["clipGroups"].type = json::JsonValue::Type::kArray;
-  for (uint8_t group : scene.clipGroups) {
+  for (RoutingGroupIndex group : scene.clipGroups) {
     json::JsonValue g;
     g.type = json::JsonValue::Type::kNumber;
     g.number = static_cast<double>(group);
@@ -172,8 +172,9 @@ SceneSnapshot deserializeSceneFromJson(const json::JsonValue& root) {
   if (auto* clipGroups = json::RequireField(root, "clipGroups")) {
     const auto& arr = json::ExpectArray(*clipGroups, "clipGroups");
     for (const auto& item : arr.array) {
-      uint8_t group = static_cast<uint8_t>(item.number);
-      scene.clipGroups.push_back(group);
+      const auto stored = static_cast<uint64_t>(item.number);
+      scene.clipGroups.push_back(stored == 255 ? UNASSIGNED_GROUP
+                                               : static_cast<RoutingGroupIndex>(stored));
     }
   }
 
@@ -246,7 +247,7 @@ public:
       auto config = routingMatrix_->getConfig();
 
       // Reserve space for clip groups (one per channel)
-      scene.clipGroups.resize(config.num_channels, 255); // 255 = unassigned
+      scene.clipGroups.resize(config.num_channels, UNASSIGNED_GROUP);
 
       // Reserve space for group gains (one per group)
       scene.groupGains.resize(config.num_groups, 0.0f);

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -15,100 +15,159 @@
 
 namespace orpheus {
 
-TransportController::TransportController(core::SessionGraph* sessionGraph, uint32_t sampleRate)
-    : m_sessionGraph(sessionGraph), m_sampleRate(sampleRate), m_callback(nullptr) {
-  // Calculate fade-out samples
-  m_fadeOutSamples =
-      static_cast<size_t>((FADE_OUT_DURATION_MS / 1000.0f) * static_cast<float>(sampleRate));
+namespace {
 
-  // Calculate restart crossfade samples (broadcast-safe restart mechanism)
-  m_restartCrossfadeSamples = static_cast<size_t>((RESTART_CROSSFADE_DURATION_MS / 1000.0f) *
-                                                  static_cast<float>(sampleRate));
+std::optional<ChannelFormat> standardChannelFormat(ChannelLayout layout) {
+  switch (layout) {
+  case ChannelLayout::Mono:
+    return ChannelFormat::Mono();
+  case ChannelLayout::Stereo:
+    return ChannelFormat::Stereo();
+  case ChannelLayout::LCR:
+    return ChannelFormat::LCR();
+  case ChannelLayout::Quad:
+    return ChannelFormat::Quad();
+  case ChannelLayout::Surround_5_0:
+    return ChannelFormat::Surround50();
+  case ChannelLayout::Surround_5_1:
+    return ChannelFormat::Surround51();
+  case ChannelLayout::Surround_7_1:
+    return ChannelFormat::Surround71();
+  case ChannelLayout::SMPTE_51_ST:
+    return ChannelFormat::SMPTE51Stereo();
+  case ChannelLayout::SMPTE_51_LTRT:
+    return ChannelFormat::SMPTE51MatrixStereo();
+  default:
+    return std::nullopt;
+  }
+}
 
-  // ORP127 G4: per-sample clip-gain ramp increment for the default smoothing
-  // time. A full 0→1 change takes CLIP_GAIN_SMOOTHING_MS; each sample moves by
-  // 1 / (ms/1000 * sampleRate).
-  {
-    float smoothingSamples = (CLIP_GAIN_SMOOTHING_MS / 1000.0f) * static_cast<float>(sampleRate);
-    m_clipGainRampIncrement = (smoothingSamples > 0.0f) ? (1.0f / smoothingSamples) : 1.0f;
+std::optional<ChannelFormat> inferUnambiguousChannelFormat(uint16_t channels) {
+  switch (channels) {
+  case 1:
+    return ChannelFormat::Mono();
+  case 2:
+    return ChannelFormat::Stereo();
+  case 3:
+    return ChannelFormat::LCR();
+  case 4:
+    return ChannelFormat::Quad();
+  case 5:
+    return ChannelFormat::Surround50();
+  case 6:
+    return ChannelFormat::Surround51();
+  default:
+    return std::nullopt;
+  }
+}
+
+bool isValidSpeakerPatch(ChannelLayout layout, uint8_t patchSize,
+                         const std::array<Speaker, 8>& patch, uint16_t fileChannels) {
+  if (layout == ChannelLayout::Unspecified) {
+    return patchSize == 0;
+  }
+  if (fileChannels == 0 || fileChannels > patch.size() || patchSize != fileChannels) {
+    return false;
+  }
+  for (size_t channel = 0; channel < patchSize; ++channel) {
+    if (patch[channel] == Speaker::None) {
+      return false;
+    }
+    for (size_t earlier = 0; earlier < channel; ++earlier) {
+      if (patch[channel] == patch[earlier]) {
+        return false;
+      }
+    }
   }
 
-  // Create and initialize routing matrix
-  m_routingMatrix = createRoutingMatrix();
+  if (layout == ChannelLayout::Custom) {
+    return true;
+  }
+  const auto standard = standardChannelFormat(layout);
+  if (!standard.has_value() || standard->num_channels != fileChannels) {
+    return false;
+  }
+  return std::equal(patch.begin(), patch.begin() + patchSize,
+                    standard->channel_map.begin());
+}
 
-  // ORP121 A-01: ST2110-aligned channel architecture
-  // Each clip can use up to 2 routing channels (L/R for stereo sources)
-  // Mono sources use 1 channel, stereo sources use 2 independent channels
-  // This follows ST2110-30 principle: audio as discrete independent channels
-  static constexpr size_t MAX_ROUTING_CHANNELS = MAX_ACTIVE_CLIPS * 2;
+} // namespace
+
+TransportController::TransportController(core::SessionGraph* sessionGraph,
+                                         const TransportConfig& config)
+    : m_sessionGraph(sessionGraph), m_config(config), m_sampleRate(config.sampleRate),
+      m_callback(nullptr) {
+  m_fadeOutSamples = static_cast<size_t>((FADE_OUT_DURATION_MS / 1000.0f) *
+                                         static_cast<float>(m_sampleRate));
+  m_restartCrossfadeSamples =
+      static_cast<size_t>((RESTART_CROSSFADE_DURATION_MS / 1000.0f) *
+                          static_cast<float>(m_sampleRate));
+
+  const float smoothingSamples =
+      (CLIP_GAIN_SMOOTHING_MS / 1000.0f) * static_cast<float>(m_sampleRate);
+  m_clipGainRampIncrement = smoothingSamples > 0.0f ? 1.0f / smoothingSamples : 1.0f;
+
+  m_routingMatrix = createRoutingMatrix();
+  const size_t routingLaneCount =
+      static_cast<size_t>(m_config.maxActiveVoices) * m_config.maxSourceChannels;
 
   RoutingConfig routingConfig;
-  // num_channels is structural: 2 routing channels per active clip (L/R), so it
-  // scales with MAX_ACTIVE_CLIPS. num_groups is a typical soundboard default;
-  // hosts that need a different grouping topology can reconfigure the matrix.
-  routingConfig.num_channels = MAX_ROUTING_CHANNELS; // 2 channels per clip (stereo)
-  routingConfig.num_groups = 4;                      // typical soundboard default
-  routingConfig.num_outputs = 2;                     // stereo output
+  routingConfig.num_channels = static_cast<RoutingChannelIndex>(routingLaneCount);
+  routingConfig.num_groups = static_cast<RoutingGroupIndex>(m_config.numGroups);
+  routingConfig.num_outputs = static_cast<RoutingOutputIndex>(m_config.outputChannels);
+  routingConfig.sample_rate = m_sampleRate;
   routingConfig.solo_mode = SoloMode::SIP;
   routingConfig.metering_mode = MeteringMode::Peak;
-  routingConfig.gain_smoothing_ms =
-      0.0f; // DISABLED: Fades handled at clip level, smoothing causes zigzag artifacts
+  routingConfig.gain_smoothing_ms = 0.0f;
   routingConfig.enable_metering = true;
-  routingConfig.enable_clipping_protection =
-      true; // Enabled by default: prevents distortion when many voices fade out
-            // simultaneously (soft-knee tanh limiter, no audible quality loss).
-
+  routingConfig.enable_clipping_protection = true;
+  routingConfig.source_channel_policy = m_config.sourceChannelPolicy;
+  routingConfig.downmix_policy =
+      m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete
+          ? DownmixPolicy::None
+          : DownmixPolicy::ITU_BS775_3;
   m_routingMatrix->initialize(routingConfig);
 
-  // ORP121 A-01: Configure channel pairs for stereo routing
-  // Each clip's L channel: pan = -1.0 (hard left)
-  // Each clip's R channel: pan = +1.0 (hard right)
-  // Both channels route to the same group (group 0 by default)
-  for (size_t clip = 0; clip < MAX_ACTIVE_CLIPS; ++clip) {
-    size_t ch_L = clip * 2;
-    size_t ch_R = clip * 2 + 1;
-
-    // Configure L channel (hard left pan)
-    ChannelConfig configL;
-    configL.gain_db = 0.0f;
-    configL.pan = -1.0f; // Hard left for stereo L channel
-    configL.mute = false;
-    configL.solo = false;
-    m_routingMatrix->configureChannel(static_cast<uint8_t>(ch_L), configL);
-    m_routingMatrix->setChannelGroup(static_cast<uint8_t>(ch_L), 0);
-
-    // Configure R channel (hard right pan)
-    ChannelConfig configR;
-    configR.gain_db = 0.0f;
-    configR.pan = 1.0f; // Hard right for stereo R channel
-    configR.mute = false;
-    configR.solo = false;
-    m_routingMatrix->configureChannel(static_cast<uint8_t>(ch_R), configR);
-    m_routingMatrix->setChannelGroup(static_cast<uint8_t>(ch_R), 0);
+  for (size_t voice = 0; voice < m_config.maxActiveVoices; ++voice) {
+    for (size_t lane = 0; lane < m_config.maxSourceChannels; ++lane) {
+      const auto channel =
+          static_cast<RoutingChannelIndex>(voice * m_config.maxSourceChannels + lane);
+      ChannelConfig channelConfig;
+      channelConfig.gain_db = 0.0f;
+      channelConfig.pan = lane % 2 == 0 ? -1.0f : 1.0f;
+      channelConfig.output_channel =
+          static_cast<RoutingOutputIndex>(lane % m_config.outputChannels);
+      m_routingMatrix->configureChannel(channel, channelConfig);
+      m_routingMatrix->setChannelGroup(channel, UNASSIGNED_GROUP);
+    }
+  }
+  for (size_t group = 0; group < MAX_LOGICAL_GROUPS; ++group) {
+    m_groupOutputStarts[group].store(0, std::memory_order_relaxed);
+    m_groupOutputWidths[group].store(0, std::memory_order_relaxed);
+  }
+  for (RoutingGroupIndex group = 0; group < m_config.numGroups; ++group) {
+    m_groupOutputWidths[group].store(
+        static_cast<uint16_t>(m_config.outputChannels),
+        std::memory_order_relaxed);
+    (void)m_routingMatrix->setGroupOutputRoute(
+        group, 0, static_cast<uint16_t>(m_config.outputChannels));
   }
 
-  // Pre-allocate per-clip read buffers (interleaved audio from files)
-  m_clipReadBuffers.resize(MAX_ACTIVE_CLIPS);
+  m_clipReadBuffers.resize(m_config.maxActiveVoices);
   for (auto& buffer : m_clipReadBuffers) {
-    buffer.resize(MAX_BUFFER_FRAMES * MAX_FILE_CHANNELS, 0.0f);
+    buffer.resize(static_cast<size_t>(m_config.maxBlockFrames) * m_config.maxSourceChannels, 0.0f);
   }
 
-  // ORP121 A-01: Pre-allocate stereo clip channel buffers
-  // Each clip has L and R buffers: index = clip * 2 + (0 for L, 1 for R)
-  m_clipChannelBuffers.resize(MAX_ROUTING_CHANNELS);
+  m_clipChannelBuffers.resize(routingLaneCount);
   for (auto& buffer : m_clipChannelBuffers) {
-    buffer.resize(MAX_BUFFER_FRAMES, 0.0f);
+    buffer.resize(m_config.maxBlockFrames, 0.0f);
   }
 
-  // Pre-allocate pointer array for processRouting()
-  m_clipChannelPointers.resize(MAX_ROUTING_CHANNELS);
-  for (size_t i = 0; i < MAX_ROUTING_CHANNELS; ++i) {
-    m_clipChannelPointers[i] = m_clipChannelBuffers[i].data();
+  m_clipChannelPointers.resize(routingLaneCount);
+  for (size_t lane = 0; lane < routingLaneCount; ++lane) {
+    m_clipChannelPointers[lane] = m_clipChannelBuffers[lane].data();
   }
 
-  // FTR027 §1: seed the tempo cache from the session graph so beats derive
-  // from the real session tempo immediately, before the first
-  // processCallbacks() pump.
   if (m_sessionGraph) {
     m_tempoBpm.store(m_sessionGraph->tempo(), std::memory_order_relaxed);
   }
@@ -131,6 +190,11 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
     auto it = m_audioFiles.find(handle);
     if (it != m_audioFiles.end()) {
       auto& entry = it->second;
+      if (entry.sourceLayout == ChannelLayout::Unspecified ||
+          !isValidSpeakerPatch(entry.sourceLayout, entry.speakerPatchSize,
+                               entry.speakerPatch, entry.metadata.num_channels)) {
+        return SessionGraphError::InvalidParameter;
+      }
       // ORP134 G1: lazy preparation for hosts that never call
       // prepareClipAudio() — decode/stream setup happens HERE on the control
       // thread, never on the audio thread.
@@ -152,6 +216,7 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
       // Precompute linear gain
       context->gainLinear = std::pow(10.0f, entry.gainDb / 20.0f);
       context->loopEnabled = entry.loopEnabled;
+      context->routingGroup = entry.routingGroup;
       context->voiceMode = entry.voiceMode; // ORP127 G5
     } else {
       // Clip not registered - use defaults for testing
@@ -167,6 +232,7 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
       context->gainDb = 0.0f;
       context->gainLinear = 1.0f;
       context->loopEnabled = false;
+      context->routingGroup = 0;
       context->voiceMode = VoiceMode::Polyphonic; // ORP127 G5: default
     }
   }
@@ -251,9 +317,8 @@ SessionGraphError TransportController::stopOtherClips(ClipHandle exceptHandle) {
 }
 
 SessionGraphError TransportController::setMaxVoicesPerClip(uint32_t maxVoices) {
-  // ORP127 G7: clamp to [1, hard max]. Atomic so the audio thread reads a
-  // consistent value in addActiveClip.
-  uint32_t clamped = std::clamp(maxVoices, 1u, VOICE_CAP_HARD_MAX);
+  const uint32_t configuredLimit = std::min(m_config.maxActiveVoices, VOICE_CAP_HARD_MAX);
+  const uint32_t clamped = std::clamp(maxVoices, 1u, configuredLimit);
   m_maxVoicesPerClip.store(clamped, std::memory_order_relaxed);
   return SessionGraphError::OK;
 }
@@ -308,34 +373,31 @@ void TransportController::setCallback(ITransportCallback* callback) {
   m_callback = callback;
 }
 
-TransportRenderConfig TransportController::getRenderConfig() const noexcept {
-  TransportRenderConfig config;
-  config.sampleRate = m_sampleRate;
-  config.maxBlockFrames = static_cast<uint32_t>(MAX_BUFFER_FRAMES);
-  if (m_routingMatrix) {
-    config.outputChannels = m_routingMatrix->getConfig().num_outputs;
-  }
-  return config;
+TransportConfig TransportController::getRenderConfig() const noexcept {
+  return m_config;
 }
 
-void TransportController::processAudio(float** outputBuffers, size_t numChannels,
+void TransportController::processAudio(float* const* outputBuffers, size_t numChannels,
                                        size_t numFrames) noexcept {
-  // Process pending commands from UI thread
+  if (outputBuffers == nullptr || numChannels != m_config.outputChannels ||
+      numFrames > m_config.maxBlockFrames) {
+    if (outputBuffers != nullptr) {
+      for (size_t channel = 0; channel < numChannels; ++channel) {
+        if (outputBuffers[channel] != nullptr) {
+          std::memset(outputBuffers[channel], 0, numFrames * sizeof(float));
+        }
+      }
+    }
+    return;
+  }
+
   processCommands();
-
-  // Routing matrix controls output channel count
-  (void)numChannels;
-
-  // Clamp frames to max buffer size
-  numFrames = std::min(numFrames, MAX_BUFFER_FRAMES);
 
   const bool publishTelemetry =
       m_realtimeTelemetry.beginRealtimeBlock(static_cast<uint32_t>(numFrames), m_sampleRate);
 
-  // ORP121 A-01: Clear all clip channel buffers (stereo - 2 per clip)
-  static constexpr size_t MAX_ROUTING_CHANNELS = MAX_ACTIVE_CLIPS * 2;
-  for (size_t i = 0; i < MAX_ROUTING_CHANNELS; ++i) {
-    std::memset(m_clipChannelBuffers[i].data(), 0, numFrames * sizeof(float));
+  for (auto& lane : m_clipChannelBuffers) {
+    std::memset(lane.data(), 0, numFrames * sizeof(float));
   }
 
   // ORP127 G2: The stop fade-out is now computed per sample inside the render
@@ -370,7 +432,8 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
       clip.source->setDemand(trimIn);
     } else if (clip.currentSample >= trimOut) {
       // Position at or past OUT point - handle loop or stop
-      bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
+      const bool shouldLoop =
+          clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
       if (shouldLoop) {
         // Loop mode: restart from IN point
         clip.currentSample = trimIn;
@@ -567,32 +630,30 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
         }
       }
 
-      // ORP121 A-01: Preserve stereo from source (ST2110-aligned)
-      // Each file channel maps to discrete routing channels
-      // - Mono: Duplicate to L/R (phantom center image)
-      // - Stereo: Direct L→L, R→R mapping
-      // - Multi-channel (>2): ITU-R BS.775-3 downmix to stereo
-      float sample_L, sample_R;
-
-      if (numFileChannels == 1) {
-        // Mono source: Duplicate to both L/R (centered phantom image)
-        float mono = clipReadBuffer[frame];
-        sample_L = mono;
-        sample_R = mono;
-      } else if (numFileChannels == 2) {
-        // Stereo source: Preserve L/R separation
-        sample_L = clipReadBuffer[frame * 2 + 0];
-        sample_R = clipReadBuffer[frame * 2 + 1];
+      const size_t laneBase = i * m_config.maxSourceChannels;
+      if (m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete) {
+        for (size_t channel = 0; channel < numFileChannels; ++channel) {
+          m_clipChannelBuffers[laneBase + channel][frame] =
+              clipReadBuffer[frame * numFileChannels + channel] * gain;
+        }
       } else {
-        // Multi-channel (>2): Apply ITU-R BS.775-3 downmix to stereo
-        sample_L = applyDownmixLeft(clipReadBuffer, frame, numFileChannels);
-        sample_R = applyDownmixRight(clipReadBuffer, frame, numFileChannels);
+        float left = 0.0f;
+        float right = 0.0f;
+        if (numFileChannels == 1) {
+          left = clipReadBuffer[frame];
+          right = left;
+        } else if (numFileChannels == 2) {
+          left = clipReadBuffer[frame * 2];
+          right = clipReadBuffer[frame * 2 + 1];
+        } else {
+          left = applyDownmixLeft(clipReadBuffer, frame, numFileChannels);
+          right = applyDownmixRight(clipReadBuffer, frame, numFileChannels);
+        }
+        m_clipChannelBuffers[laneBase][frame] = left * gain;
+        if (m_config.maxSourceChannels > 1) {
+          m_clipChannelBuffers[laneBase + 1][frame] = right * gain;
+        }
       }
-
-      // Apply gain and write to stereo clip buffers
-      // L channel at index i*2, R channel at index i*2+1
-      m_clipChannelBuffers[i * 2][frame] = sample_L * gain;
-      m_clipChannelBuffers[i * 2 + 1][frame] = sample_R * gain;
     }
 
     // Advance clip position by actual frames read (not buffer size!)
@@ -633,16 +694,22 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
       int64_t fadeProgress = clip.currentSample - clip.fadeOutStartPos;
 
       if (fadeProgress >= fadeOutSampleCount) {
-        // Fade-out complete, remove clip
-        TransportEvent event{};
-        event.type = TransportEventType::ClipStopped;
-        event.handle = clip.handle;
-        event.voiceId = clip.voiceId;
-        event.position = getCurrentPosition();
-        postTransportEvent(event);
+        const ClipHandle stoppedHandle = clip.handle;
+        const uint32_t stoppedVoiceId = clip.voiceId;
+        removeActiveVoice(stoppedVoiceId);
 
-        removeActiveClip(clip.handle);
-        continue; // Don't increment i, we just removed this clip
+        // Callbacks are handle-level state transitions. A fading tail ending
+        // must not report the clip stopped while a newly fired voice for the
+        // same handle is still live.
+        if (countActiveVoices(stoppedHandle) == 0) {
+          TransportEvent event{};
+          event.type = TransportEventType::ClipStopped;
+          event.handle = stoppedHandle;
+          event.voiceId = stoppedVoiceId;
+          event.position = getCurrentPosition();
+          postTransportEvent(event);
+        }
+        continue;
       }
     }
 
@@ -650,7 +717,8 @@ void TransportController::processAudio(float** outputBuffers, size_t numChannels
     int64_t clipTrimOut = clip.trimOutSamples.load(std::memory_order_acquire);
     if (clip.currentSample >= clipTrimOut) {
       // Check if clip should loop
-      bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
+      const bool shouldLoop =
+          clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
 
       if (shouldLoop) {
         // Loop: jump back to trim IN point (works even without a source)
@@ -727,9 +795,7 @@ void TransportController::processCommands() {
 
     switch (cmd.type) {
     case TransportCommand::Type::Start: {
-      // ORP127 G5: honor the clip's voice policy when firing.
-      if (cmd.startContext) {
-        startVoiceWithMode(cmd.startContext);
+      if (cmd.startContext && startVoiceWithMode(cmd.startContext)) {
         TransportEvent event{};
         event.type = TransportEventType::ClipStarted;
         event.handle = cmd.handle;
@@ -760,20 +826,25 @@ void TransportController::processCommands() {
       break;
 
     case TransportCommand::Type::Panic:
-      // OCC155 Ask #5: hard-cut. Drop every voice with no fade so output is
-      // silent on this block. Post ClipStopped for each so the host's UI state
-      // (playing indicators) clears exactly as it would on a natural stop.
-      // Releasing each voice's source shared_ptr here is the same refcount
-      // decrement that removeActiveVoice() already does on the audio thread —
-      // no new RT hazard. Iterate before zeroing the count.
+      // Emit one handle-level stop transition even if a handle currently has
+      // both a fading tail and a freshly fired voice.
       for (size_t i = 0; i < m_activeClipCount; ++i) {
-        TransportEvent event{};
-        event.type = TransportEventType::ClipStopped;
-        event.handle = m_activeClips[i].handle;
-        event.voiceId = m_activeClips[i].voiceId;
-        event.position = getCurrentPosition();
-        postTransportEvent(event);
-        m_activeClips[i].source.reset(); // release source reference (refcount--)
+        bool firstVoiceForHandle = true;
+        for (size_t earlier = 0; earlier < i; ++earlier) {
+          if (m_activeClips[earlier].handle == m_activeClips[i].handle) {
+            firstVoiceForHandle = false;
+            break;
+          }
+        }
+        if (firstVoiceForHandle) {
+          TransportEvent event{};
+          event.type = TransportEventType::ClipStopped;
+          event.handle = m_activeClips[i].handle;
+          event.voiceId = m_activeClips[i].voiceId;
+          event.position = getCurrentPosition();
+          postTransportEvent(event);
+        }
+        m_activeClips[i].source.reset();
       }
       m_activeClipCount = 0;
       break;
@@ -939,6 +1010,8 @@ void TransportController::processCommands() {
           clip.loopEnabled.store(cmd.data.metadata.loopEnabled, std::memory_order_release);
           clip.gainDb.store(cmd.data.metadata.gainDb, std::memory_order_release);
           clip.gainLinear.store(cmd.data.metadata.gainLinear, std::memory_order_release);
+          clip.routingGroup = cmd.data.metadata.routingGroup;
+          configureVoiceRouting(i, clip.routingGroup, clip.numChannels);
         }
       }
       break;
@@ -1017,43 +1090,30 @@ void TransportController::restartVoiceInPlace(ActiveClip& clip) {
   clip.restartFadeFramesRemaining = static_cast<int64_t>(m_restartCrossfadeSamples);
 }
 
-void TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackContext>& context) {
+bool TransportController::startVoiceWithMode(
+    const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
-    return;
+    return false;
 
   const ClipHandle handle = context->handle;
   const VoiceMode mode = context->voiceMode;
 
   switch (mode) {
   case VoiceMode::Polyphonic:
-    // Historical behavior: always allocate a new voice (addActiveClip evicts
-    // the oldest voice for this handle if already at MAX_VOICES_PER_CLIP).
-    addActiveClip(context);
-    return;
+    return addActiveClip(context);
 
   case VoiceMode::MonoStrict: {
-    // Strict single voice: fire-while-anything replaces it from zero with no
-    // fade tail. Cut every existing voice for this handle (including fading
-    // tails) and restart the first in place; if none exist, add fresh.
     ActiveClip* primary = nullptr;
     for (size_t i = 0; i < m_activeClipCount; ++i) {
-      if (m_activeClips[i].handle == handle) {
-        if (!primary) {
-          primary = &m_activeClips[i];
-        }
-      }
+      if (m_activeClips[i].handle == handle && !primary)
+        primary = &m_activeClips[i];
     }
-    if (!primary) {
-      addActiveClip(context);
-      return;
-    }
-    // Remove any *other* voices for this handle (no fade — strict cut). Iterate
-    // from the end so removeActiveVoice's slot compaction is safe.
+    if (!primary)
+      return addActiveClip(context);
+
     for (size_t i = m_activeClipCount; i-- > 0;) {
       if (m_activeClips[i].handle == handle && &m_activeClips[i] != primary) {
         removeActiveVoice(m_activeClips[i].voiceId);
-        // primary pointer may have moved if the last slot was compacted into
-        // its position; re-find it.
         primary = nullptr;
         for (size_t j = 0; j < m_activeClipCount; ++j) {
           if (m_activeClips[j].handle == handle) {
@@ -1065,32 +1125,23 @@ void TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
           break;
       }
     }
-    if (primary) {
-      // MonoStrict restarts from zero with NO crossfade tail (hard, sample-
-      // accurate replace) — just reset position; the clip fade-in (if any)
-      // still applies via hasLoopedOnce=false.
-      int64_t trimIn = primary->trimInSamples.load(std::memory_order_relaxed);
-      primary->currentSample = trimIn;
-      if (primary->source) {
-        primary->source->setDemand(trimIn);
-      }
-      primary->isStopping = false;
-      primary->fadeOutGain = 1.0f;
-      primary->hasLoopedOnce = false;
-      primary->isRestarting = false;
-      primary->restartFadeFramesRemaining = 0;
-      primary->voiceMode = mode;
-    } else {
-      addActiveClip(context);
-    }
-    return;
+    if (!primary)
+      return addActiveClip(context);
+
+    const int64_t trimIn = primary->trimInSamples.load(std::memory_order_relaxed);
+    primary->currentSample = trimIn;
+    if (primary->source)
+      primary->source->setDemand(trimIn);
+    primary->isStopping = false;
+    primary->fadeOutGain = 1.0f;
+    primary->hasLoopedOnce = false;
+    primary->isRestarting = false;
+    primary->restartFadeFramesRemaining = 0;
+    primary->voiceMode = mode;
+    return true;
   }
 
   case VoiceMode::MonoWithFadeOverlap: {
-    // One primary voice. If a live (non-stopping) voice exists, restart it in
-    // place (with a short crossfade). If only fading tails exist, add a fresh
-    // voice alongside them so the tail completes naturally (voices == 2 during
-    // the overlap window).
     ActiveClip* live = nullptr;
     for (size_t i = 0; i < m_activeClipCount; ++i) {
       if (m_activeClips[i].handle == handle && !m_activeClips[i].isStopping) {
@@ -1098,23 +1149,36 @@ void TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
         break;
       }
     }
-    if (live) {
-      restartVoiceInPlace(*live);
-      live->voiceMode = mode;
-    } else {
-      addActiveClip(context);
-    }
-    return;
+    if (!live)
+      return addActiveClip(context);
+
+    restartVoiceInPlace(*live);
+    live->voiceMode = mode;
+    return true;
   }
   }
 
-  // Defensive default (unknown enum) — behave polyphonically.
-  addActiveClip(context);
+  return addActiveClip(context);
 }
 
-void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context) {
+void TransportController::configureVoiceRouting(
+    size_t voiceIndex, RoutingGroupIndex group, uint16_t numChannels) noexcept {
+  const size_t laneBase = voiceIndex * m_config.maxSourceChannels;
+  for (uint32_t lane = 0; lane < m_config.maxSourceChannels; ++lane) {
+    const bool activeLane = lane < numChannels;
+    const auto routeGroup = activeLane ? group : UNASSIGNED_GROUP;
+    const auto output =
+        activeLane ? static_cast<RoutingOutputIndex>(lane)
+                   : static_cast<RoutingOutputIndex>(0);
+    (void)m_routingMatrix->setChannelRoute(
+        static_cast<RoutingChannelIndex>(laneBase + lane), routeGroup, output);
+  }
+}
+
+bool TransportController::addActiveClip(
+    const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
-    return;
+    return false;
 
   ClipHandle handle = context->handle;
 
@@ -1126,32 +1190,24 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
     // At max capacity - remove oldest voice instance for this clip
     ActiveClip* oldest = findOldestVoice(handle);
     if (oldest) {
-      uint32_t oldestVoiceId = oldest->voiceId;
-
-      // Post event that voice was stopped (for UI tracking)
-      // Note: Callback reports handle, not specific voiceId (UI tracks per-handle, not per-voice)
-      TransportEvent event{};
-      event.type = TransportEventType::ClipStopped;
-      event.handle = handle;
-      event.voiceId = oldestVoiceId;
-      event.position = getCurrentPosition();
-      postTransportEvent(event);
-
+      const uint32_t oldestVoiceId = oldest->voiceId;
+      // Replacing one voice for a handle is not a handle-level stop.
       removeActiveVoice(oldestVoiceId);
     }
   }
 
-  if (m_activeClipCount >= MAX_ACTIVE_CLIPS) {
+  if (m_activeClipCount >= m_config.maxActiveVoices) {
     TransportEvent event{};
     event.type = TransportEventType::ActiveClipLimitReached;
     event.handle = handle;
     event.position = getCurrentPosition();
     postTransportEvent(event);
-    return;
+    return false;
   }
 
   // Initialize clip with immutable context - NO MUTEX NEEDED HERE
-  ActiveClip& clip = m_activeClips[m_activeClipCount++];
+  const size_t voiceIndex = m_activeClipCount++;
+  ActiveClip& clip = m_activeClips[voiceIndex];
   clip.handle = handle;
   clip.voiceId = m_nextVoiceId++; // Multi-voice: Assign unique voice ID
   clip.startSample = m_currentSample.load(std::memory_order_relaxed);
@@ -1189,6 +1245,8 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   clip.numChannels = context->numChannels;
   clip.fileLengthSamples = context->fileLengthSamples; // ORP127 G3
   clip.voiceMode = context->voiceMode;                 // ORP127 G5
+  clip.routingGroup = context->routingGroup;
+  configureVoiceRouting(voiceIndex, clip.routingGroup, clip.numChannels);
   clip.fadeOutGain = 1.0f;
   clip.isStopping = false;
   clip.fadeOutStartPos = 0; // Will be set when stopClip() is called
@@ -1205,6 +1263,7 @@ void TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   if (clip.source) {
     clip.source->setDemand(context->trimInSamples);
   }
+  return true;
 }
 
 void TransportController::removeActiveVoice(uint32_t voiceId) {
@@ -1255,7 +1314,10 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
         dest.numChannels = src.numChannels;
         dest.fileLengthSamples = src.fileLengthSamples; // ORP127 G3
         dest.voiceMode = src.voiceMode;                 // ORP127 G5
+        dest.routingGroup = src.routingGroup;
+        configureVoiceRouting(i, dest.routingGroup, dest.numChannels);
       }
+      configureVoiceRouting(m_activeClipCount - 1, UNASSIGNED_GROUP, 0);
       --m_activeClipCount;
       return;
     }
@@ -1309,7 +1371,12 @@ void TransportController::removeActiveClip(ClipHandle handle) {
         dest.hasLoopedOnce = src.hasLoopedOnce; // ORP097 Bug 7 Fix
         dest.source = src.source;               // Copy shared_ptr (atomic refcount increment)
         dest.numChannels = src.numChannels;
+        dest.fileLengthSamples = src.fileLengthSamples;
+        dest.voiceMode = src.voiceMode;
+        dest.routingGroup = src.routingGroup;
+        configureVoiceRouting(i, dest.routingGroup, dest.numChannels);
       }
+      configureVoiceRouting(m_activeClipCount - 1, UNASSIGNED_GROUP, 0);
       --m_activeClipCount;
       return;
     }
@@ -1508,6 +1575,20 @@ SessionGraphError TransportController::registerClipAudio(ClipHandle handle,
     entry.metadata = result.value;
   }
 
+  if (entry.metadata.num_channels == 0 ||
+      entry.metadata.num_channels > m_config.maxSourceChannels ||
+      (m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete &&
+       entry.metadata.num_channels > m_config.outputChannels)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  if (const auto inferred = inferUnambiguousChannelFormat(entry.metadata.num_channels)) {
+    entry.sourceLayout = inferred->layout;
+    entry.speakerPatchSize = inferred->num_channels;
+    std::copy_n(inferred->channel_map.begin(), inferred->num_channels,
+                entry.speakerPatch.begin());
+  }
+
   // Apply session defaults to new clip
   entry.fadeInSeconds = m_sessionDefaults.fadeInSeconds;
   entry.fadeOutSeconds = m_sessionDefaults.fadeOutSeconds;
@@ -1581,7 +1662,7 @@ SessionGraphError TransportController::ensurePreparedSourceLocked(AudioFileEntry
 
   const uint16_t numChannels = entry.metadata.num_channels;
   if (!entry.reader || !entry.reader->isOpen() || numChannels == 0 ||
-      numChannels > MAX_FILE_CHANNELS) {
+      numChannels > m_config.maxSourceChannels) {
     return SessionGraphError::NotReady;
   }
 
@@ -1892,6 +1973,7 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   // Validate metadata before applying changes (atomic operation)
   // Get file duration for validation
   int64_t fileDurationSamples = 0;
+  uint16_t fileChannels = 0;
   {
     std::lock_guard<std::mutex> lock(m_audioFilesMutex);
     auto it = m_audioFiles.find(handle);
@@ -1899,6 +1981,7 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
       return SessionGraphError::ClipNotRegistered;
     }
     fileDurationSamples = it->second.metadata.duration_samples;
+    fileChannels = it->second.metadata.num_channels;
   }
 
   // Validate trim points
@@ -1933,6 +2016,17 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
     return SessionGraphError::InvalidParameter;
   }
 
+  if (metadata.routingGroup >= m_config.numGroups ||
+      fileChannels >
+          m_groupOutputWidths[metadata.routingGroup].load(
+              std::memory_order_acquire)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  if (!isValidSpeakerPatch(metadata.sourceLayout, metadata.speakerPatchSize,
+                           metadata.speakerPatch, fileChannels)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
   // All validation passed - apply changes atomically
   // Calculate fade sample counts
   int64_t fadeInSampleCount =
@@ -1955,6 +2049,10 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
       it->second.stopOthersOnPlay = metadata.stopOthersOnPlay;
       it->second.voiceMode = metadata.voiceMode; // ORP127 G5
       it->second.gainDb = metadata.gainDb;
+      it->second.routingGroup = metadata.routingGroup;
+      it->second.sourceLayout = metadata.sourceLayout;
+      it->second.speakerPatchSize = metadata.speakerPatchSize;
+      it->second.speakerPatch = metadata.speakerPatch;
     }
   }
 
@@ -1975,6 +2073,7 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   cmd.data.metadata.loopEnabled = metadata.loopEnabled;
   cmd.data.metadata.gainDb = metadata.gainDb;
   cmd.data.metadata.gainLinear = std::pow(10.0f, metadata.gainDb / 20.0f);
+  cmd.data.metadata.routingGroup = metadata.routingGroup;
 
   // Post best-effort: if the queue is full the persistent store already holds
   // the new metadata and it will be picked up on next start. Return OK to match
@@ -2007,6 +2106,10 @@ std::optional<ClipMetadata> TransportController::getClipMetadata(ClipHandle hand
   metadata.stopOthersOnPlay = it->second.stopOthersOnPlay;
   metadata.voiceMode = it->second.voiceMode; // ORP127 G5
   metadata.gainDb = it->second.gainDb;
+  metadata.routingGroup = it->second.routingGroup;
+  metadata.sourceLayout = it->second.sourceLayout;
+  metadata.speakerPatchSize = it->second.speakerPatchSize;
+  metadata.speakerPatch = it->second.speakerPatch;
 
   // If trim OUT is not set (0), use file duration
   if (metadata.trimOutSamples == 0) {
@@ -2014,6 +2117,44 @@ std::optional<ClipMetadata> TransportController::getClipMetadata(ClipHandle hand
   }
 
   return metadata;
+}
+
+SessionGraphError TransportController::setGroupOutputBus(
+    RoutingGroupIndex group, const OutputBusRoute& route) {
+  if (group >= m_config.numGroups || route.channelCount == 0 ||
+      static_cast<uint32_t>(route.outputStart) + route.channelCount >
+          m_config.outputChannels) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  std::lock_guard<std::mutex> lock(m_audioFilesMutex);
+  for (const auto& [handle, entry] : m_audioFiles) {
+    (void)handle;
+    if (entry.routingGroup == group &&
+        entry.metadata.num_channels > route.channelCount) {
+      return SessionGraphError::InvalidParameter;
+    }
+  }
+  const auto result = m_routingMatrix->setGroupOutputRoute(
+      group, route.outputStart, route.channelCount);
+  if (result != SessionGraphError::OK) {
+    return result;
+  }
+  m_groupOutputStarts[group].store(route.outputStart,
+                                    std::memory_order_release);
+  m_groupOutputWidths[group].store(route.channelCount,
+                                   std::memory_order_release);
+  return SessionGraphError::OK;
+}
+
+std::optional<OutputBusRoute>
+TransportController::getGroupOutputBus(RoutingGroupIndex group) const {
+  if (group >= m_config.numGroups) {
+    return std::nullopt;
+  }
+  return OutputBusRoute{
+      m_groupOutputStarts[group].load(std::memory_order_acquire),
+      m_groupOutputWidths[group].load(std::memory_order_acquire)};
 }
 
 float TransportController::calculateFadeGain(float normalizedPosition, FadeCurve curve) const {
@@ -2323,9 +2464,22 @@ float TransportController::applyDownmixRight(const float* src, size_t frame, siz
 }
 
 // Factory function
-std::unique_ptr<ITransportController> createTransportController(core::SessionGraph* sessionGraph,
-                                                                uint32_t sampleRate) {
-  return std::make_unique<TransportController>(sessionGraph, sampleRate);
+std::unique_ptr<ITransportController>
+createTransportController(core::SessionGraph* sessionGraph, const TransportConfig& config) {
+  constexpr uint32_t maxBlockFrames = 2048;
+  constexpr uint32_t maxActiveVoices = 32;
+  constexpr uint32_t maxSourceChannels = 8;
+  const uint64_t routingLanes =
+      static_cast<uint64_t>(config.maxActiveVoices) * config.maxSourceChannels;
+  if (config.sampleRate == 0 || config.outputChannels == 0 || config.outputChannels > 32 ||
+      config.maxBlockFrames == 0 || config.maxBlockFrames > maxBlockFrames ||
+      config.maxActiveVoices == 0 || config.maxActiveVoices > maxActiveVoices ||
+      config.numGroups == 0 || config.numGroups > 32 ||
+      config.maxSourceChannels == 0 || config.maxSourceChannels > maxSourceChannels ||
+      routingLanes > 256) {
+    return nullptr;
+  }
+  return std::make_unique<TransportController>(sessionGraph, config);
 }
 
 } // namespace orpheus

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -42,6 +42,7 @@ struct ClipPlaybackContext {
   float gainLinear;
   bool loopEnabled;
   uint16_t numChannels;
+  RoutingGroupIndex routingGroup{0};
   VoiceMode voiceMode; // ORP127 G5: voice policy captured at fire time
 };
 
@@ -110,6 +111,7 @@ struct TransportCommand {
       bool loopEnabled;
       float gainDb;
       float gainLinear;
+      RoutingGroupIndex routingGroup;
     } metadata;
   } data;
 };
@@ -167,6 +169,7 @@ struct ActiveClip {
       hasLoopedOnce; // true if clip has looped at least once (prevents re-applying start/end fades)
 
   uint16_t numChannels; // Number of channels in audio file
+  RoutingGroupIndex routingGroup{0};
 
   // ORP134 G1: thread-safe clip-source reference (captured from AudioFileEntry
   // when the clip starts). shared_ptr gives reference-counted lifetime:
@@ -231,11 +234,11 @@ struct VoiceSnapshot {
 /// Transport controller implementation
 class TransportController : public ITransportController {
 public:
-  TransportController(core::SessionGraph* sessionGraph, uint32_t sampleRate);
+  TransportController(core::SessionGraph* sessionGraph, const TransportConfig& config);
   ~TransportController() override;
 
-  TransportRenderConfig getRenderConfig() const noexcept override;
-  void processAudio(float** outputBuffers, size_t numChannels,
+  TransportConfig getRenderConfig() const noexcept override;
+  void processAudio(float* const* outputBuffers, size_t numChannels,
                     size_t numFrames) noexcept override;
   void processCallbacks() override;
 
@@ -267,6 +270,10 @@ public:
   bool getClipStopOthersMode(ClipHandle handle) const override;
   SessionGraphError updateClipMetadata(ClipHandle handle, const ClipMetadata& metadata) override;
   std::optional<ClipMetadata> getClipMetadata(ClipHandle handle) const override;
+  SessionGraphError setGroupOutputBus(
+      RoutingGroupIndex group, const OutputBusRoute& route) override;
+  std::optional<OutputBusRoute>
+  getGroupOutputBus(RoutingGroupIndex group) const override;
   void setSessionDefaults(const SessionDefaults& defaults) override;
   SessionDefaults getSessionDefaults() const override;
   bool isClipLooping(ClipHandle handle) const override;
@@ -344,9 +351,11 @@ private:
   /// @return Pointer to oldest voice, or nullptr if none found
   ActiveClip* findOldestVoice(ClipHandle handle);
 
-  /// Add a clip to active list (audio thread only)
-  /// @param context Playback context with immutable state
-  void addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context);
+  /// Add a clip to the active list. Returns false when the global voice pool
+  /// cannot accept the start.
+  bool addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context);
+  void configureVoiceRouting(size_t voiceIndex, RoutingGroupIndex group,
+                             uint16_t numChannels) noexcept;
 
   /// ORP127 G5: Fire a voice honoring the context's VoiceMode (audio thread).
   /// - Polyphonic: always allocate a new voice (historical behavior).
@@ -354,7 +363,7 @@ private:
   ///   only fading tails exist, add a fresh voice alongside them.
   /// - MonoStrict: restart in place with no fade tail; if a voice is fading,
   ///   cut it and start fresh (single voice, sample-accurate replace).
-  void startVoiceWithMode(const std::shared_ptr<ClipPlaybackContext>& context);
+  bool startVoiceWithMode(const std::shared_ptr<ClipPlaybackContext>& context);
 
   /// ORP127 G5: Reset an existing voice back to its trim IN for an in-place
   /// restart (used by the mono voice modes). Applies the broadcast-safe restart
@@ -393,6 +402,7 @@ private:
 
   // Configuration
   core::SessionGraph* m_sessionGraph;
+  TransportConfig m_config;
   uint32_t m_sampleRate;
   ITransportCallback* m_callback; // User-provided callback
 
@@ -472,6 +482,8 @@ private:
   size_t m_fadeOutSamples;          // Calculated from sample rate
   size_t m_restartCrossfadeSamples; // Calculated from sample rate
 
+  static constexpr size_t MAX_FILE_CHANNELS = 8;
+
   // Audio file registry (UI thread access, mutex protected)
   struct AudioFileEntry {
     std::shared_ptr<orpheus::IAudioFileReader> reader;
@@ -491,6 +503,12 @@ private:
     // ORP127 G5: voice allocation policy for this clip (default preserves the
     // SDK's historical polyphonic behavior).
     VoiceMode voiceMode = VoiceMode::Polyphonic;
+    RoutingGroupIndex routingGroup = 0;
+    ChannelLayout sourceLayout = ChannelLayout::Unspecified;
+    uint8_t speakerPatchSize = 0;
+    std::array<Speaker, MAX_FILE_CHANNELS> speakerPatch = {
+        Speaker::None, Speaker::None, Speaker::None, Speaker::None,
+        Speaker::None, Speaker::None, Speaker::None, Speaker::None};
 
     // ORP134 G1: the realtime playback source built by prepareClipAudio()
     // (or lazily by startClip). The reader above remains the background
@@ -509,6 +527,11 @@ private:
 
   // Routing matrix for final mix (audio thread processes, UI thread configures)
   std::unique_ptr<IRoutingMatrix> m_routingMatrix;
+  static constexpr size_t MAX_LOGICAL_GROUPS = 32;
+  std::array<std::atomic<RoutingOutputIndex>, MAX_LOGICAL_GROUPS>
+      m_groupOutputStarts{};
+  std::array<std::atomic<uint16_t>, MAX_LOGICAL_GROUPS>
+      m_groupOutputWidths{};
 
   // Fixed-capacity audio-thread → message-thread telemetry bridge.
   RealtimeTelemetry m_realtimeTelemetry{};
@@ -522,21 +545,18 @@ private:
   int64_t m_preparedSourceMaxFrames{DEFAULT_PREPARED_SOURCE_MAX_FRAMES};
   std::unique_ptr<MediaStreamWorker> m_streamWorker; // guarded by m_audioFilesMutex
 
-  // Per-clip buffers (audio thread only, pre-allocated)
+  // Compile-time ceilings; each instance allocates only its configured shape.
   static constexpr size_t MAX_BUFFER_FRAMES = 2048;
-  static constexpr size_t MAX_FILE_CHANNELS = 8;
 
-  // Each clip gets its own read buffer (for interleaved audio from file)
-  std::vector<std::vector<float>>
-      m_clipReadBuffers; // [MAX_ACTIVE_CLIPS][MAX_BUFFER_FRAMES * MAX_FILE_CHANNELS]
+  // Per-voice interleaved decode buffers.
+  std::vector<std::vector<float>> m_clipReadBuffers;
 
-  // ORP121 A-01: Stereo clip buffers for routing (preserves source L/R)
-  // Each clip has L and R buffers: [clip_index * 2 + 0] = L, [clip_index * 2 + 1] = R
-  // Total channels = MAX_ACTIVE_CLIPS * 2 for stereo preservation
-  std::vector<std::vector<float>> m_clipChannelBuffers; // [MAX_ACTIVE_CLIPS * 2][MAX_BUFFER_FRAMES]
-  std::vector<float*> m_clipChannelPointers;            // Pointers for processRouting()
+  // Preallocated planar routing lanes:
+  // [voice slot * maxSourceChannels + source channel][frame].
+  std::vector<std::vector<float>> m_clipChannelBuffers;
+  std::vector<float*> m_clipChannelPointers;
 
-  // ORP121 A-01: ITU-R BS.775-3 downmix helpers for multi-channel sources
+  // StereoPairs compatibility downmix.
   float applyDownmixLeft(const float* src, size_t frame, size_t numCh) const;
   float applyDownmixRight(const float* src, size_t frame, size_t numCh) const;
 };

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <cstring>
 #include <sstream>
 #include <thread>
@@ -38,6 +39,8 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
 
   // Store configuration
   config_ = config;
+  expected_stream_sample_ = 0;
+  stream_timeline_initialized_ = false;
 
   // Find device
   device_id_ = findDevice(config.device_name);
@@ -164,6 +167,14 @@ AudioDriverCapabilities CoreAudioDriver::getCapabilities() const {
   caps.max_input_channels = config_.num_inputs;
   caps.native_sample_rates.push_back(config_.sample_rate);
   caps.native_buffer_sizes.push_back(config_.buffer_size);
+  const std::string endpoint =
+      config_.device_id.empty() ? "coreaudio:default" : config_.device_id;
+  for (uint16_t channel = 0; channel < config_.num_inputs; ++channel) {
+    caps.input_channel_ids.push_back(endpoint + ":input:" + std::to_string(channel));
+  }
+  for (uint16_t channel = 0; channel < config_.num_outputs; ++channel) {
+    caps.output_channel_ids.push_back(endpoint + ":output:" + std::to_string(channel));
+  }
   caps.supports_exclusive_mode = false;
   caps.supports_shared_mode = true;
   caps.supports_device_hot_swap = true;
@@ -250,16 +261,43 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   }
 
   // Invoke user callback (lock-free). Timing is opt-in for diagnostics builds;
-  // production callbacks should not pay for hot-path instrumentation.
+  // production callbacks should not pay for callback-duration instrumentation.
   const float** input_ptrs = driver->input_buffers_.empty()
                                  ? nullptr
                                  : const_cast<const float**>(driver->input_buffers_.data());
   float** output_ptrs = driver->output_buffers_.data();
 
+  const bool sample_time_valid =
+      inTimeStamp != nullptr && (inTimeStamp->mFlags & kAudioTimeStampSampleTimeValid) != 0;
+  const int64_t reported_sample_time =
+      sample_time_valid ? static_cast<int64_t>(std::llround(inTimeStamp->mSampleTime)) : 0;
+  const bool device_position_available = sample_time_valid && reported_sample_time >= 0;
+  const int64_t stream_time =
+      device_position_available ? reported_sample_time : driver->expected_stream_sample_;
+  const bool discontinuity = !driver->stream_timeline_initialized_ ||
+                             !device_position_available ||
+                             stream_time != driver->expected_stream_sample_;
+  const bool host_time_valid =
+      inTimeStamp != nullptr && (inTimeStamp->mFlags & kAudioTimeStampHostTimeValid) != 0;
+
+  AudioProcessBlock block;
+  block.input_buffers = input_ptrs;
+  block.output_buffers = output_ptrs;
+  block.num_input_channels = static_cast<uint16_t>(num_input_channels);
+  block.num_output_channels = static_cast<uint16_t>(num_channels);
+  block.num_frames = frames_to_process;
+  block.device_sample_position =
+      device_position_available ? static_cast<uint64_t>(reported_sample_time) : 0;
+  block.host_time_nanoseconds =
+      host_time_valid ? AudioConvertHostTimeToNanos(inTimeStamp->mHostTime) : 0;
+  block.discontinuity = discontinuity;
+
 #if defined(ORPHEUS_ENABLE_AUDIO_CALLBACK_TIMING)
   const UInt64 callback_start = AudioGetCurrentHostTime();
 #endif
-  callback->processAudio(input_ptrs, output_ptrs, num_channels, frames_to_process);
+  callback->processAudio(block);
+  driver->expected_stream_sample_ = stream_time + frames_to_process;
+  driver->stream_timeline_initialized_ = true;
 #if defined(ORPHEUS_ENABLE_AUDIO_CALLBACK_TIMING)
   const UInt64 callback_end = AudioGetCurrentHostTime();
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -93,6 +93,8 @@ private:
   // Performance monitoring (optional, only read by diagnostics callback builds)
   std::atomic<IPerformanceMonitor*> performance_monitor_{nullptr};
   std::atomic<uint32_t> callbacks_in_flight_{0};
+  int64_t expected_stream_sample_{0};
+  bool stream_timeline_initialized_{false};
 
   // Audio thread buffers (allocated once in initialize)
   std::vector<float*> input_buffers_;

--- a/src/platform/audio_drivers/wasapi/wasapi_driver.cpp
+++ b/src/platform/audio_drivers/wasapi/wasapi_driver.cpp
@@ -247,6 +247,12 @@ public:
     if (initialized_) {
       capabilities.native_sample_rates.push_back(config_.sample_rate);
       capabilities.native_buffer_sizes.push_back(config_.buffer_size);
+      const std::string endpoint =
+          config_.device_id.empty() ? "wasapi:default" : config_.device_id;
+      for (uint16_t channel = 0; channel < config_.num_outputs; ++channel) {
+        capabilities.output_channel_ids.push_back(endpoint + ":output:" +
+                                                  std::to_string(channel));
+      }
     }
     return capabilities;
   }
@@ -261,19 +267,23 @@ private:
     const bool uninitialize = SUCCEEDED(comResult);
     DWORD taskIndex = 0;
     HANDLE task = AvSetMmThreadCharacteristicsW(L"Pro Audio", &taskIndex);
+    bool discontinuity = true;
 
     while (running_.load(std::memory_order_acquire)) {
       if (WaitForSingleObject(event_, 2000) != WAIT_OBJECT_0 ||
           !running_.load(std::memory_order_acquire)) {
+        discontinuity = true;
         continue;
       }
       UINT32 padding = 0;
       if (FAILED(client_->GetCurrentPadding(&padding)) || padding >= bufferFrames_) {
+        discontinuity = true;
         continue;
       }
       const UINT32 frames = bufferFrames_ - padding;
       BYTE* deviceBuffer = nullptr;
       if (FAILED(renderClient_->GetBuffer(frames, &deviceBuffer))) {
+        discontinuity = true;
         continue;
       }
 
@@ -284,9 +294,19 @@ private:
       const auto started = std::chrono::steady_clock::now();
       uint32_t activeClips = 0;
       if (callback != nullptr) {
-        callback->processAudio(nullptr, planarPointers_.data(), planarPointers_.size(), frames);
+        AudioProcessBlock block;
+        block.output_buffers = planarPointers_.data();
+        block.num_output_channels = static_cast<uint16_t>(planarPointers_.size());
+        block.num_frames = frames;
+        block.device_sample_position = 0;
+        block.host_time_nanoseconds = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(started.time_since_epoch())
+                .count());
+        block.discontinuity = discontinuity;
+        callback->processAudio(block);
         activeClips = callback->activeClipCount();
       }
+      discontinuity = false;
 
       if (isFloatFormat(format_)) {
         auto* output = reinterpret_cast<float*>(deviceBuffer);

--- a/tests/audio_io/coreaudio_driver_test.cpp
+++ b/tests/audio_io/coreaudio_driver_test.cpp
@@ -22,8 +22,10 @@ using namespace orpheus;
 // Test callback that counts invocations and measures timing
 class TestCallback : public IAudioCallback {
 public:
-  void processAudio(const float** input_buffers, float** output_buffers, size_t num_channels,
-                    size_t num_frames) override {
+  void processAudio(const AudioProcessBlock& block) noexcept override {
+    auto output_buffers = block.output_buffers;
+    const size_t num_channels = block.num_output_channels;
+    const size_t num_frames = block.num_frames;
     m_call_count.fetch_add(1, std::memory_order_relaxed);
     m_last_num_channels = num_channels;
     m_last_num_frames = num_frames;
@@ -101,8 +103,11 @@ private:
 // zero; this callback makes that observable.
 class InputCaptureCallback : public IAudioCallback {
 public:
-  void processAudio(const float** input_buffers, float** output_buffers, size_t num_channels,
-                    size_t num_frames) override {
+  void processAudio(const AudioProcessBlock& block) noexcept override {
+    auto input_buffers = block.input_buffers;
+    auto output_buffers = block.output_buffers;
+    const size_t num_channels = block.num_output_channels;
+    const size_t num_frames = block.num_frames;
     m_call_count.fetch_add(1, std::memory_order_relaxed);
 
     if (input_buffers != nullptr && input_buffers[0] != nullptr) {

--- a/tests/audio_io/device_hot_swap_test.cpp
+++ b/tests/audio_io/device_hot_swap_test.cpp
@@ -14,8 +14,10 @@ using namespace orpheus;
 /// Simple audio callback for testing (generates silence)
 class SilenceCallback : public IAudioCallback {
 public:
-  void processAudio(const float** /*input_buffers*/, float** output_buffers, size_t num_channels,
-                    size_t num_frames) override {
+  void processAudio(const AudioProcessBlock& block) noexcept override {
+    auto output_buffers = block.output_buffers;
+    const size_t num_channels = block.num_output_channels;
+    const size_t num_frames = block.num_frames;
     // Generate silence
     for (size_t ch = 0; ch < num_channels; ++ch) {
       for (size_t i = 0; i < num_frames; ++i) {

--- a/tests/audio_io/dummy_driver_test.cpp
+++ b/tests/audio_io/dummy_driver_test.cpp
@@ -11,11 +11,13 @@ using namespace orpheus;
 // Test callback that counts invocations
 class TestCallback : public IAudioCallback {
 public:
-  void processAudio(const float** input_buffers, float** output_buffers, size_t num_channels,
-                    size_t num_frames) override {
+  void processAudio(const AudioProcessBlock& block) noexcept override {
+    auto output_buffers = block.output_buffers;
+    const size_t num_channels = block.num_output_channels;
+    const size_t num_frames = block.num_frames;
     m_call_count.fetch_add(1, std::memory_order_relaxed);
-    m_last_num_channels = num_channels;
-    m_last_num_frames = num_frames;
+    m_last_num_channels.store(num_channels, std::memory_order_relaxed);
+    m_last_num_frames.store(num_frames, std::memory_order_relaxed);
 
     // Fill output with a simple pattern for verification
     for (size_t ch = 0; ch < num_channels; ++ch) {
@@ -23,6 +25,20 @@ public:
         output_buffers[ch][i] = 0.5f; // Simple constant
       }
     }
+    bool distinct = true;
+    bool patternVerified = num_frames > 0;
+    for (size_t ch = 0; ch < num_channels; ++ch) {
+      for (size_t other = 0; other < ch; ++other) {
+        distinct = distinct && output_buffers[ch] != output_buffers[other];
+      }
+      if (num_frames > 0) {
+        output_buffers[ch][0] = static_cast<float>(ch + 1) / 16.0f;
+        patternVerified =
+            patternVerified && output_buffers[ch][0] == static_cast<float>(ch + 1) / 16.0f;
+      }
+    }
+    m_distinct_output_channels.store(distinct, std::memory_order_relaxed);
+    m_channel_pattern_verified.store(patternVerified, std::memory_order_relaxed);
   }
 
   int getCallCount() const {
@@ -34,16 +50,24 @@ public:
   }
 
   size_t getLastNumChannels() const {
-    return m_last_num_channels;
+    return m_last_num_channels.load(std::memory_order_relaxed);
   }
   size_t getLastNumFrames() const {
-    return m_last_num_frames;
+    return m_last_num_frames.load(std::memory_order_relaxed);
+  }
+  bool hasDistinctOutputChannels() const {
+    return m_distinct_output_channels.load(std::memory_order_relaxed);
+  }
+  bool isChannelPatternVerified() const {
+    return m_channel_pattern_verified.load(std::memory_order_relaxed);
   }
 
 private:
   std::atomic<int> m_call_count{0};
-  size_t m_last_num_channels{0};
-  size_t m_last_num_frames{0};
+  std::atomic<size_t> m_last_num_channels{0};
+  std::atomic<size_t> m_last_num_frames{0};
+  std::atomic<bool> m_distinct_output_channels{false};
+  std::atomic<bool> m_channel_pattern_verified{false};
 };
 
 // Test fixture
@@ -165,6 +189,24 @@ TEST_F(DummyDriverTest, CallbackIsInvoked) {
   EXPECT_EQ(m_callback->getLastNumFrames(), config.buffer_size);
 
   m_driver->stop();
+}
+
+TEST_F(DummyDriverTest, EightOutputCallbackReceivesDistinctWritableLanes) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 64;
+  config.num_outputs = 8;
+
+  ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  ASSERT_EQ(m_driver->stop(), SessionGraphError::OK);
+
+  EXPECT_GT(m_callback->getCallCount(), 0);
+  EXPECT_EQ(m_callback->getLastNumChannels(), 8u);
+  EXPECT_EQ(m_callback->getLastNumFrames(), 64u);
+  EXPECT_TRUE(m_callback->hasDistinctOutputChannels());
+  EXPECT_TRUE(m_callback->isChannelPatternVerified());
 }
 
 TEST_F(DummyDriverTest, CallbackIsNotInvokedAfterStop) {

--- a/tests/cmake/add_subdirectory/main.cpp
+++ b/tests/cmake/add_subdirectory/main.cpp
@@ -17,7 +17,7 @@ using namespace orpheus;
 int main() {
   // Transport is host-neutral: a null SessionGraph is fine for a link/compile
   // smoke test (we never register real audio here).
-  auto transport = createTransportController(nullptr, 48000);
+  auto transport = createTransportController(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   if (!transport) {
     return 1;
   }

--- a/tests/cmake/find_package/transport_routing.cpp
+++ b/tests/cmake/find_package/transport_routing.cpp
@@ -27,7 +27,7 @@ int main() {
     return 2;
   }
 
-  auto transport = orpheus::createTransportController(nullptr, 48000);
+  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   auto manager = orpheus::createAudioDriverManager();
   return transport != nullptr && manager != nullptr && routing->maxBlockFrames() >= 1 ? 0 : 1;
 }

--- a/tests/cmake/find_package/workflow_contracts.cpp
+++ b/tests/cmake/find_package/workflow_contracts.cpp
@@ -40,7 +40,7 @@ int main() {
     return 4;
   }
 
-  auto transport = orpheus::createTransportController(&graph, 48000);
+  auto transport = orpheus::createTransportController(&graph, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   if (!transport || !transport->getRealtimeTelemetry()) {
     return 5;
   }

--- a/tests/common/performance_integration_test.cpp
+++ b/tests/common/performance_integration_test.cpp
@@ -16,7 +16,7 @@ protected:
   void SetUp() override {
     m_sessionGraph = std::make_unique<core::SessionGraph>();
     m_monitor = createPerformanceMonitor(m_sessionGraph.get());
-    m_transport = createTransportController(m_sessionGraph.get(), 48000);
+    m_transport = createTransportController(m_sessionGraph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   }
 
   void TearDown() override {

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -28,12 +28,12 @@ int main() {
   constexpr orpheus::ClipHandle kHandle = 17;
   constexpr size_t kFrames = 64;
 
-  auto transport = orpheus::createTransportController(nullptr, kSampleRate);
+  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
   if (!transport) {
     return 1;
   }
 
-  const orpheus::TransportRenderConfig config = transport->getRenderConfig();
+  const orpheus::TransportConfig config = transport->getRenderConfig();
   if (config.sampleRate != kSampleRate || config.outputChannels != 2 ||
       config.maxBlockFrames < kFrames) {
     return 2;

--- a/tests/routing/routing_matrix_test.cpp
+++ b/tests/routing/routing_matrix_test.cpp
@@ -82,7 +82,7 @@ TEST_F(RoutingMatrixTest, InitializeWithInvalidChannelCount) {
 }
 
 TEST_F(RoutingMatrixTest, InitializeWithTooManyChannels) {
-  config.num_channels = 65; // > 64
+  config.num_channels = 257; // > 256 logical source lanes
   auto result = matrix->initialize(config);
 
   EXPECT_EQ(result, SessionGraphError::InvalidParameter);
@@ -95,11 +95,12 @@ TEST_F(RoutingMatrixTest, InitializeWithInvalidGroupCount) {
   EXPECT_EQ(result, SessionGraphError::InvalidParameter);
 }
 
-TEST_F(RoutingMatrixTest, InitializeWithInvalidOutputCount) {
-  config.num_outputs = 1; // < 2 (stereo minimum)
+TEST_F(RoutingMatrixTest, InitializeWithMonoOutput) {
+  config.num_outputs = 1;
   auto result = matrix->initialize(config);
 
-  EXPECT_EQ(result, SessionGraphError::InvalidParameter);
+  EXPECT_EQ(result, SessionGraphError::OK);
+  EXPECT_EQ(matrix->getConfig().num_outputs, 1);
 }
 
 // ============================================================================
@@ -352,6 +353,28 @@ TEST_F(RoutingMatrixTest, SoloChannelMutesOthers) {
 
   // Channel 1 should be effectively muted (solo active, not solo'd)
   EXPECT_TRUE(matrix->isChannelMuted(1));
+}
+
+TEST_F(RoutingMatrixTest, GroupSoloDoesNotMuteSourceChannels) {
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  ASSERT_EQ(matrix->setGroupSolo(0, true), SessionGraphError::OK);
+
+  EXPECT_TRUE(matrix->isSoloActive());
+  for (RoutingChannelIndex channel = 0; channel < config.num_channels; ++channel)
+    EXPECT_FALSE(matrix->isChannelMuted(channel));
+  EXPECT_FALSE(matrix->isGroupMuted(0));
+  EXPECT_TRUE(matrix->isGroupMuted(1));
+}
+
+TEST_F(RoutingMatrixTest, ChannelSoloDoesNotMuteLogicalGroups) {
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  ASSERT_EQ(matrix->setChannelSolo(0, true), SessionGraphError::OK);
+
+  EXPECT_TRUE(matrix->isSoloActive());
+  EXPECT_FALSE(matrix->isChannelMuted(0));
+  EXPECT_TRUE(matrix->isChannelMuted(1));
+  for (RoutingGroupIndex group = 0; group < config.num_groups; ++group)
+    EXPECT_FALSE(matrix->isGroupMuted(group));
 }
 
 // ============================================================================

--- a/tests/session/scene_manager_test.cpp
+++ b/tests/session/scene_manager_test.cpp
@@ -22,7 +22,7 @@ protected:
 
     // Create scene manager
     sceneManager = createSceneManager(sessionGraph.get());
-    transport = createTransportController(sessionGraph.get(), 48000);
+    transport = createTransportController(sessionGraph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     sceneManager->setTransportController(transport.get());
 
     // Use std::filesystem for portable temp directory
@@ -125,7 +125,7 @@ TEST_F(SceneManagerTest, CaptureSceneTimestampIncreases) {
 
 TEST(SceneManagerPackageContract, SelfContainedFactoryCanCaptureAndRecall) {
   auto manager = createSceneManager();
-  auto packageTransport = createTransportController(nullptr, 48000);
+  auto packageTransport = createTransportController(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   ASSERT_NE(manager, nullptr);
   ASSERT_NE(packageTransport, nullptr);
   ASSERT_NE(packageTransport->getRoutingMatrix(), nullptr);

--- a/tests/session/scene_routing_test.cpp
+++ b/tests/session/scene_routing_test.cpp
@@ -27,7 +27,7 @@ protected:
     m_graph = std::make_unique<core::SessionGraph>();
     m_scenes = createSceneManager(m_graph.get());
     ASSERT_NE(m_scenes, nullptr);
-    m_transport = createTransportController(m_graph.get(), 48000);
+    m_transport = createTransportController(m_graph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     ASSERT_NE(m_transport, nullptr);
     m_scenes->setTransportController(m_transport.get());
 

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -147,6 +147,37 @@ if(TARGET orpheus_audio_io)
         COMMAND transport_integration_test
     )
 
+    add_executable(multichannel_transport_test
+        multichannel_transport_test.cpp
+    )
+
+    target_link_libraries(multichannel_transport_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(multichannel_transport_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(multichannel_transport_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(multichannel_transport_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+    )
+
+    add_test(
+        NAME multichannel_transport_test
+        COMMAND multichannel_transport_test
+    )
+
     # Multi-clip stress test
     add_executable(multi_clip_stress_test
         multi_clip_stress_test.cpp

--- a/tests/transport/callback_queue_stress_test.cpp
+++ b/tests/transport/callback_queue_stress_test.cpp
@@ -62,7 +62,7 @@ protected:
   static constexpr size_t BUFFER_SIZE = 512;
 
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, SAMPLE_RATE);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(SAMPLE_RATE)});
     m_callback = std::make_unique<CountingCallback>();
     m_transport->setCallback(m_callback.get());
   }

--- a/tests/transport/choke_and_voice_cap_test.cpp
+++ b/tests/transport/choke_and_voice_cap_test.cpp
@@ -84,7 +84,7 @@ public:
 class ChokeAndVoiceCapTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_dir = std::filesystem::temp_directory_path() / "orp127_choke";
     std::filesystem::create_directories(m_dir);
   }

--- a/tests/transport/clip_cue_points_test.cpp
+++ b/tests/transport/clip_cue_points_test.cpp
@@ -13,7 +13,7 @@ class ClipCuePointsTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Create transport controller (nullptr for SessionGraph - not needed for cue point tests)
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
     // Register a test clip handle
     m_clipHandle = 12345;

--- a/tests/transport/clip_cue_points_test_simple.cpp
+++ b/tests/transport/clip_cue_points_test_simple.cpp
@@ -9,7 +9,7 @@ using namespace orpheus;
 /// Test invalid handle error cases (no audio file needed)
 TEST(ClipCuePointsSimpleTest, AddCuePointInvalidHandle) {
   // No audio file needed - testing error handling
-  auto transport = createTransportController(nullptr, 48000);
+  auto transport = createTransportController(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
   // Try to add cue point to non-existent clip
   int index = transport->addCuePoint(99999, 1000, "Invalid", 0xFFFFFFFF);
@@ -18,7 +18,7 @@ TEST(ClipCuePointsSimpleTest, AddCuePointInvalidHandle) {
 
 /// Test getting cue points from invalid handle
 TEST(ClipCuePointsSimpleTest, GetCuePointsInvalidHandle) {
-  auto transport = createTransportController(nullptr, 48000);
+  auto transport = createTransportController(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
   // Try to get cue points from non-existent clip
   auto cuePoints = transport->getCuePoints(99999);

--- a/tests/transport/clip_gain_smoothing_test.cpp
+++ b/tests/transport/clip_gain_smoothing_test.cpp
@@ -64,7 +64,7 @@ std::string writeConstantWav(const std::filesystem::path& path, float durationSe
 class ClipGainSmoothingTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_path = (std::filesystem::temp_directory_path() / "orp127_gain_smooth.wav").string();
     writeConstantWav(m_path, 2.0f, kSampleRate);
   }

--- a/tests/transport/clip_gain_test.cpp
+++ b/tests/transport/clip_gain_test.cpp
@@ -22,7 +22,7 @@ using namespace orpheus;
 class ClipGainTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_gain.wav").string();
     // Create test audio file with known samples for verification
     createTestAudioFile();

--- a/tests/transport/clip_loop_test.cpp
+++ b/tests/transport/clip_loop_test.cpp
@@ -13,7 +13,7 @@ using namespace orpheus;
 class ClipLoopTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
     // Create test audio file (short clip for faster loop testing)
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_loop.wav").string();

--- a/tests/transport/clip_metadata_test.cpp
+++ b/tests/transport/clip_metadata_test.cpp
@@ -12,7 +12,7 @@ using namespace orpheus;
 class ClipMetadataTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_metadata.wav").string();
     createTestAudioFile();
   }

--- a/tests/transport/clip_restart_test.cpp
+++ b/tests/transport/clip_restart_test.cpp
@@ -14,7 +14,7 @@ using namespace orpheus;
 class ClipRestartTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_restart.wav").string();
     createTestAudioFile();
   }
@@ -179,7 +179,7 @@ protected:
   void SetUp() override {
     m_session = std::make_unique<core::SessionGraph>();
     m_session->set_tempo(90.0);
-    m_transport = std::make_unique<TransportController>(m_session.get(), 48000);
+    m_transport = std::make_unique<TransportController>(m_session.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_transport->processCallbacks();
     m_callback = std::make_unique<TestCallback>();
     m_transport->setCallback(m_callback.get());

--- a/tests/transport/clip_seek_test.cpp
+++ b/tests/transport/clip_seek_test.cpp
@@ -14,7 +14,7 @@ using namespace orpheus;
 class ClipSeekTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_seek.wav").string();
     createTestAudioFile();
   }
@@ -264,7 +264,7 @@ protected:
   void SetUp() override {
     m_session = std::make_unique<core::SessionGraph>();
     m_session->set_tempo(90.0);
-    m_transport = std::make_unique<TransportController>(m_session.get(), 48000);
+    m_transport = std::make_unique<TransportController>(m_session.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_transport->processCallbacks();
     m_callback = std::make_unique<TestCallback>();
     m_transport->setCallback(m_callback.get());

--- a/tests/transport/command_producer_assert_test.cpp
+++ b/tests/transport/command_producer_assert_test.cpp
@@ -27,7 +27,8 @@ constexpr uint32_t kSampleRate = 48000;
 
 TEST(CommandProducerAssertTest, SingleThreadProducerIsAccepted) {
   // The legal pattern: every control-mutating call from one thread.
-  TransportController transport(nullptr, kSampleRate);
+  TransportController transport(
+      nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
   for (int i = 0; i < 64; ++i) {
     EXPECT_EQ(transport.startClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
     EXPECT_EQ(transport.stopClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
@@ -38,7 +39,8 @@ TEST(CommandProducerAssertTest, SingleThreadProducerIsAccepted) {
 TEST(CommandProducerAssertTest, DedicatedControlThreadIsAccepted) {
   // A single non-main control thread is equally legal — the contract is ONE
   // producer thread, not specifically the thread that constructed the object.
-  TransportController transport(nullptr, kSampleRate);
+  TransportController transport(
+      nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
   std::thread control([&transport]() {
     for (int i = 0; i < 64; ++i) {
       EXPECT_EQ(transport.startClip(static_cast<ClipHandle>(i % 8 + 1)), SessionGraphError::OK);
@@ -56,7 +58,8 @@ TEST(CommandProducerAssertTest, SecondProducerThreadAsserts) {
 
   EXPECT_DEATH(
       {
-        TransportController transport(nullptr, kSampleRate);
+        TransportController transport(
+            nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
         // Main thread claims the producer role...
         transport.startClip(1);
         // ...so a post from any other thread violates the SPSC contract.

--- a/tests/transport/fade_processing_test.cpp
+++ b/tests/transport/fade_processing_test.cpp
@@ -15,7 +15,7 @@ using namespace orpheus;
 class FadeProcessingTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_fade_audio.wav").string();
     // Create a test audio file (1 second of silence at 48kHz)
     createTestAudioFile();

--- a/tests/transport/integration_test.cpp
+++ b/tests/transport/integration_test.cpp
@@ -17,12 +17,9 @@ class TransportAudioAdapter : public IAudioCallback {
 public:
   explicit TransportAudioAdapter(TransportController* transport) : m_transport(transport) {}
 
-  void processAudio(const float** input_buffers, float** output_buffers, size_t num_channels,
-                    size_t num_frames) override {
-    (void)input_buffers; // Not used for playback
-
+  void processAudio(const AudioProcessBlock& block) noexcept override {
     if (m_transport) {
-      m_transport->processAudio(output_buffers, num_channels, num_frames);
+      m_transport->processAudio(block.output_buffers, block.num_output_channels, block.num_frames);
     }
 
     m_callback_count.fetch_add(1, std::memory_order_relaxed);
@@ -90,7 +87,7 @@ class TransportIntegrationTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Create transport controller (no SessionGraph for now)
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
     // Create transport callback
     m_transport_callback = std::make_unique<TestTransportCallback>();

--- a/tests/transport/multi_clip_stress_test.cpp
+++ b/tests/transport/multi_clip_stress_test.cpp
@@ -30,7 +30,7 @@ class MultiClipStressTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Create transport controller (no SessionGraph for now)
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
     // Create dummy audio driver
     m_driver = createDummyAudioDriver();
@@ -109,12 +109,10 @@ protected:
   public:
     explicit TransportAudioAdapter(TransportController* transport) : m_transport(transport) {}
 
-    void processAudio(const float** input_buffers, float** output_buffers, size_t num_channels,
-                      size_t num_frames) override {
-      (void)input_buffers; // Not used for playback
-
+    void processAudio(const AudioProcessBlock& block) noexcept override {
       if (m_transport) {
-        m_transport->processAudio(output_buffers, num_channels, num_frames);
+        m_transport->processAudio(block.output_buffers, block.num_output_channels,
+                                  block.num_frames);
       }
 
       m_callbackCount.fetch_add(1, std::memory_order_relaxed);

--- a/tests/transport/multichannel_transport_test.cpp
+++ b/tests/transport/multichannel_transport_test.cpp
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+#include "../../src/core/transport/transport_controller.h"
+#include <orpheus/channel_format.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace orpheus;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint16_t kChannels = 8;
+constexpr size_t kFrames = 64;
+
+class MultichannelTransportTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    filePath = (std::filesystem::temp_directory_path() /
+                "orpheus_multichannel_transport_test.wav")
+                   .string();
+    stereoPath = (std::filesystem::temp_directory_path() /
+                  "orpheus_stereo_route_test.wav")
+                     .string();
+    writeFixture(filePath, kChannels);
+    writeFixture(stereoPath, 2);
+  }
+
+  void TearDown() override {
+    std::error_code error;
+    std::filesystem::remove(filePath, error);
+    std::filesystem::remove(stereoPath, error);
+  }
+
+  void writeFixture(const std::string& path, uint16_t channels) const {
+    constexpr uint16_t bitsPerSample = 16;
+    const uint16_t blockAlign = channels * (bitsPerSample / 8);
+    const uint32_t dataSize = static_cast<uint32_t>(kFrames * blockAlign);
+    const uint32_t riffSize = 36 + dataSize;
+    const uint32_t byteRate = kSampleRate * blockAlign;
+    constexpr uint32_t fmtSize = 16;
+    constexpr uint16_t pcmFormat = 1;
+
+    std::ofstream file(path, std::ios::binary);
+    ASSERT_TRUE(file.is_open());
+    file.write("RIFF", 4);
+    file.write(reinterpret_cast<const char*>(&riffSize), sizeof(riffSize));
+    file.write("WAVEfmt ", 8);
+    file.write(reinterpret_cast<const char*>(&fmtSize), sizeof(fmtSize));
+    file.write(reinterpret_cast<const char*>(&pcmFormat), sizeof(pcmFormat));
+    file.write(reinterpret_cast<const char*>(&channels), sizeof(channels));
+    file.write(reinterpret_cast<const char*>(&kSampleRate), sizeof(kSampleRate));
+    file.write(reinterpret_cast<const char*>(&byteRate), sizeof(byteRate));
+    file.write(reinterpret_cast<const char*>(&blockAlign), sizeof(blockAlign));
+    file.write(reinterpret_cast<const char*>(&bitsPerSample), sizeof(bitsPerSample));
+    file.write("data", 4);
+    file.write(reinterpret_cast<const char*>(&dataSize), sizeof(dataSize));
+
+    for (size_t frame = 0; frame < kFrames; ++frame) {
+      for (uint16_t channel = 0; channel < channels; ++channel) {
+        const int16_t sample = static_cast<int16_t>((channel + 1) * 2048);
+        file.write(reinterpret_cast<const char*>(&sample), sizeof(sample));
+      }
+    }
+    ASSERT_TRUE(file.good());
+  }
+
+  std::string filePath;
+  std::string stereoPath;
+};
+
+TEST(ChannelFormatTest, DistinguishesDiscreteAndMatrixStereoCompoundPairs) {
+  const auto discrete = ChannelFormat::SMPTE51Stereo();
+  const auto matrix = ChannelFormat::SMPTE51MatrixStereo();
+
+  EXPECT_EQ(discrete.layout, ChannelLayout::SMPTE_51_ST);
+  EXPECT_EQ(discrete.channel_map[6], Speaker::Lo);
+  EXPECT_EQ(discrete.channel_map[7], Speaker::Ro);
+  EXPECT_EQ(matrix.layout, ChannelLayout::SMPTE_51_LTRT);
+  EXPECT_EQ(matrix.channel_map[6], Speaker::Lt);
+  EXPECT_EQ(matrix.channel_map[7], Speaker::Rt);
+  EXPECT_NE(discrete.channel_map[6], matrix.channel_map[6]);
+  EXPECT_NE(discrete.channel_map[7], matrix.channel_map[7]);
+}
+
+TEST_F(MultichannelTransportTest, RequiresExplicitSMPTEBundleAndPreservesEightChannels) {
+  TransportConfig config;
+  config.sampleRate = kSampleRate;
+  config.outputChannels = kChannels;
+  config.maxBlockFrames = static_cast<uint32_t>(kFrames);
+  config.maxActiveVoices = 2;
+  config.maxSourceChannels = kChannels;
+  config.sourceChannelPolicy = SourceChannelPolicy::Discrete;
+
+  auto transport = createTransportController(nullptr, config);
+  ASSERT_NE(transport, nullptr);
+  ASSERT_EQ(transport->registerClipAudio(1, filePath), SessionGraphError::OK);
+  EXPECT_EQ(transport->startClip(1), SessionGraphError::InvalidParameter);
+
+  auto metadata = transport->getClipMetadata(1);
+  ASSERT_TRUE(metadata.has_value());
+  const auto format = ChannelFormat::SMPTE51Stereo();
+  metadata->sourceLayout = format.layout;
+  metadata->speakerPatchSize = format.num_channels;
+  const auto wrongBed = ChannelFormat::Surround71();
+  std::copy_n(wrongBed.channel_map.begin(), wrongBed.num_channels,
+              metadata->speakerPatch.begin());
+  EXPECT_EQ(transport->updateClipMetadata(1, *metadata),
+            SessionGraphError::InvalidParameter);
+  std::copy_n(format.channel_map.begin(), format.num_channels,
+              metadata->speakerPatch.begin());
+  ASSERT_EQ(transport->updateClipMetadata(1, *metadata), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+
+  std::array<std::array<float, kFrames>, kChannels> storage{};
+  std::array<float*, kChannels> outputs{};
+  for (size_t channel = 0; channel < kChannels; ++channel) {
+    outputs[channel] = storage[channel].data();
+  }
+
+  transport->processAudio(outputs.data(), outputs.size(), kFrames);
+
+  for (size_t channel = 0; channel < kChannels; ++channel) {
+    const float expected = static_cast<float>((channel + 1) * 2048) / 32768.0f;
+    EXPECT_NEAR(storage[channel][0], expected, 1.0e-4f) << "channel " << channel;
+    EXPECT_NEAR(storage[channel][kFrames - 1], expected, 1.0e-4f) << "channel " << channel;
+  }
+}
+
+TEST_F(MultichannelTransportTest, RoutesStereoThroughLogicalGroupToSelectedOutputPair) {
+  TransportConfig config;
+  config.sampleRate = kSampleRate;
+  config.outputChannels = kChannels;
+  config.maxBlockFrames = static_cast<uint32_t>(kFrames);
+  config.maxActiveVoices = 2;
+  config.maxSourceChannels = kChannels;
+
+  auto transport = createTransportController(nullptr, config);
+  ASSERT_NE(transport, nullptr);
+  ASSERT_EQ(transport->registerClipAudio(2, stereoPath), SessionGraphError::OK);
+  ASSERT_EQ(transport->setGroupOutputBus(3, OutputBusRoute{6, 2}),
+            SessionGraphError::OK);
+  EXPECT_EQ(transport->getGroupOutputBus(3),
+            std::optional<OutputBusRoute>(OutputBusRoute{6, 2}));
+
+  auto metadata = transport->getClipMetadata(2);
+  ASSERT_TRUE(metadata.has_value());
+  metadata->routingGroup = 3;
+  metadata->loopEnabled = true;
+  ASSERT_EQ(transport->updateClipMetadata(2, *metadata), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(2), SessionGraphError::OK);
+
+  std::array<std::array<float, kFrames>, kChannels> storage{};
+  std::array<float*, kChannels> outputs{};
+  for (size_t channel = 0; channel < kChannels; ++channel) {
+    outputs[channel] = storage[channel].data();
+  }
+
+  transport->processAudio(outputs.data(), outputs.size(), kFrames);
+  for (size_t channel = 0; channel < 6; ++channel) {
+    EXPECT_FLOAT_EQ(storage[channel][0], 0.0f) << "channel " << channel;
+  }
+  EXPECT_NEAR(storage[6][0], 2048.0f / 32768.0f, 1.0e-4f);
+  EXPECT_NEAR(storage[7][0], 4096.0f / 32768.0f, 1.0e-4f);
+
+  ASSERT_EQ(transport->getRoutingMatrix()->setGroupMute(3, true), SessionGraphError::OK);
+  transport->processAudio(outputs.data(), outputs.size(), kFrames);
+  for (const auto& channel : storage) {
+    EXPECT_FLOAT_EQ(channel[0], 0.0f);
+  }
+}
+
+TEST(MultichannelTransportConfigTest, RejectsUnsupportedRealtimeBounds) {
+  TransportConfig config;
+  config.sampleRate = kSampleRate;
+
+  config.outputChannels = 33;
+  EXPECT_EQ(createTransportController(nullptr, config), nullptr);
+
+  config.outputChannels = 2;
+  config.maxBlockFrames = 2049;
+  EXPECT_EQ(createTransportController(nullptr, config), nullptr);
+
+  config.maxBlockFrames = 512;
+  config.maxActiveVoices = 32;
+  config.maxSourceChannels = 9;
+  EXPECT_EQ(createTransportController(nullptr, config), nullptr);
+
+  config.maxActiveVoices = 33;
+  config.maxSourceChannels = 8;
+  EXPECT_EQ(createTransportController(nullptr, config), nullptr);
+}
+
+
+TEST(ChannelFormatTest, DistinguishesSMPTE51StereoBundleFromSurround71Bed) {
+  const auto programme = ChannelFormat::SMPTE51Stereo();
+  const std::array<Speaker, 8> expectedProgramme = {
+      Speaker::L,  Speaker::R,  Speaker::C,  Speaker::LFE,
+      Speaker::Ls, Speaker::Rs, Speaker::Lo, Speaker::Ro,
+  };
+  EXPECT_EQ(programme.layout, ChannelLayout::SMPTE_51_ST);
+  EXPECT_EQ(programme.num_channels, expectedProgramme.size());
+  EXPECT_TRUE(std::equal(expectedProgramme.begin(), expectedProgramme.end(),
+                         programme.channel_map.begin()));
+
+  const auto surround = ChannelFormat::Surround71();
+  EXPECT_EQ(surround.channel_map[6], Speaker::Lb);
+  EXPECT_EQ(surround.channel_map[7], Speaker::Rb);
+  EXPECT_NE(programme.channel_map[6], surround.channel_map[6]);
+  EXPECT_NE(programme.channel_map[7], surround.channel_map[7]);
+}
+} // namespace

--- a/tests/transport/occ155_api_test.cpp
+++ b/tests/transport/occ155_api_test.cpp
@@ -119,7 +119,7 @@ std::string writeSineWav(const std::filesystem::path& path, float freq, float du
 class Occ155ApiTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_dir = std::filesystem::temp_directory_path() / "occ155_api";
     std::filesystem::create_directories(m_dir);
     m_constPath = writeConstantWav(m_dir / "const.wav", 2.0f, kSampleRate);

--- a/tests/transport/out_point_enforcement_test.cpp
+++ b/tests/transport/out_point_enforcement_test.cpp
@@ -13,7 +13,7 @@ using namespace orpheus;
 class OutPointEnforcementTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_out_point.wav").string();
     createTestAudioFile();
   }
@@ -228,7 +228,7 @@ protected:
   };
 
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_callback = std::make_unique<TestCallback>();
     m_transport->setCallback(m_callback.get());
     m_testFilePath =

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -103,7 +103,7 @@ protected:
   void SetUp() override {
     m_tempDir = std::filesystem::temp_directory_path() / "orp136_rt_harness";
     std::filesystem::create_directories(m_tempDir);
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_left.assign(kBufferFrames, 0.0f);
     m_right.assign(kBufferFrames, 0.0f);
     m_buffers[0] = m_left.data();

--- a/tests/transport/sample_rate_conversion_test.cpp
+++ b/tests/transport/sample_rate_conversion_test.cpp
@@ -89,7 +89,7 @@ protected:
   void SetUp() override {
     m_dir = std::filesystem::temp_directory_path() / "orp127_src";
     std::filesystem::create_directories(m_dir);
-    m_transport = std::make_unique<TransportController>(nullptr, kEngineRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kEngineRate)});
   }
   void TearDown() override {
     m_transport.reset();

--- a/tests/transport/stop_fade_envelope_test.cpp
+++ b/tests/transport/stop_fade_envelope_test.cpp
@@ -69,7 +69,7 @@ std::string writeConstantWav(const std::filesystem::path& path, float durationSe
 class StopFadeEnvelopeTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_path = (std::filesystem::temp_directory_path() / "orp127_stop_fade.wav").string();
     writeConstantWav(m_path, 2.0f, kSampleRate);
   }

--- a/tests/transport/transport_controller_test.cpp
+++ b/tests/transport/transport_controller_test.cpp
@@ -19,7 +19,7 @@ class TransportControllerTest : public ::testing::Test {
 protected:
   void SetUp() override {
     m_sessionGraph = std::make_unique<MockSessionGraph>();
-    m_transport = createTransportController(m_sessionGraph.get(), 48000);
+    m_transport = createTransportController(m_sessionGraph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   }
 
   void TearDown() override {
@@ -136,7 +136,7 @@ void advanceOneSecond(ITransportController& transport, uint32_t sampleRate) {
 // tempo, not a hardcoded 120 BPM.
 TEST_F(TransportControllerTest, BeatsFollowSessionTempoAtConstruction) {
   m_sessionGraph->set_tempo(90.0);
-  auto transport = createTransportController(m_sessionGraph.get(), 48000);
+  auto transport = createTransportController(m_sessionGraph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
   advanceOneSecond(*transport, 48000);
 
@@ -150,7 +150,7 @@ TEST_F(TransportControllerTest, BeatsFollowSessionTempoAtConstruction) {
 // FTR027 §1: a set_tempo() change after construction reaches beats on the
 // next processCallbacks() pump.
 TEST_F(TransportControllerTest, BeatsTrackLiveTempoChange) {
-  auto transport = createTransportController(m_sessionGraph.get(), 48000);
+  auto transport = createTransportController(m_sessionGraph.get(), TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
 
   advanceOneSecond(*transport, 48000);
 
@@ -168,14 +168,14 @@ TEST_F(TransportControllerTest, BeatsTrackLiveTempoChange) {
 }
 
 TEST_F(TransportControllerTest, PublicInterfaceReportsRenderContract) {
-  const TransportRenderConfig config = m_transport->getRenderConfig();
+  const TransportConfig config = m_transport->getRenderConfig();
   EXPECT_EQ(config.sampleRate, 48000u);
   EXPECT_EQ(config.outputChannels, 2u);
   EXPECT_EQ(config.maxBlockFrames, 2048u);
 }
 
 TEST_F(TransportControllerTest, PublicInterfaceRendersAndDrainsCallbacks) {
-  const TransportRenderConfig config = m_transport->getRenderConfig();
+  const TransportConfig config = m_transport->getRenderConfig();
   ASSERT_GE(config.outputChannels, 2u);
   ASSERT_GE(config.maxBlockFrames, 64u);
 

--- a/tests/transport/transport_render_hash_test.cpp
+++ b/tests/transport/transport_render_hash_test.cpp
@@ -141,7 +141,8 @@ protected:
   uint64_t renderScenarioHash(size_t blockFrames) {
     EXPECT_EQ(kTotalFrames % blockFrames, 0u) << "block size must divide the render window";
 
-    TransportController transport(nullptr, kSampleRate);
+    TransportController transport(
+        nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
 
     EXPECT_EQ(transport.registerClipAudio(1, m_fixture1), SessionGraphError::OK);
     EXPECT_EQ(transport.registerClipAudio(2, m_fixture2), SessionGraphError::OK);
@@ -149,16 +150,20 @@ protected:
 
     // Clip 2: trim + fades + gain. All metadata lands before the first
     // buffer, so every block size sees identical voice state.
-    ClipMetadata meta;
-    meta.trimInSamples = 1000;
-    meta.trimOutSamples = 40000;
-    meta.fadeInSeconds = 0.05;
-    meta.fadeOutSeconds = 0.05;
-    meta.fadeInCurve = FadeCurve::EqualPower;
-    meta.fadeOutCurve = FadeCurve::Linear;
-    meta.gainDb = -6.0f;
-    meta.loopEnabled = false;
-    EXPECT_EQ(transport.updateClipMetadata(2, meta), SessionGraphError::OK);
+    auto meta = transport.getClipMetadata(2);
+    EXPECT_TRUE(meta.has_value());
+    if (!meta)
+      return 0;
+    meta->trimInSamples = 1000;
+    meta->trimOutSamples = 40000;
+    meta->fadeInSeconds = 0.05;
+    meta->fadeOutSeconds = 0.05;
+    meta->fadeInCurve = FadeCurve::EqualPower;
+    meta->fadeOutCurve = FadeCurve::Linear;
+    meta->gainDb = -6.0f;
+    meta->loopEnabled = false;
+    EXPECT_EQ(transport.updateClipMetadata(2, *meta),
+              SessionGraphError::OK);
     EXPECT_EQ(transport.updateClipGain(3, 3.0f), SessionGraphError::OK);
 
     EXPECT_EQ(transport.prepareClipAudio(1), SessionGraphError::OK);

--- a/tests/transport/voice_mode_test.cpp
+++ b/tests/transport/voice_mode_test.cpp
@@ -9,6 +9,7 @@
 //   MonoStrict          — fire while playing restarts from zero, no fade tail;
 //                         a single voice at all times.
 
+#include <algorithm>
 #include "../../src/core/transport/transport_controller.h"
 #include <cmath>
 #include <cstdint>
@@ -66,12 +67,27 @@ std::string writeSineWav(const std::filesystem::path& path, float freq, float du
   return path.string();
 }
 
+class HandleTransitionCallback : public ITransportCallback {
+public:
+  void onClipStarted(ClipHandle handle, TransportPosition) override {
+    started.push_back(handle);
+  }
+  void onClipStopped(ClipHandle handle, TransportPosition) override {
+    stopped.push_back(handle);
+  }
+  void onClipLooped(ClipHandle, TransportPosition) override {}
+  void onBufferUnderrun(TransportPosition) override {}
+
+  std::vector<ClipHandle> started;
+  std::vector<ClipHandle> stopped;
+};
+
 } // namespace
 
 class VoiceModeTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, kSampleRate);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_dir = std::filesystem::temp_directory_path() / "orp127_voicemode";
     std::filesystem::create_directories(m_dir);
     m_path = writeSineWav(m_dir / "vm.wav", 440.0f, 2.0f);
@@ -213,6 +229,65 @@ TEST_F(VoiceModeTest, MonoFadeOverlapTailCompletesAndTearsDown) {
   EXPECT_EQ(m_transport->getActiveVoiceCount(h), 1u)
       << "The fade tail must complete and be torn down, leaving only the fresh voice";
   EXPECT_EQ(m_transport->getClipState(h), PlaybackState::Playing);
+}
+
+TEST_F(VoiceModeTest, StopAllTailCompletionCannotEvictRefiredSiblingVoice) {
+  constexpr ClipHandle first = 1;
+  constexpr ClipHandle refired = 2;
+  for (const auto handle : {first, refired}) {
+    ASSERT_EQ(m_transport->registerClipAudio(handle, m_path.c_str()), SessionGraphError::OK);
+    ASSERT_EQ(m_transport->updateClipFades(
+                  handle, 0.0, 0.1, FadeCurve::Linear, FadeCurve::Linear),
+              SessionGraphError::OK);
+    ASSERT_EQ(m_transport->setClipVoiceMode(handle, VoiceMode::MonoWithFadeOverlap),
+              SessionGraphError::OK);
+  }
+
+  HandleTransitionCallback callback;
+  m_transport->setCallback(&callback);
+  ASSERT_EQ(m_transport->startClip(first), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->startClip(refired), SessionGraphError::OK);
+  pump();
+
+  ASSERT_EQ(m_transport->stopAllClips(), SessionGraphError::OK);
+  pump();
+  ASSERT_EQ(m_transport->getClipState(refired), PlaybackState::Stopping);
+
+  ASSERT_EQ(m_transport->startClip(refired), SessionGraphError::OK);
+  pump();
+  ASSERT_EQ(m_transport->getActiveVoiceCount(refired), 2u);
+
+  pump(14);
+  m_transport->processCallbacks();
+
+  EXPECT_EQ(m_transport->getActiveVoiceCount(first), 0u);
+  EXPECT_EQ(m_transport->getActiveVoiceCount(refired), 1u);
+  EXPECT_EQ(m_transport->getClipState(refired), PlaybackState::Playing);
+  EXPECT_EQ(std::count(callback.stopped.begin(), callback.stopped.end(), first), 1);
+  EXPECT_EQ(std::count(callback.stopped.begin(), callback.stopped.end(), refired), 0)
+      << "A handle-level stop must not be emitted while the fresh voice remains live";
+}
+
+TEST_F(VoiceModeTest, StopAllNearLoopBoundaryCompletesFadeInsteadOfLoopingForever) {
+  constexpr ClipHandle handle = 1;
+  ASSERT_EQ(m_transport->registerClipAudio(handle, m_path.c_str()), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->updateClipFades(
+                handle, 0.0, 0.5, FadeCurve::Linear, FadeCurve::Linear),
+            SessionGraphError::OK);
+  ASSERT_EQ(m_transport->setClipLoopMode(handle, true), SessionGraphError::OK);
+
+  ASSERT_EQ(m_transport->startClip(handle), SessionGraphError::OK);
+  pump();
+  ASSERT_EQ(m_transport->seekClip(handle, 91200), SessionGraphError::OK);
+  pump();
+  ASSERT_GT(m_transport->getClipPosition(handle), 91200);
+
+  ASSERT_EQ(m_transport->stopAllClips(), SessionGraphError::OK);
+  pump(60);
+
+  EXPECT_EQ(m_transport->getActiveVoiceCount(handle), 0u);
+  EXPECT_EQ(m_transport->getClipState(handle), PlaybackState::Stopped)
+      << "A stopping loop must not wrap to trim IN and restart its fade clock";
 }
 
 // ---- MonoStrict ------------------------------------------------------------

--- a/tests/transport/voice_state_tsan_test.cpp
+++ b/tests/transport/voice_state_tsan_test.cpp
@@ -95,7 +95,7 @@ protected:
   void SetUp() override {
     m_tempDir = std::filesystem::temp_directory_path() / "orp127_tsan";
     std::filesystem::create_directories(m_tempDir);
-    m_transport = std::make_unique<TransportController>(nullptr, 48000);
+    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   }
 
   void TearDown() override {


### PR DESCRIPTION
## Summary
- generalize transport rendering from stereo pairs to eight discrete source lanes
- add named logical group output buses, cue isolation, and persisted scene routing
- preserve channel layouts through CoreAudio/WASAPI/dummy drivers and package consumers
- separate channel-solo and group-solo domains so either control remains audible

## Verification
- `ctest --test-dir build-occ164-runtime --output-on-failure`: 147/147 tests passed
- focused multichannel render-hash and routing-matrix executables passed
- Clip Composer eight-output group and isolated-cue rendered-buffer tests passed

Real multichannel CoreAudio hardware validation remains a release gate; no hardware result is inferred here.