### PR TITLE
chore(release): publish Orpheus SDK 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-15
+
+Patch release for failure-atomic playout control and observable transport
+callback loss. C++ consumers must recompile for the appended virtual query
+methods; the stable C ABI remains at 1.0.
+
+### Added
+
+- `ITransportController::startClipWithGroupChoke()` admits a firing voice and
+  same-`routingGroup` peer choke as one bounded command. Peer fades begin only
+  after the firing voice is admitted.
+- Cumulative callback-delivery telemetry exposes attempted, retained, and
+  dropped event sequences without resetting on callback drains.
+- Coherent fixed-capacity active-voice snapshots let hosts reconcile surviving
+  per-handle state after a callback-ring gap.
+
+### Fixed
+
+- Metadata updates now enter the transport command ring before persistent
+  metadata commits, so queue saturation cannot split active and registered
+  routing state.
+- Voice IDs skip zero and active collisions when the 32-bit allocator wraps;
+  newest-voice aggregation no longer depends on zero as a sentinel.
+- Snapshot publication precedes callback-loss visibility and carries an exact
+  snapshot watermark, preventing hosts from accepting stale reconciliation
+  state.
+
+### Verification
+
+- All 149 configured SDK tests pass, including atomic choke saturation,
+  callback overflow/reconciliation, multi-voice aggregation, real-time static
+  and runtime harnesses, installed `find_package` consumers, C ABI linkage,
+  package version policy, and documentation audits.
+
 ## [0.5.0] - 2026-07-14
 
 Release of the explicit multichannel source, logical group-bus, and physical

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.5.0 LANGUAGES CXX)
+project(orpheus VERSION 0.5.1 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.5.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.5.1 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -147,6 +147,7 @@ the tree** — nothing under `packages/` is JavaScript today. See
 - [Contract Guide](orp/_process/archive/CONTRACT_DEVELOPMENT.md) – Command/event schemas shared across drivers (archived)
 - [ORP109 Roadmap](orp/ORP109%20SDK%20Feature%20Roadmap%20for%20Clip%20Composer%20Integration.md) – Feature specifications
 - [ORP110 Implementation Reports](orp/ORP110A%20App-Level%20Integration%20Report.md) – Complete feature documentation (see also ORP110B)
+- [ORP150 Atomic Clip-Group Choke Admission](orp/ORP150%20Atomic%20Clip-Group%20Choke%20Admission.md) – One-command metadata-group start/choke semantics and failure atomicity
 
 ---
 
@@ -163,6 +164,24 @@ transport->startClip(handle);
 transport->updateClipGain(handle, -6.0f);
 transport->setClipLoopMode(handle, true);
 ```
+
+### Atomic Metadata-Group Choke (ORP150)
+
+```cpp
+auto metadata = transport->getClipMetadata(handle).value();
+metadata.routingGroup = 1;
+metadata.voiceMode = VoiceMode::MonoWithFadeOverlap;
+transport->updateClipMetadata(handle, metadata);
+
+// One SPSC command: admit this start first, then fade only active peers whose
+// registered routingGroup is also 1. Check the immediate queue-admission result.
+const auto result = transport->startClipWithGroupChoke(handle);
+```
+
+Do not replace this operation with multiple `stopClip()` calls: queue
+saturation could admit only a prefix. `SessionGraphError::OK` means the atomic
+command entered the ring; a later voice-pool refusal is reported through
+`ITransportCallback::onActiveClipLimitReached` and leaves peers untouched.
 
 ### Routing Matrix (ORP109)
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -3,7 +3,7 @@
 This index catalogs public entry points exposed by the Orpheus SDK workspace. Update this document whenever new packages or
 notable APIs are added.
 
-**Last Updated:** 2026-07-09 (ORP133 truth pass)
+**Last Updated:** 2026-07-15 (ORP151 callback-loss reconciliation)
 **SDK Version:** 0.5.0 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
@@ -19,6 +19,7 @@ labels.)
 | ---------------------------------------------- | -------------------------- | ------------------------------------------------------- | ------------------- |
 | `include/orpheus/transport_controller.h`       | `ITransportController`     | Multi-clip transport with gain/loop/seek/restart        | v1.0.0-rc.1         |
 | `include/orpheus/transport_controller.h`       | Cue point extensions       | In-clip markers with seek-to-cue operations             | ORP109 (unreleased) |
+| `include/orpheus/transport_controller.h`       | Callback telemetry / active snapshot | Cumulative ring-loss detection and fixed-capacity voice reconciliation | ORP151 (`0.5.1`) |
 | `include/orpheus/session_graph.h`              | `SessionGraph`             | In-memory session representation (tracks, clips, tempo) | v0.1.0-alpha        |
 | `include/orpheus/audio_file_reader.h`          | `IAudioFileReader`         | Audio file decoding (WAV/AIFF/FLAC via libsndfile)      | v0.1.0-alpha        |
 | `include/orpheus/audio_file_reader_extended.h` | `IAudioFileReaderExtended` | Waveform pre-processing for UI rendering                | ORP109 (unreleased) |
@@ -148,6 +149,7 @@ the tree** — nothing under `packages/` is JavaScript today. See
 - [ORP109 Roadmap](orp/ORP109%20SDK%20Feature%20Roadmap%20for%20Clip%20Composer%20Integration.md) – Feature specifications
 - [ORP110 Implementation Reports](orp/ORP110A%20App-Level%20Integration%20Report.md) – Complete feature documentation (see also ORP110B)
 - [ORP150 Atomic Clip-Group Choke Admission](orp/ORP150%20Atomic%20Clip-Group%20Choke%20Admission.md) – One-command metadata-group start/choke semantics and failure atomicity
+- [ORP151 Callback Loss Telemetry and Active Voice Reconciliation](orp/ORP151%20Callback%20Loss%20Telemetry%20and%20Active%20Voice%20Reconciliation.md) – Counter lifetime, snapshot semantics, realtime publication, and installed-host reconciliation
 
 ---
 
@@ -182,6 +184,47 @@ Do not replace this operation with multiple `stopClip()` calls: queue
 saturation could admit only a prefix. `SessionGraphError::OK` means the atomic
 command entered the ring; a later voice-pool refusal is reported through
 `ITransportCallback::onActiveClipLimitReached` and leaves peers untouched.
+
+### Callback Loss Detection and Reconciliation (ORP151)
+
+```cpp
+auto previousDrops = uint64_t{0};
+
+// In the single control/message-thread pump:
+const auto before = transport->getCallbackDeliveryTelemetry();
+transport->processCallbacks();
+const auto after = transport->getCallbackDeliveryTelemetry();
+
+const bool lossDuringPump =
+    after.cumulativeDroppedCount != before.cumulativeDroppedCount;
+if (lossDuringPump ||
+    after.cumulativeDroppedCount != previousDrops) {
+  // Retained callbacks are incomplete. Reconcile current surviving state by
+  // ClipHandle; keep the historical interval marked indeterminate.
+  ActiveVoiceSnapshot active;
+  do {
+    active = transport->getActiveVoiceSnapshot();
+  } while (active.publicationSequence <
+           after.activeVoiceSnapshotSequence);
+  for (uint32_t i = 0; i < active.entryCount; ++i) {
+    reconcile(active.entries[i].handle,
+              active.entries[i].activeVoiceCount,
+              active.entries[i].state,
+              active.entries[i].newestPosition.samples);
+  }
+  previousDrops = after.cumulativeDroppedCount;
+}
+```
+
+Counters are cumulative for one controller lifetime and are not reset by
+`processCallbacks()`. Polling detects loss even when the dropped event was the
+last event in a burst. See ORP151 for the stable-copy pattern when audio remains
+active during reconciliation.
+
+`ITransportController` is a C++ virtual interface. The new queries have defaults
+for source compatibility, but `0.5.1` C++ consumers and custom implementations
+must recompile; the stable ABI promise in the repository README applies to the C
+ABI, not binary compatibility of this C++ vtable.
 
 ### Routing Matrix (ORP109)
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -4,7 +4,7 @@ This index catalogs public entry points exposed by the Orpheus SDK workspace. Up
 notable APIs are added.
 
 **Last Updated:** 2026-07-15 (ORP151 callback-loss reconciliation)
-**SDK Version:** 0.5.0 — the authoritative version is `project(orpheus VERSION ...)`
+**SDK Version:** 0.5.1 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@
 | **[ORP134 – NEXT Sprint](orp/ORP134%20NEXT%20Sprint%20-%20Streaming%20Reader%20and%20Platform%20Primitives.md)** | Streaming reader & platform primitives |
 | **[ORP135 – LATER Sprint](orp/ORP135%20LATER%20Sprint%20-%20Platform%20Leadership%20Bets.md)** | Speculative 2026+ platform bets |
 | **[ORP136 – Verification & CI](orp/ORP136%20Verification%20and%20CI%20Framework.md)** | Cross-cutting verification framework |
+| **[ORP150 – Atomic Clip-Group Choke Admission](orp/ORP150%20Atomic%20Clip-Group%20Choke%20Admission.md)** | Public one-command start/choke contract, failure atomicity, and package handoff |
 
 **📂 [ORP Directory Index](orp/README.md)** – Guide to all implementation plans
 (ORP001–ORP136), including the completed ORP125/126/127 transport sprints and the

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -8,6 +8,7 @@ Project documentation index for orpheus-sdk.
 
 ## Recent Documents
 
+- [[ORP150 Atomic Clip-Group Choke Admission]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP124 Architecture Cross-Reference Matrix]]
@@ -64,6 +65,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP140 FreqFinder Architecture Revision - SDK Integration Confirmed]]
+- [[ORP150 Atomic Clip-Group Choke Admission]]
 
 ## Archived Documents
 

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -9,6 +9,7 @@ Project documentation index for orpheus-sdk.
 ## Recent Documents
 
 - [[ORP150 Atomic Clip-Group Choke Admission]]
+- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP124 Architecture Cross-Reference Matrix]]
@@ -66,6 +67,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP140 FreqFinder Architecture Revision - SDK Integration Confirmed]]
 - [[ORP150 Atomic Clip-Group Choke Admission]]
+- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 
 ## Archived Documents
 
@@ -100,4 +102,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-01-18
+**Last Generated:** 2026-07-15

--- a/docs/orp/ORP.md
+++ b/docs/orp/ORP.md
@@ -12,6 +12,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP147 SDK Customer-Fit Gap Register and Incremental Build Guide]]
 - [[ORP148 Game-Audio Developer Opportunity Research]]
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
+- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 
 - [[ORP131 Clip Composer Subdirectory Archival]]
 - [[ORP130 CoreAudio Input Capture]]
@@ -112,6 +113,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP147 SDK Customer-Fit Gap Register and Incremental Build Guide]]
 - [[ORP148 Game-Audio Developer Opportunity Research]]
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
+- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 
 ## Archived Documents
 
@@ -129,4 +131,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-07-14
+**Last Generated:** 2026-07-15

--- a/docs/orp/ORP150 Atomic Clip-Group Choke Admission.md
+++ b/docs/orp/ORP150 Atomic Clip-Group Choke Admission.md
@@ -1,0 +1,68 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP150 — Atomic Clip-Group Choke Admission
+
+**Document type:** Public API implementation record and downstream guidance  
+**Version target:** `0.5.1`  
+**Status:** Implemented and focused gates verified  
+**Date:** 2026-07-15
+
+## Contract
+
+`ITransportController::startClipWithGroupChoke(handle)` appends a host-neutral
+public transport operation for metadata-owned exclusive groups. The control
+thread resolves the registered clip and its immutable start context, then posts
+one fixed-capacity SPSC command. It does not post one stop command per peer.
+
+The audio-thread consumer first applies the firing handle's configured
+`VoiceMode` and admits the voice. Start-event processing occurs before peer
+mutation. Only after admission succeeds does the consumer start the normal
+configured stop fade on active voices whose handle differs from the firing
+handle and whose `ClipMetadata::routingGroup` matches. Other groups and all
+voices of the firing handle remain unchanged. Surviving callbacks therefore
+retain Start-before-peer-Stop order, but publication is not guaranteed when the
+bounded callback ring overflows; hosts detect that history gap through ORP151
+callback-loss telemetry.
+
+Failure is all-or-nothing for peers:
+
+- invalid/unregistered/unavailable source or control-side allocation failure is
+  returned before command publication;
+- a full command ring returns `SessionGraphError::InternalError` without
+  publishing any part of the operation; and
+- realtime voice-pool refusal attempts the existing
+  `onActiveClipLimitReached` event and skips the choke. ORP151 callback-loss
+  telemetry detects if the bounded event ring cannot publish that notification.
+
+The method shares the existing single-control-producer contract. Hosts retain
+policy outside the SDK when their grouping is not represented by registered
+`ClipMetadata::routingGroup`; they must not emulate this atomic operation with a
+sequence of `stopClip()` calls.
+
+## Public-package evidence
+
+The clean-prefix `find_package` consumer calls the method through
+`std::unique_ptr<ITransportController>` while including only installed public
+headers. A second installed consumer models an implementation of the preceding
+interface, deliberately omits the appended method, remains concrete, and
+observes the safe default `SessionGraphError::NotSupported`.
+
+Focused rendered coverage exercises successful group isolation, queue-full and
+voice-pool refusal, `MonoWithFadeOverlap` refire bounds, attempted callback
+ordering, repeated saturation determinism, and transactional routing-metadata
+rejection/success across both persistent and active state.
+
+## Verification record
+
+Observed in the isolated implementation worktree on 2026-07-15:
+
+- focused transport selection: 4/4 CTest targets passed;
+- `atomic_group_choke_test`: its six rendered contract tests passed;
+- `cmake_find_package`: 1/1 passed, including the installed legacy custom
+  implementation fixture;
+- `realtime_static_audit`: 1/1 passed; and
+- `docs_path_audit`: 1/1 passed.
+
+The first package-gate attempt was correctly blocked because the configured
+install tree had not yet built `inspect_session`; after the installable targets
+were built, the clean-prefix configure/build/run fixture passed.

--- a/docs/orp/ORP151 Callback Loss Telemetry and Active Voice Reconciliation.md
+++ b/docs/orp/ORP151 Callback Loss Telemetry and Active Voice Reconciliation.md
@@ -117,15 +117,19 @@ Each entry aggregates all surviving voices for one handle:
 - `state` is `Playing` when any voice is playing and `Stopping` only when all
   voices for the handle are stopping; and
 - the newest fields come from the voice with the greatest transport start
-  sample, with voice ID as the deterministic tie-breaker.
+  sample; when starts share that sample, the later accepted start wins via an
+  internal wrap-aware chronological ordinal rather than numeric voice-ID order.
 
 `publicationSequence` starts at zero and advances after each completed
 `processAudio()` block. A returned value never mixes fields from different
 publications.
 
 Voice IDs remain nonzero across `uint32_t` rollover. The bounded audio-thread
-allocator skips zero and every ID still owned by an active voice, so the newest
-tie-break remains unambiguous through removal and slot compaction.
+allocator skips zero and every ID still owned by an active voice. A separate
+`uint64_t` start ordinal uses serial-number arithmetic across wrap. Before any
+surviving pair could become separated by half the serial range, the fixed live
+set is rank-rebased in place. No allocation or lock is introduced, and removal
+or slot compaction preserves both identities.
 
 ---
 
@@ -187,13 +191,14 @@ as an integrity condition and use their own policy for indeterminate history.
 
 Observed on macOS arm64, Debug, with realtime support enabled:
 
-- `callback_loss_telemetry_test`: **5/5 passed**; the cases force 302
+- `callback_loss_telemetry_test`: **6/6 passed**; the cases force 302
   attempted events without draining, observe exactly 255 retained and 47
   dropped with last dropped sequence 302, prove the reconciliation watermark,
   verify a later retained sequence 303 without counter reset, verify the
   zero-drop path, hammer concurrent coherent publication, aggregate one
-  handle across playing/fading voices and compaction, and cross `uint32_t`
-  voice-ID rollover without zero or active-ID collision;
+  handle across playing/fading voices and compaction, cross `uint32_t`
+  voice-ID rollover without zero or active-ID collision, and prove that a
+  same-sample start after ordinal/voice-ID wrap owns every newest field;
 - focused transport CTest set (`transport_controller_test`,
   `callback_queue_stress_test`, `callback_loss_telemetry_test`, and
   `voice_state_tsan_test`): **4/4 passed**;

--- a/docs/orp/ORP151 Callback Loss Telemetry and Active Voice Reconciliation.md
+++ b/docs/orp/ORP151 Callback Loss Telemetry and Active Voice Reconciliation.md
@@ -1,0 +1,209 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP151 — Callback Loss Telemetry and Active Voice Reconciliation
+
+**Document type:** SDK public-contract completion record and host adoption guide  
+**Version target:** `0.5.1`  
+**Status:** Implemented and verified in the working tree; release pending  
+**Date:** 2026-07-15
+
+---
+
+## 1. Problem and scope
+
+The transport already used a fixed audio-to-control SPSC callback ring and
+correctly refused to block the audio thread when that ring filled. The only loss
+signal was a private counter. An installed host could drain the callbacks it did
+receive and mistake the resulting model for a complete stream, especially when
+the final events in a burst were the events dropped.
+
+ORP151 makes that loss public and reconcilable without changing callback order,
+callback signatures, or realtime ownership:
+
+- every attempted transport callback event receives a monotonic lifetime
+  sequence before the ring capacity check;
+- successful posts and ring-full drops update coherent cumulative telemetry;
+- hosts can poll the telemetry even when no later event reaches the ring; and
+- hosts can replace an incomplete callback-derived model with a coherent,
+  fixed-capacity aggregate of the voices that actually survived.
+
+The change does not add a second callback queue, storage policy, logging, or an
+application-specific ledger.
+
+---
+
+## 2. Installed public contract
+
+`include/orpheus/transport_controller.h` now publishes these fixed-layout,
+trivially-copyable contracts:
+
+```cpp
+struct TransportCallbackTelemetry {
+  uint32_t schemaVersion;
+  uint32_t reserved;
+  uint64_t lastAttemptedSequence;
+  uint64_t lastPostedSequence;
+  uint64_t cumulativeDroppedCount;
+  uint64_t lastDroppedSequence;
+  uint64_t activeVoiceSnapshotSequence;
+};
+
+struct ActiveVoiceSnapshotEntry {
+  ClipHandle handle;
+  uint32_t activeVoiceCount;
+  uint32_t newestVoiceId;
+  PlaybackState state;
+  // fixed-layout flags and newest voice sample fields
+  TransportPosition newestPosition;
+};
+
+struct ActiveVoiceSnapshot {
+  uint32_t schemaVersion;
+  uint32_t entryCount;
+  uint32_t totalActiveVoiceCount;
+  uint32_t reserved;
+  uint64_t publicationSequence;
+  std::array<ActiveVoiceSnapshotEntry, kActiveVoiceSnapshotCapacity> entries;
+};
+```
+
+The appended interface queries are:
+
+```cpp
+virtual TransportCallbackTelemetry
+getCallbackDeliveryTelemetry() const noexcept;
+
+virtual ActiveVoiceSnapshot getActiveVoiceSnapshot() const noexcept;
+```
+
+The new methods have default empty implementations, so a recompiled custom
+`ITransportController` implementation remains source-compatible without adding
+overrides. This is not a C++ binary-compatibility guarantee. The repository
+guarantees stable C ABI 1.0; `ITransportController` is a C++ virtual interface.
+All C++ consumers and custom implementations must recompile for `0.5.1` before
+calling the appended slots. Existing callback signatures and retained-event
+dispatch order are unchanged.
+
+### 2.1 Callback telemetry semantics
+
+- Sequence, drop, and watermark fields are zero when a controller is
+  constructed; `schemaVersion` is the published schema constant.
+- `lastAttemptedSequence` advances before each callback-ring capacity check.
+- `lastPostedSequence` is the attempted sequence of the most recent event that
+  entered the ring. It can jump across a dropped range after the ring recovers.
+- `cumulativeDroppedCount` advances exactly once per ring-full rejection.
+- `lastDroppedSequence` identifies the most recent rejected attempted sequence.
+- `activeVoiceSnapshotSequence` is the reconciliation watermark published at
+  the same epilogue. When telemetry containing a drop is visible, the voice
+  snapshot for at least this publication sequence is already visible.
+- `processCallbacks()` does not reset or reduce any field.
+- Values belong to one controller lifetime and reset only when a new controller
+  is constructed.
+- Public counters saturate at `UINT64_MAX`; they never wrap to a smaller value.
+
+The drop counter, rather than arrival of a later callback, is the authoritative
+loss signal. A host therefore detects a dropped final burst by polling
+`getCallbackDeliveryTelemetry()`.
+
+### 2.2 Active voice snapshot semantics
+
+`ActiveVoiceSnapshot` has capacity 32, matching the transport's hard active-voice
+ceiling. Entries `[0, entryCount)` have distinct, nonzero `ClipHandle` keys.
+`totalActiveVoiceCount` includes normal voices and fading tails.
+
+Each entry aggregates all surviving voices for one handle:
+
+- `activeVoiceCount` is the exact surviving count;
+- `state` is `Playing` when any voice is playing and `Stopping` only when all
+  voices for the handle are stopping; and
+- the newest fields come from the voice with the greatest transport start
+  sample, with voice ID as the deterministic tie-breaker.
+
+`publicationSequence` starts at zero and advances after each completed
+`processAudio()` block. A returned value never mixes fields from different
+publications.
+
+Voice IDs remain nonzero across `uint32_t` rollover. The bounded audio-thread
+allocator skips zero and every ID still owned by an active voice, so the newest
+tie-break remains unambiguous through removal and slot compaction.
+
+---
+
+## 3. Realtime and concurrency design
+
+The audio thread remains the sole event and snapshot producer. Callback
+telemetry uses scalar `uint64_t` atomics. The active snapshot uses fixed arrays of
+lock-free scalar atomics. Both use an atomic publication revision so a
+non-realtime reader retries when it overlaps a write. Every payload field is
+atomic; no plain-struct overwrite races with a reader.
+
+At the common `processAudio()` epilogue, the producer publishes the resulting
+active-voice snapshot first and callback telemetry second. A host that observes
+telemetry publication therefore cannot accept a pre-event snapshot as the
+reconciliation state. `activeVoiceSnapshotSequence` makes that ordering
+testable rather than implicit.
+
+Publication is bounded by the configured maximum of 32 active voices. It does
+not allocate, lock, call a host callback, perform I/O, or log. Compile-time
+checks require the scalar atomic widths used by publication to be always
+lock-free on a supported build target.
+
+`getCallbackDeliveryTelemetry()` is an any-thread lock-free query.
+`getActiveVoiceSnapshot()` is a lock-free, non-realtime query: it may retry a
+concurrent publication and returns the fixed array by value. Callback draining
+remains the single control-thread consumer of the event ring.
+
+---
+
+## 4. Host reconciliation guidance
+
+An installed host should retain its last observed cumulative drop count. At each
+message-thread pump:
+
+1. poll `getCallbackDeliveryTelemetry()`;
+2. call `processCallbacks()` to dispatch retained events;
+3. poll telemetry again;
+4. if `cumulativeDroppedCount` increased relative to the host baseline, mark the
+   callback-derived interval incomplete; and
+5. obtain `getActiveVoiceSnapshot()` and reconcile handle presence, per-handle
+   voice count, aggregate state, and newest sample position before presenting a
+   healthy model again.
+
+For a stable reconciliation observation while audio is running, poll telemetry
+and then copy the active snapshot. Accept the copy only when
+`snapshot.publicationSequence >= telemetry.activeVoiceSnapshotSequence`;
+otherwise retry. Poll telemetry again after callback dispatch to detect a drop
+that occurred during the pump. The host stores the new cumulative value as its
+own baseline; it never asks the SDK to reset counters.
+
+A reconciled snapshot describes current surviving state. It does not recreate
+which dropped historical callbacks occurred or authorize a host to fabricate
+ledger rows. Hosts that persist lifecycle history must retain the detected gap
+as an integrity condition and use their own policy for indeterminate history.
+
+---
+
+## 5. Verification evidence
+
+Observed on macOS arm64, Debug, with realtime support enabled:
+
+- `callback_loss_telemetry_test`: **5/5 passed**; the cases force 302
+  attempted events without draining, observe exactly 255 retained and 47
+  dropped with last dropped sequence 302, prove the reconciliation watermark,
+  verify a later retained sequence 303 without counter reset, verify the
+  zero-drop path, hammer concurrent coherent publication, aggregate one
+  handle across playing/fading voices and compaction, and cross `uint32_t`
+  voice-ID rollover without zero or active-ID collision;
+- focused transport CTest set (`transport_controller_test`,
+  `callback_queue_stress_test`, `callback_loss_telemetry_test`, and
+  `voice_state_tsan_test`): **4/4 passed**;
+- installed clean-prefix `cmake_find_package`: **1/1 passed**; one consumer
+  renders a real start and observes nonzero concrete telemetry/snapshot state,
+  while a complete pre-ORP151-style custom `ITransportController` compiles and
+  runs using the new default methods;
+- `realtime_static_audit`: **1/1 passed**;
+- `realtime_harness_test`: **1/1 passed**; and
+- `docs_path_audit`: **1/1 passed**.
+
+No release, version, tag, or downstream application action is claimed by this
+record.

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.0
+**SDK Version:** 0.5.1
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.0
+**SDK Version:** 0.5.1

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.0
+**SDK Version:** 0.5.1

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.0
+**SDK Version:** 0.5.1

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <orpheus/channel_format.h>
 #include <orpheus/errors.h>
 #include <orpheus/export.h>
 #include <orpheus/realtime_telemetry.h>
-#include <orpheus/channel_format.h>
 #include <orpheus/routing_matrix.h>
 
 #include <array>
@@ -21,7 +21,6 @@ namespace orpheus {
 namespace core {
 class SessionGraph;
 } // namespace core
-
 
 using ClipHandle = uint64_t;
 
@@ -73,7 +72,6 @@ struct TransportPosition {
   double beats;    ///< Derived: seconds * session tempo (SessionGraph::tempo) / 60.0
 };
 
-
 /// Immutable construction contract for the transport renderer.
 ///
 /// All capacities are validated by createTransportController() and remain fixed
@@ -109,13 +107,13 @@ struct ClipMetadata {
   bool loopEnabled = false;                   ///< true = loop indefinitely
   bool stopOthersOnPlay = false;              ///< true = stop other clips on play
   float gainDb = 0.0f;                        ///< Gain in decibels (0 = unity)
-  VoiceMode voiceMode = VoiceMode::Polyphonic; ///< Voice allocation policy (ORP127 G5)
-  RoutingGroupIndex routingGroup = 0;          ///< Logical bus assignment
+  VoiceMode voiceMode = VoiceMode::Polyphonic;             ///< Voice allocation policy (ORP127 G5)
+  RoutingGroupIndex routingGroup = 0;                      ///< Logical bus assignment
   ChannelLayout sourceLayout = ChannelLayout::Unspecified; ///< Explicit source channel meaning
   uint8_t speakerPatchSize = 0; ///< Number of valid entries in speakerPatch
-  std::array<Speaker, 8> speakerPatch = {
-      Speaker::None, Speaker::None, Speaker::None, Speaker::None,
-      Speaker::None, Speaker::None, Speaker::None, Speaker::None};
+  std::array<Speaker, 8> speakerPatch = {Speaker::None, Speaker::None, Speaker::None,
+                                         Speaker::None, Speaker::None, Speaker::None,
+                                         Speaker::None, Speaker::None};
 };
 
 /// Session-level default metadata for new clips.
@@ -193,9 +191,10 @@ public:
 ///
 /// Threading contract (ORP133 G3 — this is the real, enforced contract):
 ///
-/// - **Control-mutating methods are single-producer.** startClip(), stopClip(),
-///   stopAllClips(), stopOtherClips(), restartClip(), seekClip(), and every
-///   updateClip*/setClip* method post commands onto a lock-free
+/// - **Control-mutating methods are single-producer.** startClip(),
+///   startClipWithGroupChoke(), stopClip(), stopAllClips(), stopOtherClips(),
+///   restartClip(), seekClip(), and every updateClip*/setClip* method post
+///   commands onto a lock-free
 ///   single-producer/single-consumer (SPSC) queue drained by the audio thread.
 ///   Exactly ONE control thread may call them — typically the host's UI/message
 ///   thread. They are NOT safe to call concurrently from multiple threads: the
@@ -271,13 +270,12 @@ public:
   /// Stop all clips in a specific routing group
   ///
   /// @deprecated ORP133 G2: NOT SUPPORTED — always returns
-  /// SessionGraphError::NotSupported. This method was a silent no-op in every
-  /// SDK release (the transport has no clip→group mapping; grouping is a host
-  /// concern), and it now reports that truthfully instead. Hosts that need
-  /// scoped group-stop should implement it with their own group model on top
-  /// of stopOtherClips() (host-neutral choke, ORP127 G7) and/or stopClip().
-  /// The method is retained only for source compatibility and may be removed
-  /// in a future major version.
+  /// SessionGraphError::NotSupported. This legacy method was a silent no-op in
+  /// earlier releases and remains unavailable for arbitrary group-only stops.
+  /// Registered ClipMetadata::routingGroup is now consumed only by the atomic
+  /// startClipWithGroupChoke() contract below. Hosts needing a standalone
+  /// group stop must enqueue explicit stopClip() operations under their own
+  /// policy. The method remains only for source compatibility.
   ///
   /// @param groupIndex Ignored
   /// @return SessionGraphError::NotSupported, always
@@ -576,12 +574,11 @@ public:
   virtual std::optional<ClipMetadata> getClipMetadata(ClipHandle handle) const = 0;
 
   /// Route one logical clip group to a contiguous physical output bus.
-  virtual SessionGraphError setGroupOutputBus(
-      RoutingGroupIndex group, const OutputBusRoute& route) = 0;
+  virtual SessionGraphError setGroupOutputBus(RoutingGroupIndex group,
+                                              const OutputBusRoute& route) = 0;
 
   /// Query the current physical destination of a logical clip group.
-  virtual std::optional<OutputBusRoute>
-  getGroupOutputBus(RoutingGroupIndex group) const = 0;
+  virtual std::optional<OutputBusRoute> getGroupOutputBus(RoutingGroupIndex group) const = 0;
 
   /// Set session-level default metadata for new clips
   ///
@@ -839,6 +836,30 @@ public:
   /// TransportPosition::beats queries, so hosts must call it even when no
   /// callback object is installed.
   virtual void processCallbacks() = 0;
+
+  /// Atomically start a clip and choke active peers in its registered group.
+  ///
+  /// The firing clip and peer choke are admitted as one bounded SPSC command.
+  /// If the command ring is full, the clip is unregistered/unavailable, or the
+  /// realtime voice pool later refuses the start, no peer voice is changed.
+  /// After successful voice admission, every active voice with a different
+  /// handle and the same ClipMetadata::routingGroup begins its normal configured
+  /// stop fade. Other groups and the firing handle are untouched.
+  ///
+  /// The firing handle retains its configured VoiceMode, including
+  /// MonoWithFadeOverlap refire behavior. Start-event processing precedes peer
+  /// mutation, so surviving callbacks retain Start-before-peer-Stop order.
+  /// Publication is not guaranteed when the bounded callback ring overflows;
+  /// hosts detect that history gap through ORP151 callback-loss telemetry and
+  /// must not infer a complete lifecycle from surviving callbacks.
+  ///
+  /// Control thread only; this method shares the single-producer contract of
+  /// startClip() and the other control-mutating methods. The default preserves
+  /// source compatibility for external interface implementations; concrete
+  /// controllers that do not override it report an unavailable capability.
+  virtual SessionGraphError startClipWithGroupChoke(ClipHandle /*handle*/) {
+    return SessionGraphError::NotSupported;
+  }
 };
 
 /// Create a transport controller with an immutable render contract.

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -111,8 +111,9 @@ struct TransportCallbackTelemetry {
 /// Per-ClipHandle aggregate in an ActiveVoiceSnapshot.
 ///
 /// "Newest" is the surviving voice with the greatest transport start sample;
-/// voice ID breaks a tie. state is Playing when any voice for the handle is
-/// playing and Stopping only when all of them are stopping.
+/// when starts share that sample, the later accepted start wins even when its
+/// voice ID wrapped. state is Playing when any voice for the handle is playing
+/// and Stopping only when all of them are stopping.
 struct ActiveVoiceSnapshotEntry {
   ClipHandle handle = 0;
   uint32_t activeVoiceCount = 0;

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace orpheus {
@@ -72,6 +73,82 @@ struct TransportPosition {
   double beats;    ///< Derived: seconds * session tempo (SessionGraph::tempo) / 60.0
 };
 
+/// Stable schema version for TransportCallbackTelemetry.
+inline constexpr uint32_t kTransportCallbackTelemetrySchemaVersion = 1;
+
+/// Stable schema version for ActiveVoiceSnapshot.
+inline constexpr uint32_t kActiveVoiceSnapshotSchemaVersion = 1;
+
+/// Maximum number of distinct clip handles represented in one active snapshot.
+///
+/// The transport admits at most 32 simultaneous voices, so the same fixed
+/// capacity is sufficient even when every surviving voice has a different
+/// ClipHandle.
+inline constexpr size_t kActiveVoiceSnapshotCapacity = 32;
+
+/// Cumulative delivery health for the audio-to-control callback ring.
+///
+/// Every attempted transport event receives the next sequence before the ring
+/// capacity check. lastPostedSequence advances only when that event is retained;
+/// lastDroppedSequence identifies the most recent rejected attempt. Therefore a
+/// host can detect loss by polling even when no later callback is posted.
+/// activeVoiceSnapshotSequence is the already-published reconciliation snapshot
+/// watermark for this telemetry observation.
+///
+/// All counters start at zero when a controller is constructed, never reset when
+/// processCallbacks() drains the ring, and remain valid until that controller is
+/// destroyed. Counters saturate at UINT64_MAX rather than wrapping.
+struct TransportCallbackTelemetry {
+  uint32_t schemaVersion = kTransportCallbackTelemetrySchemaVersion;
+  uint32_t reserved = 0;
+  uint64_t lastAttemptedSequence = 0;
+  uint64_t lastPostedSequence = 0;
+  uint64_t cumulativeDroppedCount = 0;
+  uint64_t lastDroppedSequence = 0;
+  uint64_t activeVoiceSnapshotSequence = 0;
+};
+
+/// Per-ClipHandle aggregate in an ActiveVoiceSnapshot.
+///
+/// "Newest" is the surviving voice with the greatest transport start sample;
+/// voice ID breaks a tie. state is Playing when any voice for the handle is
+/// playing and Stopping only when all of them are stopping.
+struct ActiveVoiceSnapshotEntry {
+  ClipHandle handle = 0;
+  uint32_t activeVoiceCount = 0;
+  uint32_t newestVoiceId = 0;
+  PlaybackState state = PlaybackState::Stopped;
+  uint8_t newestVoiceStopping = 0;
+  uint8_t newestVoiceLoopEnabled = 0;
+  std::array<uint8_t, 5> reserved{};
+  int64_t newestStartSample = 0;
+  int64_t newestTrimInSamples = 0;
+  int64_t newestTrimOutSamples = 0;
+  TransportPosition newestPosition{};
+};
+
+/// Coherent fixed-capacity view of all currently surviving transport voices.
+///
+/// Entries [0, entryCount) are keyed by distinct ClipHandle values.
+/// totalActiveVoiceCount includes playing voices and fading tails. The
+/// publication sequence starts at zero and advances once after every completed
+/// processAudio() block. A value copy is coherent: it never combines fields from
+/// two audio blocks.
+struct ActiveVoiceSnapshot {
+  uint32_t schemaVersion = kActiveVoiceSnapshotSchemaVersion;
+  uint32_t entryCount = 0;
+  uint32_t totalActiveVoiceCount = 0;
+  uint32_t reserved = 0;
+  uint64_t publicationSequence = 0;
+  std::array<ActiveVoiceSnapshotEntry, kActiveVoiceSnapshotCapacity> entries{};
+};
+
+static_assert(std::is_trivially_copyable_v<TransportCallbackTelemetry>);
+static_assert(std::is_standard_layout_v<TransportCallbackTelemetry>);
+static_assert(std::is_trivially_copyable_v<ActiveVoiceSnapshotEntry>);
+static_assert(std::is_standard_layout_v<ActiveVoiceSnapshotEntry>);
+static_assert(std::is_trivially_copyable_v<ActiveVoiceSnapshot>);
+static_assert(std::is_standard_layout_v<ActiveVoiceSnapshot>);
 /// Immutable construction contract for the transport renderer.
 ///
 /// All capacities are validated by createTransportController() and remain fixed
@@ -859,6 +936,23 @@ public:
   /// controllers that do not override it report an unavailable capability.
   virtual SessionGraphError startClipWithGroupChoke(ClipHandle /*handle*/) {
     return SessionGraphError::NotSupported;
+  }
+
+  /// Poll cumulative audio-to-control callback delivery health.
+  ///
+  /// Lock-free any-thread query. Draining callbacks does not reset counters.
+  /// The default preserves source compatibility for recompiled custom
+  /// implementations; it is not a C++ binary-compatibility guarantee.
+  virtual TransportCallbackTelemetry getCallbackDeliveryTelemetry() const noexcept {
+    return {};
+  }
+
+  /// Poll a coherent fixed-capacity aggregate of all active voices.
+  ///
+  /// Lock-free non-realtime query. The default preserves source compatibility
+  /// for recompiled custom implementations; it is not a C++ ABI guarantee.
+  virtual ActiveVoiceSnapshot getActiveVoiceSnapshot() const noexcept {
+    return {};
   }
 };
 

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -3,6 +3,7 @@
 
 #include "audio_io/resampling_audio_file_reader.h" // ORP127 G6: SRC decorator
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <cmath>
 #include <cstring>
@@ -94,6 +95,11 @@ bool isValidSpeakerPatch(ChannelLayout layout, uint8_t patchSize,
 
 uint64_t incrementSaturated(uint64_t value) noexcept {
   return value == std::numeric_limits<uint64_t>::max() ? value : value + 1;
+}
+
+bool isLaterStartOrdinal(uint64_t candidate, uint64_t reference) noexcept {
+  const uint64_t delta = candidate - reference;
+  return delta != 0 && delta < (uint64_t{1} << 63);
 }
 
 } // namespace
@@ -1096,19 +1102,52 @@ size_t TransportController::countActiveVoicesSnapshot(ClipHandle handle) const {
 
 ActiveClip* TransportController::findOldestVoice(ClipHandle handle) {
   ActiveClip* oldest = nullptr;
-  int64_t oldestStartSample = INT64_MAX;
-
   for (size_t i = 0; i < m_activeClipCount; ++i) {
-    if (m_activeClips[i].handle == handle) {
-      // Find voice with earliest start time (oldest)
-      if (m_activeClips[i].startSample < oldestStartSample) {
-        oldestStartSample = m_activeClips[i].startSample;
-        oldest = &m_activeClips[i];
+    ActiveClip& candidate = m_activeClips[i];
+    if (candidate.handle != handle) {
+      continue;
+    }
+    if (oldest == nullptr || candidate.startSample < oldest->startSample ||
+        (candidate.startSample == oldest->startSample &&
+         isLaterStartOrdinal(oldest->startOrdinal, candidate.startOrdinal))) {
+      oldest = &candidate;
+    }
+  }
+  return oldest;
+}
+
+uint64_t TransportController::allocateVoiceStartOrdinal() noexcept {
+  constexpr uint64_t kSerialHalfRange = uint64_t{1} << 63;
+  if (m_activeClipCount != 0) {
+    uint64_t oldestOrdinal = m_activeClips[0].startOrdinal;
+    for (size_t index = 1; index < m_activeClipCount; ++index) {
+      const uint64_t candidate = m_activeClips[index].startOrdinal;
+      if (isLaterStartOrdinal(oldestOrdinal, candidate)) {
+        oldestOrdinal = candidate;
       }
+    }
+
+    if (m_nextVoiceStartOrdinal - oldestOrdinal >= kSerialHalfRange) {
+      for (size_t index = 0; index < m_activeClipCount; ++index) {
+        m_voiceStartOrdinalScratch[index] = m_activeClips[index].startOrdinal;
+      }
+      for (size_t index = 0; index < m_activeClipCount; ++index) {
+        uint64_t rank = 0;
+        for (size_t other = 0; other < m_activeClipCount; ++other) {
+          if (isLaterStartOrdinal(m_voiceStartOrdinalScratch[index],
+                                  m_voiceStartOrdinalScratch[other])) {
+            ++rank;
+          }
+        }
+        m_activeClips[index].startOrdinal = rank;
+      }
+      m_nextVoiceStartOrdinal = static_cast<uint64_t>(m_activeClipCount);
     }
   }
 
-  return oldest;
+  const uint64_t ordinal = m_nextVoiceStartOrdinal;
+  ++m_nextVoiceStartOrdinal;
+  return ordinal;
 }
 
 void TransportController::restartVoiceInPlace(ActiveClip& clip) {
@@ -1230,6 +1269,27 @@ uint32_t TransportController::allocateVoiceId() noexcept {
   }
   return 0;
 }
+
+bool TransportController::setVoiceSnapshotFieldsForTesting(uint32_t voiceId, bool stopping,
+                                                           bool looping, int64_t trimIn,
+                                                           int64_t trimOut,
+                                                           int64_t currentSample) noexcept {
+  for (size_t index = 0; index < m_activeClipCount; ++index) {
+    ActiveClip& voice = m_activeClips[index];
+    if (voice.voiceId != voiceId) {
+      continue;
+    }
+    voice.isStopping = stopping;
+    voice.fadeOutGain = 1.0f;
+    voice.fadeOutStartPos = currentSample;
+    voice.loopEnabled.store(looping, std::memory_order_relaxed);
+    voice.trimInSamples.store(trimIn, std::memory_order_relaxed);
+    voice.trimOutSamples.store(trimOut, std::memory_order_relaxed);
+    voice.currentSample = currentSample;
+    return true;
+  }
+  return false;
+}
 bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
     return false;
@@ -1264,11 +1324,14 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
     return false;
   }
 
+  const uint64_t startOrdinal = allocateVoiceStartOrdinal();
+
   // Initialize clip with immutable context - NO MUTEX NEEDED HERE
   const size_t voiceIndex = m_activeClipCount++;
   ActiveClip& clip = m_activeClips[voiceIndex];
   clip.handle = handle;
   clip.voiceId = voiceId;
+  clip.startOrdinal = startOrdinal;
   clip.startSample = m_currentSample.load(std::memory_order_relaxed);
   clip.currentSample = context->trimInSamples; // CRITICAL: Start from IN point
 
@@ -1336,6 +1399,7 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
 
         dest.handle = src.handle;
         dest.voiceId = src.voiceId; // Multi-voice: copy voice ID
+        dest.startOrdinal = src.startOrdinal;
         dest.startSample = src.startSample;
         dest.currentSample = src.currentSample;
         dest.trimInSamples.store(src.trimInSamples.load(std::memory_order_relaxed),
@@ -1395,6 +1459,7 @@ void TransportController::removeActiveClip(ClipHandle handle) {
 
         dest.handle = src.handle;
         dest.voiceId = src.voiceId; // Multi-voice: copy voice ID
+        dest.startOrdinal = src.startOrdinal;
         dest.startSample = src.startSample;
         dest.currentSample = src.currentSample;
         dest.trimInSamples.store(src.trimInSamples.load(std::memory_order_relaxed),
@@ -1502,6 +1567,7 @@ void TransportController::publishVoiceSnapshot() noexcept {
       entry.handle = voice.handle;
       entry.state = PlaybackState::Stopping;
       m_voiceSnapshotHasNewest[entryIndex] = false;
+      m_voiceSnapshotNewestStartOrdinal[entryIndex] = 0;
     }
 
     ActiveVoiceSnapshotEntry& entry = snapshot.entries[entryIndex];
@@ -1511,7 +1577,8 @@ void TransportController::publishVoiceSnapshot() noexcept {
     }
 
     if (!m_voiceSnapshotHasNewest[entryIndex] || voice.startSample > entry.newestStartSample ||
-        (voice.startSample == entry.newestStartSample && voice.voiceId > entry.newestVoiceId)) {
+        (voice.startSample == entry.newestStartSample &&
+         isLaterStartOrdinal(voice.startOrdinal, m_voiceSnapshotNewestStartOrdinal[entryIndex]))) {
       entry.newestVoiceId = voice.voiceId;
       entry.newestVoiceStopping = voice.isStopping ? 1 : 0;
       entry.newestVoiceLoopEnabled = voice.loopEnabled.load(std::memory_order_relaxed) ? 1 : 0;
@@ -1520,6 +1587,7 @@ void TransportController::publishVoiceSnapshot() noexcept {
       entry.newestTrimOutSamples = voice.trimOutSamples.load(std::memory_order_relaxed);
       entry.newestPosition = positionAtSamples(voice.currentSample);
       m_voiceSnapshotHasNewest[entryIndex] = true;
+      m_voiceSnapshotNewestStartOrdinal[entryIndex] = voice.startOrdinal;
     }
   }
 
@@ -1547,6 +1615,10 @@ void TransportController::publishVoiceSnapshot() noexcept {
     destination.newestTrimOutSamples.store(source.newestTrimOutSamples, std::memory_order_release);
     destination.newestPositionSamples.store(source.newestPosition.samples,
                                             std::memory_order_release);
+    destination.newestPositionSecondsBits.store(
+        std::bit_cast<uint64_t>(source.newestPosition.seconds), std::memory_order_release);
+    destination.newestPositionBeatsBits.store(std::bit_cast<uint64_t>(source.newestPosition.beats),
+                                              std::memory_order_release);
   }
 
   const uint64_t evenRevision = m_voiceSnapshotRevision + 1;
@@ -2387,8 +2459,12 @@ ActiveVoiceSnapshot TransportController::getActiveVoiceSnapshot() const noexcept
       destination.newestTrimInSamples = source.newestTrimInSamples.load(std::memory_order_acquire);
       destination.newestTrimOutSamples =
           source.newestTrimOutSamples.load(std::memory_order_acquire);
-      destination.newestPosition =
-          positionAtSamples(source.newestPositionSamples.load(std::memory_order_acquire));
+      destination.newestPosition.samples =
+          source.newestPositionSamples.load(std::memory_order_acquire);
+      destination.newestPosition.seconds =
+          std::bit_cast<double>(source.newestPositionSecondsBits.load(std::memory_order_acquire));
+      destination.newestPosition.beats =
+          std::bit_cast<double>(source.newestPositionBeatsBits.load(std::memory_order_acquire));
     }
 
     const uint64_t revisionAfter =

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <new>
 #include <orpheus/session_graph.h> // For SessionGraph
 
@@ -89,6 +90,10 @@ bool isValidSpeakerPatch(ChannelLayout layout, uint8_t patchSize,
     return false;
   }
   return std::equal(patch.begin(), patch.begin() + patchSize, standard->channel_map.begin());
+}
+
+uint64_t incrementSaturated(uint64_t value) noexcept {
+  return value == std::numeric_limits<uint64_t>::max() ? value : value + 1;
 }
 
 } // namespace
@@ -350,27 +355,13 @@ uint32_t TransportController::getMaxVoicesPerClip() const {
 }
 
 PlaybackState TransportController::getClipState(ClipHandle handle) const {
-  // ORP127 G1: Read from the published voice snapshot — no access to the live
-  // audio-thread voice array. Multi-voice: Playing if ANY voice is playing,
-  // Stopping if voices exist but all are stopping, Stopped if none.
-  size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-  const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-
-  bool hasAnyVoice = false;
-  for (size_t i = 0; i < buf.count; ++i) {
-    if (buf.voices[i].handle == handle) {
-      hasAnyVoice = true;
-      if (!buf.voices[i].isStopping) {
-        return PlaybackState::Playing;
-      }
+  const ActiveVoiceSnapshot snapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    if (snapshot.entries[index].handle == handle) {
+      return snapshot.entries[index].state;
     }
   }
-
-  if (hasAnyVoice) {
-    return PlaybackState::Stopping; // All voices are stopping
-  }
-
-  return PlaybackState::Stopped; // No voices found
+  return PlaybackState::Stopped;
 }
 
 bool TransportController::isClipPlaying(ClipHandle handle) const {
@@ -788,6 +779,9 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
 
   // ORP127 G1: Publish the post-render voice state for lock-free UI queries.
   publishVoiceSnapshot();
+  // Callback loss becomes visible only after the voice state caused by every
+  // attempted event in this block is published for reconciliation.
+  publishCallbackTelemetry();
 
   if (publishTelemetry) {
     RealtimeTelemetrySnapshot snapshot;
@@ -1091,16 +1085,13 @@ size_t TransportController::countActiveVoices(ClipHandle handle) const {
 }
 
 size_t TransportController::countActiveVoicesSnapshot(ClipHandle handle) const {
-  // ORP127 G1: UI-thread-safe voice count via the published snapshot.
-  size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-  const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-  size_t count = 0;
-  for (size_t i = 0; i < buf.count; ++i) {
-    if (buf.voices[i].handle == handle) {
-      ++count;
+  const ActiveVoiceSnapshot snapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    if (snapshot.entries[index].handle == handle) {
+      return snapshot.entries[index].activeVoiceCount;
     }
   }
-  return count;
+  return 0;
 }
 
 ActiveClip* TransportController::findOldestVoice(ClipHandle handle) {
@@ -1218,6 +1209,27 @@ void TransportController::configureVoiceRouting(size_t voiceIndex, RoutingGroupI
   }
 }
 
+uint32_t TransportController::allocateVoiceId() noexcept {
+  for (size_t attempt = 0; attempt <= MAX_ACTIVE_CLIPS; ++attempt) {
+    uint32_t candidate = m_nextVoiceId;
+    if (candidate == 0) {
+      candidate = 1;
+    }
+    m_nextVoiceId = candidate == std::numeric_limits<uint32_t>::max() ? 1 : candidate + 1;
+
+    bool inUse = false;
+    for (size_t active = 0; active < m_activeClipCount; ++active) {
+      if (m_activeClips[active].voiceId == candidate) {
+        inUse = true;
+        break;
+      }
+    }
+    if (!inUse) {
+      return candidate;
+    }
+  }
+  return 0;
+}
 bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
     return false;
@@ -1247,11 +1259,16 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
     return false;
   }
 
+  const uint32_t voiceId = allocateVoiceId();
+  if (voiceId == 0) {
+    return false;
+  }
+
   // Initialize clip with immutable context - NO MUTEX NEEDED HERE
   const size_t voiceIndex = m_activeClipCount++;
   ActiveClip& clip = m_activeClips[voiceIndex];
   clip.handle = handle;
-  clip.voiceId = m_nextVoiceId++; // Multi-voice: Assign unique voice ID
+  clip.voiceId = voiceId;
   clip.startSample = m_currentSample.load(std::memory_order_relaxed);
   clip.currentSample = context->trimInSamples; // CRITICAL: Start from IN point
 
@@ -1460,55 +1477,119 @@ SessionGraphError TransportController::postCommand(const TransportCommand& comma
   return SessionGraphError::OK;
 }
 
-void TransportController::publishVoiceSnapshot() {
-  // ORP127 G1: Audio-thread-only. Copy the live voice array into the back
-  // buffer, then flip the published index with release ordering. UI-thread
-  // readers acquire the index and see a complete, self-consistent snapshot.
-  size_t front = m_snapshotIndex.load(std::memory_order_relaxed);
-  size_t back = front ^ 1;
-  VoiceSnapshotBuffer& buf = m_snapshotBuffers[back];
+void TransportController::publishVoiceSnapshot() noexcept {
+  ActiveVoiceSnapshot& snapshot = m_voiceSnapshotScratch;
+  snapshot.entryCount = 0;
+  snapshot.totalActiveVoiceCount = static_cast<uint32_t>(m_activeClipCount);
+  snapshot.publicationSequence = incrementSaturated(m_voiceSnapshotSequence);
+  m_voiceSnapshotSequence = snapshot.publicationSequence;
 
-  size_t count = m_activeClipCount;
-  buf.count = count;
-  for (size_t i = 0; i < count; ++i) {
-    const ActiveClip& clip = m_activeClips[i];
-    VoiceSnapshot& snap = buf.voices[i];
-    snap.handle = clip.handle;
-    snap.voiceId = clip.voiceId;
-    snap.startSample = clip.startSample;
-    snap.currentSample = clip.currentSample;
-    snap.trimInSamples = clip.trimInSamples.load(std::memory_order_relaxed);
-    snap.trimOutSamples = clip.trimOutSamples.load(std::memory_order_relaxed);
-    snap.isStopping = clip.isStopping;
-    snap.loopEnabled = clip.loopEnabled.load(std::memory_order_relaxed);
+  for (size_t voiceIndex = 0; voiceIndex < m_activeClipCount; ++voiceIndex) {
+    const ActiveClip& voice = m_activeClips[voiceIndex];
+    uint32_t entryIndex = 0;
+    while (entryIndex < snapshot.entryCount &&
+           snapshot.entries[entryIndex].handle != voice.handle) {
+      ++entryIndex;
+    }
+
+    if (entryIndex == snapshot.entryCount) {
+      if (snapshot.entryCount >= kActiveVoiceSnapshotCapacity) {
+        break;
+      }
+      ++snapshot.entryCount;
+      ActiveVoiceSnapshotEntry& entry = snapshot.entries[entryIndex];
+      entry = {};
+      entry.handle = voice.handle;
+      entry.state = PlaybackState::Stopping;
+      m_voiceSnapshotHasNewest[entryIndex] = false;
+    }
+
+    ActiveVoiceSnapshotEntry& entry = snapshot.entries[entryIndex];
+    ++entry.activeVoiceCount;
+    if (!voice.isStopping) {
+      entry.state = PlaybackState::Playing;
+    }
+
+    if (!m_voiceSnapshotHasNewest[entryIndex] || voice.startSample > entry.newestStartSample ||
+        (voice.startSample == entry.newestStartSample && voice.voiceId > entry.newestVoiceId)) {
+      entry.newestVoiceId = voice.voiceId;
+      entry.newestVoiceStopping = voice.isStopping ? 1 : 0;
+      entry.newestVoiceLoopEnabled = voice.loopEnabled.load(std::memory_order_relaxed) ? 1 : 0;
+      entry.newestStartSample = voice.startSample;
+      entry.newestTrimInSamples = voice.trimInSamples.load(std::memory_order_relaxed);
+      entry.newestTrimOutSamples = voice.trimOutSamples.load(std::memory_order_relaxed);
+      entry.newestPosition = positionAtSamples(voice.currentSample);
+      m_voiceSnapshotHasNewest[entryIndex] = true;
+    }
   }
 
-  m_snapshotIndex.store(back, std::memory_order_release);
+  const uint64_t oddRevision = m_voiceSnapshotRevision + 1;
+  m_voiceSnapshotRevision = oddRevision;
+  m_publishedVoiceSnapshot.revision.store(oddRevision, std::memory_order_release);
+  m_publishedVoiceSnapshot.publicationSequence.store(snapshot.publicationSequence,
+                                                     std::memory_order_release);
+  m_publishedVoiceSnapshot.entryCount.store(snapshot.entryCount, std::memory_order_release);
+  m_publishedVoiceSnapshot.totalActiveVoiceCount.store(snapshot.totalActiveVoiceCount,
+                                                       std::memory_order_release);
+
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    const ActiveVoiceSnapshotEntry& source = snapshot.entries[index];
+    AtomicActiveVoiceSnapshotEntry& destination = m_publishedVoiceSnapshot.entries[index];
+    destination.handle.store(source.handle, std::memory_order_release);
+    destination.activeVoiceCount.store(source.activeVoiceCount, std::memory_order_release);
+    destination.newestVoiceId.store(source.newestVoiceId, std::memory_order_release);
+    destination.state.store(static_cast<uint8_t>(source.state), std::memory_order_release);
+    destination.newestVoiceStopping.store(source.newestVoiceStopping, std::memory_order_release);
+    destination.newestVoiceLoopEnabled.store(source.newestVoiceLoopEnabled,
+                                             std::memory_order_release);
+    destination.newestStartSample.store(source.newestStartSample, std::memory_order_release);
+    destination.newestTrimInSamples.store(source.newestTrimInSamples, std::memory_order_release);
+    destination.newestTrimOutSamples.store(source.newestTrimOutSamples, std::memory_order_release);
+    destination.newestPositionSamples.store(source.newestPosition.samples,
+                                            std::memory_order_release);
+  }
+
+  const uint64_t evenRevision = m_voiceSnapshotRevision + 1;
+  m_voiceSnapshotRevision = evenRevision;
+  m_publishedVoiceSnapshot.revision.store(evenRevision, std::memory_order_release);
 }
 
-void TransportController::postTransportEvent(const TransportEvent& event) {
-  // ORP121 C-03 / ORP133 G1: Lock-free SPSC event queue
-  // Audio thread writes POD events to the ring buffer (no mutex, no blocking,
-  // no std::function construction/destruction on the audio thread)
-  //
-  // Memory ordering rationale:
-  // - relaxed for same-thread reads (writeIdx in postTransportEvent)
-  // - acquire for cross-thread reads (readIdx check for full detection)
-  // - release for writes (ensures event data visible before index update)
+void TransportController::postTransportEvent(const TransportEvent& sourceEvent) noexcept {
+  TransportEvent event = sourceEvent;
+  m_callbackAttemptedSequence = incrementSaturated(m_callbackAttemptedSequence);
+  event.sequence = m_callbackAttemptedSequence;
 
-  size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_relaxed);
-  size_t nextIdx = (writeIdx + 1) & (CALLBACK_QUEUE_SIZE - 1); // Mask for wrap (power of 2)
+  const size_t writeIdx = m_callbackWriteIndex.load(std::memory_order_relaxed);
+  const size_t nextIdx = (writeIdx + 1) & (CALLBACK_QUEUE_SIZE - 1);
 
-  // Check if queue full (read index caught up)
   if (nextIdx == m_callbackReadIndex.load(std::memory_order_acquire)) {
-    // Queue full - drop event (better than blocking audio thread)
-    // Increment dropped callback counter for diagnostics
-    m_droppedCallbackCount.fetch_add(1, std::memory_order_relaxed);
+    m_callbackDroppedCount = incrementSaturated(m_callbackDroppedCount);
+    m_callbackLastDroppedSequence = event.sequence;
     return;
   }
 
   m_eventRing[writeIdx] = event;
   m_callbackWriteIndex.store(nextIdx, std::memory_order_release);
+  m_callbackPostedSequence = event.sequence;
+}
+
+void TransportController::publishCallbackTelemetry() noexcept {
+  const uint64_t oddRevision = m_callbackTelemetryRevision + 1;
+  m_callbackTelemetryRevision = oddRevision;
+  m_publishedCallbackTelemetry.revision.store(oddRevision, std::memory_order_release);
+  m_publishedCallbackTelemetry.lastAttemptedSequence.store(m_callbackAttemptedSequence,
+                                                           std::memory_order_release);
+  m_publishedCallbackTelemetry.lastPostedSequence.store(m_callbackPostedSequence,
+                                                        std::memory_order_release);
+  m_publishedCallbackTelemetry.cumulativeDroppedCount.store(m_callbackDroppedCount,
+                                                            std::memory_order_release);
+  m_publishedCallbackTelemetry.lastDroppedSequence.store(m_callbackLastDroppedSequence,
+                                                         std::memory_order_release);
+  m_publishedCallbackTelemetry.activeVoiceSnapshotSequence.store(m_voiceSnapshotSequence,
+                                                                 std::memory_order_release);
+  const uint64_t evenRevision = m_callbackTelemetryRevision + 1;
+  m_callbackTelemetryRevision = evenRevision;
+  m_publishedCallbackTelemetry.revision.store(evenRevision, std::memory_order_release);
 }
 
 void TransportController::processCallbacks() {
@@ -1801,16 +1882,13 @@ SessionGraphError TransportController::updateClipFades(ClipHandle handle, double
   // Get current trim points (or use defaults). ORP127 G1: read from the
   // published snapshot for active voices instead of the live audio-thread array.
   bool foundActiveClip = false;
-  {
-    size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-    const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-    for (size_t i = 0; i < buf.count; ++i) {
-      if (buf.voices[i].handle == handle) {
-        currentTrimIn = buf.voices[i].trimInSamples;
-        currentTrimOut = buf.voices[i].trimOutSamples;
-        foundActiveClip = true;
-        break;
-      }
+  const ActiveVoiceSnapshot activeSnapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < activeSnapshot.entryCount; ++index) {
+    if (activeSnapshot.entries[index].handle == handle) {
+      currentTrimIn = activeSnapshot.entries[index].newestTrimInSamples;
+      currentTrimOut = activeSnapshot.entries[index].newestTrimOutSamples;
+      foundActiveClip = true;
+      break;
     }
   }
 
@@ -1862,15 +1940,12 @@ SessionGraphError TransportController::getClipTrimPoints(ClipHandle handle, int6
   }
 
   // ORP127 G1: Try the published snapshot first (most recent active values).
-  {
-    size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-    const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-    for (size_t i = 0; i < buf.count; ++i) {
-      if (buf.voices[i].handle == handle) {
-        trimInSamples = buf.voices[i].trimInSamples;
-        trimOutSamples = buf.voices[i].trimOutSamples;
-        return SessionGraphError::OK;
-      }
+  const ActiveVoiceSnapshot activeSnapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < activeSnapshot.entryCount; ++index) {
+    if (activeSnapshot.entries[index].handle == handle) {
+      trimInSamples = activeSnapshot.entries[index].newestTrimInSamples;
+      trimOutSamples = activeSnapshot.entries[index].newestTrimOutSamples;
+      return SessionGraphError::OK;
     }
   }
 
@@ -1949,34 +2024,21 @@ SessionGraphError TransportController::setClipLoopMode(ClipHandle handle, bool s
 }
 
 int64_t TransportController::getClipPosition(ClipHandle handle) const {
-  // ORP127 G1: Multi-voice position from the published snapshot (UI-safe).
-  // Return the position of the newest voice (most recently started).
-  size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-  const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-
-  int64_t newestPosition = -1;
-  int64_t newestStartSample = INT64_MIN;
-  const VoiceSnapshot* newestVoice = nullptr;
-
-  for (size_t i = 0; i < buf.count; ++i) {
-    if (buf.voices[i].handle == handle) {
-      if (buf.voices[i].startSample > newestStartSample) {
-        newestStartSample = buf.voices[i].startSample;
-        newestPosition = buf.voices[i].currentSample;
-        newestVoice = &buf.voices[i];
-      }
+  const ActiveVoiceSnapshot snapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    const ActiveVoiceSnapshotEntry& entry = snapshot.entries[index];
+    if (entry.handle != handle) {
+      continue;
     }
-  }
 
-  // Clamp reported position to last valid playback position (trimOut - 1) for stopping clips
-  // (internally position advances past OUT to complete fade, but UI shouldn't see this)
-  // Edit Law #2: "Playhead < OUT" - position must be strictly less than OUT
-  if (newestVoice && newestVoice->isStopping) {
-    int64_t maxValidPosition = newestVoice->trimOutSamples - 1; // Last valid playback sample
-    newestPosition = std::min(newestPosition, maxValidPosition);
+    int64_t position = entry.newestPosition.samples;
+    if (entry.newestVoiceStopping != 0) {
+      const int64_t maxValidPosition = entry.newestTrimOutSamples - 1;
+      position = std::min(position, maxValidPosition);
+    }
+    return position;
   }
-
-  return newestPosition; // Returns -1 if no voices found
+  return -1;
 }
 
 SessionGraphError TransportController::setClipStopOthersMode(ClipHandle handle, bool enabled) {
@@ -2221,15 +2283,13 @@ SessionDefaults TransportController::getSessionDefaults() const {
 }
 
 bool TransportController::isClipLooping(ClipHandle handle) const {
-  // ORP127 G1: Query the published snapshot (UI-safe, no live-array access).
-  size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-  const VoiceSnapshotBuffer& buf = m_snapshotBuffers[front];
-  for (size_t i = 0; i < buf.count; ++i) {
-    if (buf.voices[i].handle == handle) {
-      return buf.voices[i].loopEnabled;
+  const ActiveVoiceSnapshot snapshot = getActiveVoiceSnapshot();
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    if (snapshot.entries[index].handle == handle) {
+      return snapshot.entries[index].newestVoiceLoopEnabled != 0;
     }
   }
-  return false; // Clip not playing
+  return false;
 }
 
 SessionGraphError TransportController::setClipVoiceMode(ClipHandle handle, VoiceMode mode) {
@@ -2265,8 +2325,78 @@ size_t TransportController::getActiveVoiceCount(ClipHandle handle) const {
 }
 
 size_t TransportController::getTotalActiveVoiceCount() const {
-  const size_t front = m_snapshotIndex.load(std::memory_order_acquire);
-  return m_snapshotBuffers[front].count;
+  return getActiveVoiceSnapshot().totalActiveVoiceCount;
+}
+
+TransportCallbackTelemetry TransportController::getCallbackDeliveryTelemetry() const noexcept {
+  for (;;) {
+    const uint64_t revisionBefore =
+        m_publishedCallbackTelemetry.revision.load(std::memory_order_acquire);
+    if ((revisionBefore & 1u) != 0) {
+      continue;
+    }
+
+    TransportCallbackTelemetry telemetry{};
+    telemetry.lastAttemptedSequence =
+        m_publishedCallbackTelemetry.lastAttemptedSequence.load(std::memory_order_acquire);
+    telemetry.lastPostedSequence =
+        m_publishedCallbackTelemetry.lastPostedSequence.load(std::memory_order_acquire);
+    telemetry.cumulativeDroppedCount =
+        m_publishedCallbackTelemetry.cumulativeDroppedCount.load(std::memory_order_acquire);
+    telemetry.lastDroppedSequence =
+        m_publishedCallbackTelemetry.lastDroppedSequence.load(std::memory_order_acquire);
+    telemetry.activeVoiceSnapshotSequence =
+        m_publishedCallbackTelemetry.activeVoiceSnapshotSequence.load(std::memory_order_acquire);
+
+    const uint64_t revisionAfter =
+        m_publishedCallbackTelemetry.revision.load(std::memory_order_acquire);
+    if (revisionBefore == revisionAfter) {
+      return telemetry;
+    }
+  }
+}
+
+ActiveVoiceSnapshot TransportController::getActiveVoiceSnapshot() const noexcept {
+  for (;;) {
+    const uint64_t revisionBefore =
+        m_publishedVoiceSnapshot.revision.load(std::memory_order_acquire);
+    if ((revisionBefore & 1u) != 0) {
+      continue;
+    }
+
+    ActiveVoiceSnapshot snapshot{};
+    snapshot.publicationSequence =
+        m_publishedVoiceSnapshot.publicationSequence.load(std::memory_order_acquire);
+    snapshot.entryCount =
+        std::min<uint32_t>(m_publishedVoiceSnapshot.entryCount.load(std::memory_order_acquire),
+                           static_cast<uint32_t>(kActiveVoiceSnapshotCapacity));
+    snapshot.totalActiveVoiceCount =
+        m_publishedVoiceSnapshot.totalActiveVoiceCount.load(std::memory_order_acquire);
+
+    for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+      const AtomicActiveVoiceSnapshotEntry& source = m_publishedVoiceSnapshot.entries[index];
+      ActiveVoiceSnapshotEntry& destination = snapshot.entries[index];
+      destination.handle = source.handle.load(std::memory_order_acquire);
+      destination.activeVoiceCount = source.activeVoiceCount.load(std::memory_order_acquire);
+      destination.newestVoiceId = source.newestVoiceId.load(std::memory_order_acquire);
+      destination.state = static_cast<PlaybackState>(source.state.load(std::memory_order_acquire));
+      destination.newestVoiceStopping = source.newestVoiceStopping.load(std::memory_order_acquire);
+      destination.newestVoiceLoopEnabled =
+          source.newestVoiceLoopEnabled.load(std::memory_order_acquire);
+      destination.newestStartSample = source.newestStartSample.load(std::memory_order_acquire);
+      destination.newestTrimInSamples = source.newestTrimInSamples.load(std::memory_order_acquire);
+      destination.newestTrimOutSamples =
+          source.newestTrimOutSamples.load(std::memory_order_acquire);
+      destination.newestPosition =
+          positionAtSamples(source.newestPositionSamples.load(std::memory_order_acquire));
+    }
+
+    const uint64_t revisionAfter =
+        m_publishedVoiceSnapshot.revision.load(std::memory_order_acquire);
+    if (revisionBefore == revisionAfter) {
+      return snapshot;
+    }
+  }
 }
 
 SessionGraphError TransportController::restartClip(ClipHandle handle) {

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <new>
 #include <orpheus/session_graph.h> // For SessionGraph
 
 // MSVC and some platforms don't define M_PI_2 by default
@@ -87,8 +88,7 @@ bool isValidSpeakerPatch(ChannelLayout layout, uint8_t patchSize,
   if (!standard.has_value() || standard->num_channels != fileChannels) {
     return false;
   }
-  return std::equal(patch.begin(), patch.begin() + patchSize,
-                    standard->channel_map.begin());
+  return std::equal(patch.begin(), patch.begin() + patchSize, standard->channel_map.begin());
 }
 
 } // namespace
@@ -97,11 +97,10 @@ TransportController::TransportController(core::SessionGraph* sessionGraph,
                                          const TransportConfig& config)
     : m_sessionGraph(sessionGraph), m_config(config), m_sampleRate(config.sampleRate),
       m_callback(nullptr) {
-  m_fadeOutSamples = static_cast<size_t>((FADE_OUT_DURATION_MS / 1000.0f) *
-                                         static_cast<float>(m_sampleRate));
-  m_restartCrossfadeSamples =
-      static_cast<size_t>((RESTART_CROSSFADE_DURATION_MS / 1000.0f) *
-                          static_cast<float>(m_sampleRate));
+  m_fadeOutSamples =
+      static_cast<size_t>((FADE_OUT_DURATION_MS / 1000.0f) * static_cast<float>(m_sampleRate));
+  m_restartCrossfadeSamples = static_cast<size_t>((RESTART_CROSSFADE_DURATION_MS / 1000.0f) *
+                                                  static_cast<float>(m_sampleRate));
 
   const float smoothingSamples =
       (CLIP_GAIN_SMOOTHING_MS / 1000.0f) * static_cast<float>(m_sampleRate);
@@ -122,10 +121,9 @@ TransportController::TransportController(core::SessionGraph* sessionGraph,
   routingConfig.enable_metering = true;
   routingConfig.enable_clipping_protection = true;
   routingConfig.source_channel_policy = m_config.sourceChannelPolicy;
-  routingConfig.downmix_policy =
-      m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete
-          ? DownmixPolicy::None
-          : DownmixPolicy::ITU_BS775_3;
+  routingConfig.downmix_policy = m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete
+                                     ? DownmixPolicy::None
+                                     : DownmixPolicy::ITU_BS775_3;
   m_routingMatrix->initialize(routingConfig);
 
   for (size_t voice = 0; voice < m_config.maxActiveVoices; ++voice) {
@@ -146,11 +144,10 @@ TransportController::TransportController(core::SessionGraph* sessionGraph,
     m_groupOutputWidths[group].store(0, std::memory_order_relaxed);
   }
   for (RoutingGroupIndex group = 0; group < m_config.numGroups; ++group) {
-    m_groupOutputWidths[group].store(
-        static_cast<uint16_t>(m_config.outputChannels),
-        std::memory_order_relaxed);
-    (void)m_routingMatrix->setGroupOutputRoute(
-        group, 0, static_cast<uint16_t>(m_config.outputChannels));
+    m_groupOutputWidths[group].store(static_cast<uint16_t>(m_config.outputChannels),
+                                     std::memory_order_relaxed);
+    (void)m_routingMatrix->setGroupOutputRoute(group, 0,
+                                               static_cast<uint16_t>(m_config.outputChannels));
   }
 
   m_clipReadBuffers.resize(m_config.maxActiveVoices);
@@ -175,69 +172,85 @@ TransportController::TransportController(core::SessionGraph* sessionGraph,
 
 TransportController::~TransportController() = default;
 
-SessionGraphError TransportController::startClip(ClipHandle handle) {
-  // Validate handle
+SessionGraphError
+TransportController::makeStartContext(ClipHandle handle, bool requireRegisteredSource,
+                                      std::shared_ptr<ClipPlaybackContext>& context) {
   if (handle == 0) {
     return SessionGraphError::InvalidHandle;
   }
 
-  // Resolve playback context (UI thread - safe to lock mutex)
-  auto context = std::make_shared<ClipPlaybackContext>();
-  context->handle = handle;
+  try {
+    context = std::make_shared<ClipPlaybackContext>();
+    context->handle = handle;
 
-  {
     std::lock_guard<std::mutex> lock(m_audioFilesMutex);
     auto it = m_audioFiles.find(handle);
     if (it != m_audioFiles.end()) {
       auto& entry = it->second;
       if (entry.sourceLayout == ChannelLayout::Unspecified ||
-          !isValidSpeakerPatch(entry.sourceLayout, entry.speakerPatchSize,
-                               entry.speakerPatch, entry.metadata.num_channels)) {
+          !isValidSpeakerPatch(entry.sourceLayout, entry.speakerPatchSize, entry.speakerPatch,
+                               entry.metadata.num_channels)) {
         return SessionGraphError::InvalidParameter;
       }
-      // ORP134 G1: lazy preparation for hosts that never call
-      // prepareClipAudio() — decode/stream setup happens HERE on the control
-      // thread, never on the audio thread.
-      ensurePreparedSourceLocked(entry);
+
+      // Source construction is control-thread work. Group-choke starts must
+      // reject unavailable media before posting the one atomic realtime command.
+      const SessionGraphError prepareResult = ensurePreparedSourceLocked(entry);
+      if (requireRegisteredSource && prepareResult != SessionGraphError::OK) {
+        return prepareResult;
+      }
       context->source = entry.source;
       context->numChannels = entry.metadata.num_channels;
       context->trimInSamples = entry.trimInSamples;
-      context->fileLengthSamples = entry.metadata.duration_samples; // ORP127 G3
-
-      // If trim OUT is not set (0), use file duration
+      context->fileLengthSamples = entry.metadata.duration_samples;
       context->trimOutSamples =
-          (entry.trimOutSamples == 0) ? entry.metadata.duration_samples : entry.trimOutSamples;
-
+          entry.trimOutSamples == 0 ? entry.metadata.duration_samples : entry.trimOutSamples;
       context->fadeInSeconds = entry.fadeInSeconds;
       context->fadeOutSeconds = entry.fadeOutSeconds;
       context->fadeInCurve = entry.fadeInCurve;
       context->fadeOutCurve = entry.fadeOutCurve;
       context->gainDb = entry.gainDb;
-      // Precompute linear gain
       context->gainLinear = std::pow(10.0f, entry.gainDb / 20.0f);
       context->loopEnabled = entry.loopEnabled;
       context->routingGroup = entry.routingGroup;
-      context->voiceMode = entry.voiceMode; // ORP127 G5
-    } else {
-      // Clip not registered - use defaults for testing
-      context->source = nullptr;
-      context->numChannels = 2;
-      context->trimInSamples = 0;
-      context->trimOutSamples = 48000 * 60;    // Default 60s
-      context->fileLengthSamples = 48000 * 60; // ORP127 G3: match default OUT
-      context->fadeInSeconds = 0.0;
-      context->fadeOutSeconds = 0.0;
-      context->fadeInCurve = FadeCurve::Linear;
-      context->fadeOutCurve = FadeCurve::Linear;
-      context->gainDb = 0.0f;
-      context->gainLinear = 1.0f;
-      context->loopEnabled = false;
-      context->routingGroup = 0;
-      context->voiceMode = VoiceMode::Polyphonic; // ORP127 G5: default
+      context->voiceMode = entry.voiceMode;
+      return SessionGraphError::OK;
     }
+
+    if (requireRegisteredSource) {
+      context.reset();
+      return SessionGraphError::ClipNotRegistered;
+    }
+
+    // Preserve the historical source-less test/default start contract.
+    context->source = nullptr;
+    context->numChannels = 2;
+    context->trimInSamples = 0;
+    context->trimOutSamples = 48000 * 60;
+    context->fileLengthSamples = 48000 * 60;
+    context->fadeInSeconds = 0.0;
+    context->fadeOutSeconds = 0.0;
+    context->fadeInCurve = FadeCurve::Linear;
+    context->fadeOutCurve = FadeCurve::Linear;
+    context->gainDb = 0.0f;
+    context->gainLinear = 1.0f;
+    context->loopEnabled = false;
+    context->routingGroup = 0;
+    context->voiceMode = VoiceMode::Polyphonic;
+    return SessionGraphError::OK;
+  } catch (const std::bad_alloc&) {
+    context.reset();
+    return SessionGraphError::InternalError;
+  }
+}
+
+SessionGraphError TransportController::startClip(ClipHandle handle) {
+  std::shared_ptr<ClipPlaybackContext> context;
+  const SessionGraphError contextResult = makeStartContext(handle, false, context);
+  if (contextResult != SessionGraphError::OK) {
+    return contextResult;
   }
 
-  // Check "Stop Others" mode (UI thread check is fine for initiating stop command)
   bool stopOthers = false;
   {
     std::lock_guard<std::mutex> lock(m_audioFilesMutex);
@@ -248,16 +261,25 @@ SessionGraphError TransportController::startClip(ClipHandle handle) {
   }
 
   if (stopOthers) {
-    // ORP127 G7: choke OTHER clips (not this one) before the Start command that
-    // follows in queue order. Using stopOtherClips(handle) instead of the old
-    // global stopAllClips() means existing voices of THIS clip are preserved and
-    // the choke is correctly scoped to everything else.
     stopOtherClips(handle);
   }
 
-  // Post Start command to audio thread
   TransportCommand cmd{};
   cmd.type = TransportCommand::Type::Start;
+  cmd.handle = handle;
+  cmd.startContext = context;
+  return postCommand(cmd);
+}
+
+SessionGraphError TransportController::startClipWithGroupChoke(ClipHandle handle) {
+  std::shared_ptr<ClipPlaybackContext> context;
+  const SessionGraphError contextResult = makeStartContext(handle, true, context);
+  if (contextResult != SessionGraphError::OK) {
+    return contextResult;
+  }
+
+  TransportCommand cmd{};
+  cmd.type = TransportCommand::Type::StartWithGroupChoke;
   cmd.handle = handle;
   cmd.startContext = context;
   return postCommand(cmd);
@@ -432,8 +454,7 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
       clip.source->setDemand(trimIn);
     } else if (clip.currentSample >= trimOut) {
       // Position at or past OUT point - handle loop or stop
-      const bool shouldLoop =
-          clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
+      const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
       if (shouldLoop) {
         // Loop mode: restart from IN point
         clip.currentSample = trimIn;
@@ -717,8 +738,7 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
     int64_t clipTrimOut = clip.trimOutSamples.load(std::memory_order_acquire);
     if (clip.currentSample >= clipTrimOut) {
       // Check if clip should loop
-      const bool shouldLoop =
-          clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
+      const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
 
       if (shouldLoop) {
         // Loop: jump back to trim IN point (works even without a source)
@@ -801,6 +821,31 @@ void TransportController::processCommands() {
         event.handle = cmd.handle;
         event.position = getCurrentPosition();
         postTransportEvent(event);
+      }
+    } break;
+
+    case TransportCommand::Type::StartWithGroupChoke: {
+      // Admission is deliberately first. A voice-pool refusal may publish the
+      // existing typed rejection event, but it cannot mutate any peer.
+      if (cmd.startContext && startVoiceWithMode(cmd.startContext)) {
+        TransportEvent event{};
+        event.type = TransportEventType::ClipStarted;
+        event.handle = cmd.handle;
+        event.position = getCurrentPosition();
+        postTransportEvent(event);
+
+        // Only after the firing voice is live do same-group peers enter their
+        // normal configured stop fades. The firing handle is always spared so
+        // MonoWithFadeOverlap and other per-handle policies remain authoritative.
+        const RoutingGroupIndex group = cmd.startContext->routingGroup;
+        for (size_t i = 0; i < m_activeClipCount; ++i) {
+          ActiveClip& peer = m_activeClips[i];
+          if (peer.handle != cmd.handle && peer.routingGroup == group && !peer.isStopping) {
+            peer.isStopping = true;
+            peer.fadeOutGain = 1.0f;
+            peer.fadeOutStartPos = peer.currentSample;
+          }
+        }
       }
     } break;
 
@@ -1090,8 +1135,7 @@ void TransportController::restartVoiceInPlace(ActiveClip& clip) {
   clip.restartFadeFramesRemaining = static_cast<int64_t>(m_restartCrossfadeSamples);
 }
 
-bool TransportController::startVoiceWithMode(
-    const std::shared_ptr<ClipPlaybackContext>& context) {
+bool TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
     return false;
 
@@ -1161,22 +1205,20 @@ bool TransportController::startVoiceWithMode(
   return addActiveClip(context);
 }
 
-void TransportController::configureVoiceRouting(
-    size_t voiceIndex, RoutingGroupIndex group, uint16_t numChannels) noexcept {
+void TransportController::configureVoiceRouting(size_t voiceIndex, RoutingGroupIndex group,
+                                                uint16_t numChannels) noexcept {
   const size_t laneBase = voiceIndex * m_config.maxSourceChannels;
   for (uint32_t lane = 0; lane < m_config.maxSourceChannels; ++lane) {
     const bool activeLane = lane < numChannels;
     const auto routeGroup = activeLane ? group : UNASSIGNED_GROUP;
     const auto output =
-        activeLane ? static_cast<RoutingOutputIndex>(lane)
-                   : static_cast<RoutingOutputIndex>(0);
-    (void)m_routingMatrix->setChannelRoute(
-        static_cast<RoutingChannelIndex>(laneBase + lane), routeGroup, output);
+        activeLane ? static_cast<RoutingOutputIndex>(lane) : static_cast<RoutingOutputIndex>(0);
+    (void)m_routingMatrix->setChannelRoute(static_cast<RoutingChannelIndex>(laneBase + lane),
+                                           routeGroup, output);
   }
 }
 
-bool TransportController::addActiveClip(
-    const std::shared_ptr<ClipPlaybackContext>& context) {
+bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context) {
   if (!context)
     return false;
 
@@ -1585,8 +1627,7 @@ SessionGraphError TransportController::registerClipAudio(ClipHandle handle,
   if (const auto inferred = inferUnambiguousChannelFormat(entry.metadata.num_channels)) {
     entry.sourceLayout = inferred->layout;
     entry.speakerPatchSize = inferred->num_channels;
-    std::copy_n(inferred->channel_map.begin(), inferred->num_channels,
-                entry.speakerPatch.begin());
+    std::copy_n(inferred->channel_map.begin(), inferred->num_channels, entry.speakerPatch.begin());
   }
 
   // Apply session defaults to new clip
@@ -2017,13 +2058,11 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   }
 
   if (metadata.routingGroup >= m_config.numGroups ||
-      fileChannels >
-          m_groupOutputWidths[metadata.routingGroup].load(
-              std::memory_order_acquire)) {
+      fileChannels > m_groupOutputWidths[metadata.routingGroup].load(std::memory_order_acquire)) {
     return SessionGraphError::InvalidParameter;
   }
-  if (!isValidSpeakerPatch(metadata.sourceLayout, metadata.speakerPatchSize,
-                           metadata.speakerPatch, fileChannels)) {
+  if (!isValidSpeakerPatch(metadata.sourceLayout, metadata.speakerPatchSize, metadata.speakerPatch,
+                           fileChannels)) {
     return SessionGraphError::InvalidParameter;
   }
 
@@ -2033,28 +2072,6 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
       static_cast<int64_t>(metadata.fadeInSeconds * static_cast<double>(m_sampleRate));
   int64_t fadeOutSampleCount =
       static_cast<int64_t>(metadata.fadeOutSeconds * static_cast<double>(m_sampleRate));
-
-  // Update persistent storage
-  {
-    std::lock_guard<std::mutex> lock(m_audioFilesMutex);
-    auto it = m_audioFiles.find(handle);
-    if (it != m_audioFiles.end()) {
-      it->second.trimInSamples = metadata.trimInSamples;
-      it->second.trimOutSamples = trimOut;
-      it->second.fadeInSeconds = metadata.fadeInSeconds;
-      it->second.fadeOutSeconds = metadata.fadeOutSeconds;
-      it->second.fadeInCurve = metadata.fadeInCurve;
-      it->second.fadeOutCurve = metadata.fadeOutCurve;
-      it->second.loopEnabled = metadata.loopEnabled;
-      it->second.stopOthersOnPlay = metadata.stopOthersOnPlay;
-      it->second.voiceMode = metadata.voiceMode; // ORP127 G5
-      it->second.gainDb = metadata.gainDb;
-      it->second.routingGroup = metadata.routingGroup;
-      it->second.sourceLayout = metadata.sourceLayout;
-      it->second.speakerPatchSize = metadata.speakerPatchSize;
-      it->second.speakerPatch = metadata.speakerPatch;
-    }
-  }
 
   // ORP127 G1: Apply to active voices via a command on the audio thread — no
   // direct writes to the live voice array from the UI thread. Precompute linear
@@ -2075,10 +2092,35 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   cmd.data.metadata.gainLinear = std::pow(10.0f, metadata.gainDb / 20.0f);
   cmd.data.metadata.routingGroup = metadata.routingGroup;
 
-  // Post best-effort: if the queue is full the persistent store already holds
-  // the new metadata and it will be picked up on next start. Return OK to match
-  // the historical contract (validation success == OK).
-  postCommand(cmd);
+  // Queue admission precedes the persistent commit. A full ring therefore
+  // cannot publish metadata that active voices did not receive, which is
+  // required when group choke compares registered and active routing groups.
+  {
+    std::lock_guard<std::mutex> lock(m_audioFilesMutex);
+    auto it = m_audioFiles.find(handle);
+    if (it == m_audioFiles.end()) {
+      return SessionGraphError::ClipNotRegistered;
+    }
+    const SessionGraphError postResult = postCommand(cmd);
+    if (postResult != SessionGraphError::OK) {
+      return postResult;
+    }
+
+    it->second.trimInSamples = metadata.trimInSamples;
+    it->second.trimOutSamples = trimOut;
+    it->second.fadeInSeconds = metadata.fadeInSeconds;
+    it->second.fadeOutSeconds = metadata.fadeOutSeconds;
+    it->second.fadeInCurve = metadata.fadeInCurve;
+    it->second.fadeOutCurve = metadata.fadeOutCurve;
+    it->second.loopEnabled = metadata.loopEnabled;
+    it->second.stopOthersOnPlay = metadata.stopOthersOnPlay;
+    it->second.voiceMode = metadata.voiceMode;
+    it->second.gainDb = metadata.gainDb;
+    it->second.routingGroup = metadata.routingGroup;
+    it->second.sourceLayout = metadata.sourceLayout;
+    it->second.speakerPatchSize = metadata.speakerPatchSize;
+    it->second.speakerPatch = metadata.speakerPatch;
+  }
 
   return SessionGraphError::OK;
 }
@@ -2119,31 +2161,27 @@ std::optional<ClipMetadata> TransportController::getClipMetadata(ClipHandle hand
   return metadata;
 }
 
-SessionGraphError TransportController::setGroupOutputBus(
-    RoutingGroupIndex group, const OutputBusRoute& route) {
+SessionGraphError TransportController::setGroupOutputBus(RoutingGroupIndex group,
+                                                         const OutputBusRoute& route) {
   if (group >= m_config.numGroups || route.channelCount == 0 ||
-      static_cast<uint32_t>(route.outputStart) + route.channelCount >
-          m_config.outputChannels) {
+      static_cast<uint32_t>(route.outputStart) + route.channelCount > m_config.outputChannels) {
     return SessionGraphError::InvalidParameter;
   }
 
   std::lock_guard<std::mutex> lock(m_audioFilesMutex);
   for (const auto& [handle, entry] : m_audioFiles) {
     (void)handle;
-    if (entry.routingGroup == group &&
-        entry.metadata.num_channels > route.channelCount) {
+    if (entry.routingGroup == group && entry.metadata.num_channels > route.channelCount) {
       return SessionGraphError::InvalidParameter;
     }
   }
-  const auto result = m_routingMatrix->setGroupOutputRoute(
-      group, route.outputStart, route.channelCount);
+  const auto result =
+      m_routingMatrix->setGroupOutputRoute(group, route.outputStart, route.channelCount);
   if (result != SessionGraphError::OK) {
     return result;
   }
-  m_groupOutputStarts[group].store(route.outputStart,
-                                    std::memory_order_release);
-  m_groupOutputWidths[group].store(route.channelCount,
-                                   std::memory_order_release);
+  m_groupOutputStarts[group].store(route.outputStart, std::memory_order_release);
+  m_groupOutputWidths[group].store(route.channelCount, std::memory_order_release);
   return SessionGraphError::OK;
 }
 
@@ -2152,9 +2190,8 @@ TransportController::getGroupOutputBus(RoutingGroupIndex group) const {
   if (group >= m_config.numGroups) {
     return std::nullopt;
   }
-  return OutputBusRoute{
-      m_groupOutputStarts[group].load(std::memory_order_acquire),
-      m_groupOutputWidths[group].load(std::memory_order_acquire)};
+  return OutputBusRoute{m_groupOutputStarts[group].load(std::memory_order_acquire),
+                        m_groupOutputWidths[group].load(std::memory_order_acquire)};
 }
 
 float TransportController::calculateFadeGain(float normalizedPosition, FadeCurve curve) const {
@@ -2464,8 +2501,8 @@ float TransportController::applyDownmixRight(const float* src, size_t frame, siz
 }
 
 // Factory function
-std::unique_ptr<ITransportController>
-createTransportController(core::SessionGraph* sessionGraph, const TransportConfig& config) {
+std::unique_ptr<ITransportController> createTransportController(core::SessionGraph* sessionGraph,
+                                                                const TransportConfig& config) {
   constexpr uint32_t maxBlockFrames = 2048;
   constexpr uint32_t maxActiveVoices = 32;
   constexpr uint32_t maxSourceChannels = 8;
@@ -2474,9 +2511,8 @@ createTransportController(core::SessionGraph* sessionGraph, const TransportConfi
   if (config.sampleRate == 0 || config.outputChannels == 0 || config.outputChannels > 32 ||
       config.maxBlockFrames == 0 || config.maxBlockFrames > maxBlockFrames ||
       config.maxActiveVoices == 0 || config.maxActiveVoices > maxActiveVoices ||
-      config.numGroups == 0 || config.numGroups > 32 ||
-      config.maxSourceChannels == 0 || config.maxSourceChannels > maxSourceChannels ||
-      routingLanes > 256) {
+      config.numGroups == 0 || config.numGroups > 32 || config.maxSourceChannels == 0 ||
+      config.maxSourceChannels > maxSourceChannels || routingLanes > 256) {
     return nullptr;
   }
   return std::make_unique<TransportController>(sessionGraph, config);

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -121,6 +121,7 @@ struct TransportCommand {
 struct ActiveClip {
   ClipHandle handle;
   uint32_t voiceId;      // Unique voice instance ID (for multi-voice layering)
+  uint64_t startOrdinal; // Chronological start generation (wrap-aware)
   int64_t startSample;   // When clip started playing (transport time)
   int64_t currentSample; // Current position within clip audio
 
@@ -325,6 +326,16 @@ public:
     m_nextVoiceId = nextVoiceId;
   }
 
+  /// Test-only control of the next chronological start ordinal.
+  void setNextVoiceStartOrdinalForTesting(uint64_t nextOrdinal) noexcept {
+    m_nextVoiceStartOrdinal = nextOrdinal;
+  }
+
+  /// Test-only mutation while the audio callback is stopped.
+  bool setVoiceSnapshotFieldsForTesting(uint32_t voiceId, bool stopping, bool looping,
+                                        int64_t trimIn, int64_t trimOut,
+                                        int64_t currentSample) noexcept;
+
 private:
   /// Derive seconds/beats from the sample-canonical coordinate and current
   /// block-boundary tempo snapshot.
@@ -356,6 +367,10 @@ private:
   /// Find oldest active voice for a given clip handle
   /// @return Pointer to oldest voice, or nullptr if none found
   ActiveClip* findOldestVoice(ClipHandle handle);
+
+  /// Allocate the chronological start ordinal, rebasing the bounded live set
+  /// before serial-number comparisons could become ambiguous.
+  uint64_t allocateVoiceStartOrdinal() noexcept;
 
   /// Add a clip to the active list. Returns false when the global voice pool
   /// cannot accept the start.
@@ -444,6 +459,8 @@ private:
     std::atomic<int64_t> newestTrimInSamples{0};
     std::atomic<int64_t> newestTrimOutSamples{0};
     std::atomic<int64_t> newestPositionSamples{0};
+    std::atomic<uint64_t> newestPositionSecondsBits{0};
+    std::atomic<uint64_t> newestPositionBeatsBits{0};
   };
   struct AtomicActiveVoiceSnapshot {
     std::atomic<uint64_t> revision{0};
@@ -455,6 +472,7 @@ private:
   AtomicActiveVoiceSnapshot m_publishedVoiceSnapshot{};
   ActiveVoiceSnapshot m_voiceSnapshotScratch{};
   std::array<bool, kActiveVoiceSnapshotCapacity> m_voiceSnapshotHasNewest{};
+  std::array<uint64_t, kActiveVoiceSnapshotCapacity> m_voiceSnapshotNewestStartOrdinal{};
   uint64_t m_voiceSnapshotRevision{0};
   uint64_t m_voiceSnapshotSequence{0};
 
@@ -464,6 +482,11 @@ private:
   static constexpr uint32_t DEFAULT_MAX_VOICES_PER_CLIP = 8;
   std::atomic<uint32_t> m_maxVoicesPerClip{DEFAULT_MAX_VOICES_PER_CLIP};
   uint32_t m_nextVoiceId{1}; // Incrementing voice ID counter (0 = invalid)
+  // Chronological serial-number arithmetic. Unsigned wrap is intentional.
+  // The bounded live set is rebased before any pair can be separated by 2^63,
+  // keeping comparisons unambiguous for the controller lifetime.
+  uint64_t m_nextVoiceStartOrdinal{0};
+  std::array<uint64_t, MAX_ACTIVE_CLIPS> m_voiceStartOrdinalScratch{};
 
   // Transport position (audio thread writes, UI thread reads)
   std::atomic<int64_t> m_currentSample{0};

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -209,6 +209,7 @@ enum class TransportEventType : uint8_t {
 /// ORP133 G1: Trivially-copyable event payload for the audio→UI SPSC ring.
 struct TransportEvent {
   TransportEventType type;
+  uint64_t sequence;          ///< Monotonic attempted-delivery sequence
   ClipHandle handle;          ///< Subject clip (0 for transport-wide events)
   uint32_t voiceId;           ///< Voice instance when known, 0 otherwise (diagnostic)
   TransportPosition position; ///< Position payload delivered to the callback
@@ -218,19 +219,10 @@ static_assert(std::is_trivially_copyable_v<TransportEvent>,
               "TransportEvent must stay POD: it is copied through the audio->UI ring "
               "with no construction/destruction on the audio thread");
 
-/// ORP127 G1: Immutable per-voice snapshot published by the audio thread for
-/// lock-free UI-thread queries. Plain-old-data so it can be copied wholesale
-/// without touching the live (audio-thread-owned) ActiveClip array.
-struct VoiceSnapshot {
-  ClipHandle handle;
-  uint32_t voiceId;
-  int64_t startSample;
-  int64_t currentSample;
-  int64_t trimInSamples;
-  int64_t trimOutSamples;
-  bool isStopping;
-  bool loopEnabled;
-};
+static_assert(std::atomic<uint8_t>::is_always_lock_free);
+static_assert(std::atomic<uint32_t>::is_always_lock_free);
+static_assert(std::atomic<uint64_t>::is_always_lock_free);
+static_assert(std::atomic<int64_t>::is_always_lock_free);
 
 /// Transport controller implementation
 class TransportController : public ITransportController {
@@ -282,6 +274,8 @@ public:
   VoiceMode getClipVoiceMode(ClipHandle handle) const override;
   size_t getActiveVoiceCount(ClipHandle handle) const override;
   size_t getTotalActiveVoiceCount() const override;
+  TransportCallbackTelemetry getCallbackDeliveryTelemetry() const noexcept override;
+  ActiveVoiceSnapshot getActiveVoiceSnapshot() const noexcept override;
   SessionGraphError restartClip(ClipHandle handle) override;
   SessionGraphError seekClip(ClipHandle handle, int64_t position) override;
 
@@ -326,6 +320,11 @@ public:
     m_preparedSourceMaxFrames = maxFrames;
   }
 
+  /// Test-only control of the next RT voice-ID candidate.
+  void setNextVoiceIdForTesting(uint32_t nextVoiceId) noexcept {
+    m_nextVoiceId = nextVoiceId;
+  }
+
 private:
   /// Derive seconds/beats from the sample-canonical coordinate and current
   /// block-boundary tempo snapshot.
@@ -361,6 +360,10 @@ private:
   /// Add a clip to the active list. Returns false when the global voice pool
   /// cannot accept the start.
   bool addActiveClip(const std::shared_ptr<ClipPlaybackContext>& context);
+
+  /// Allocate a nonzero ID distinct from every active voice. Audio-thread only;
+  /// bounded by the fixed active-voice capacity.
+  uint32_t allocateVoiceId() noexcept;
   void configureVoiceRouting(size_t voiceIndex, RoutingGroupIndex group,
                              uint16_t numChannels) noexcept;
 
@@ -385,10 +388,12 @@ private:
   /// @note Deprecated: Use removeActiveVoice() for multi-voice
   void removeActiveClip(ClipHandle handle);
 
-  /// ORP133 G1: Post a POD transport event to the UI thread (audio thread only).
-  /// Drops the event (and bumps m_droppedCallbackCount) if the ring is full —
-  /// never blocks the audio thread.
-  void postTransportEvent(const TransportEvent& event);
+  /// Post a POD transport event to the control-thread ring (audio thread only).
+  /// Every attempt advances cumulative telemetry before the capacity check.
+  void postTransportEvent(const TransportEvent& event) noexcept;
+
+  /// Publish callback delivery counters through a coherent atomic seqlock.
+  void publishCallbackTelemetry() noexcept;
 
   /// Calculate fade gain based on curve type
   /// @param normalizedPosition Position in fade (0.0 to 1.0)
@@ -396,11 +401,9 @@ private:
   /// @return Gain value (0.0 to 1.0)
   float calculateFadeGain(float normalizedPosition, FadeCurve curve) const;
 
-  /// ORP127 G1: Publish a snapshot of all active voices for UI-thread queries.
-  /// Called from the audio thread at the end of processAudio(). Writes into the
-  /// back buffer, then flips m_snapshotIndex with release ordering so UI readers
-  /// (acquire) always see a fully-consistent set of voices — never a torn view.
-  void publishVoiceSnapshot();
+  /// Publish a coherent per-handle aggregate of all surviving voices.
+  /// Audio-thread only; fixed work bounded by the configured 32-voice ceiling.
+  void publishVoiceSnapshot() noexcept;
 
   /// ORP127 G1: Post a command to the audio thread. Returns OK, or InternalError
   /// if the SPSC command queue is full. Centralizes the write-index/full-check
@@ -427,16 +430,33 @@ private:
   std::array<ActiveClip, MAX_ACTIVE_CLIPS> m_activeClips;
   size_t m_activeClipCount{0};
 
-  // ORP127 G1: Double-buffered voice snapshot for lock-free UI-thread queries.
-  // Audio thread writes the back buffer in publishVoiceSnapshot() and flips
-  // m_snapshotIndex (release); UI-thread queries read the front buffer via
-  // m_snapshotIndex (acquire). No UI thread ever touches m_activeClips.
-  struct VoiceSnapshotBuffer {
-    std::array<VoiceSnapshot, MAX_ACTIVE_CLIPS> voices;
-    size_t count{0};
+  // Atomic seqlock publication. Every payload field is atomic, so a reader that
+  // overlaps publication can retry without a C++ data race; the RT writer never
+  // waits, locks, or allocates.
+  struct AtomicActiveVoiceSnapshotEntry {
+    std::atomic<ClipHandle> handle{0};
+    std::atomic<uint32_t> activeVoiceCount{0};
+    std::atomic<uint32_t> newestVoiceId{0};
+    std::atomic<uint8_t> state{static_cast<uint8_t>(PlaybackState::Stopped)};
+    std::atomic<uint8_t> newestVoiceStopping{0};
+    std::atomic<uint8_t> newestVoiceLoopEnabled{0};
+    std::atomic<int64_t> newestStartSample{0};
+    std::atomic<int64_t> newestTrimInSamples{0};
+    std::atomic<int64_t> newestTrimOutSamples{0};
+    std::atomic<int64_t> newestPositionSamples{0};
   };
-  std::array<VoiceSnapshotBuffer, 2> m_snapshotBuffers;
-  std::atomic<size_t> m_snapshotIndex{0}; // Index of the front (published) buffer
+  struct AtomicActiveVoiceSnapshot {
+    std::atomic<uint64_t> revision{0};
+    std::atomic<uint64_t> publicationSequence{0};
+    std::atomic<uint32_t> entryCount{0};
+    std::atomic<uint32_t> totalActiveVoiceCount{0};
+    std::array<AtomicActiveVoiceSnapshotEntry, kActiveVoiceSnapshotCapacity> entries{};
+  };
+  AtomicActiveVoiceSnapshot m_publishedVoiceSnapshot{};
+  ActiveVoiceSnapshot m_voiceSnapshotScratch{};
+  std::array<bool, kActiveVoiceSnapshotCapacity> m_voiceSnapshotHasNewest{};
+  uint64_t m_voiceSnapshotRevision{0};
+  uint64_t m_voiceSnapshotSequence{0};
 
   // Multi-voice management (ORP127 G7: configurable voice cap for resource
   // protection). Default 8, hard ceiling 32; hosts typically set 2/4/8/16.
@@ -465,8 +485,23 @@ private:
   std::atomic<size_t> m_callbackWriteIndex{0};
   std::atomic<size_t> m_callbackReadIndex{0};
 
-  // Diagnostic counter for dropped callbacks (queue overflow)
-  std::atomic<uint32_t> m_droppedCallbackCount{0};
+  // Lifetime-cumulative callback-delivery telemetry. The audio thread is the
+  // only writer; arbitrary non-RT readers obtain a coherent value copy through
+  // the atomic revision.
+  struct AtomicCallbackTelemetry {
+    std::atomic<uint64_t> revision{0};
+    std::atomic<uint64_t> lastAttemptedSequence{0};
+    std::atomic<uint64_t> lastPostedSequence{0};
+    std::atomic<uint64_t> cumulativeDroppedCount{0};
+    std::atomic<uint64_t> lastDroppedSequence{0};
+    std::atomic<uint64_t> activeVoiceSnapshotSequence{0};
+  };
+  AtomicCallbackTelemetry m_publishedCallbackTelemetry{};
+  uint64_t m_callbackTelemetryRevision{0};
+  uint64_t m_callbackAttemptedSequence{0};
+  uint64_t m_callbackPostedSequence{0};
+  uint64_t m_callbackDroppedCount{0};
+  uint64_t m_callbackLastDroppedSequence{0};
 
 #ifndef NDEBUG
   // ORP133 G3: Debug-only enforcement of the command queue's single-producer

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -63,11 +63,12 @@ struct TransportCommand {
     UpdateStopOthers,
     // ORP127 G1: UI-thread voice mutations routed onto the audio thread so no
     // ActiveClip field is written from two threads.
-    Restart,        // Restart all voices for a handle from trim IN (with fade-in)
-    Seek,           // Seek all voices for a handle to an absolute position
-    UpdateMetadata, // Apply a full metadata batch to active voices
-    SetVoiceMode,   // ORP127 G5: change a clip's voice policy (audio-thread state)
-    StopOthers      // ORP127 G7: stop every voice except cmd.handle (choke primitive)
+    Restart,            // Restart all voices for a handle from trim IN (with fade-in)
+    Seek,               // Seek all voices for a handle to an absolute position
+    UpdateMetadata,     // Apply a full metadata batch to active voices
+    SetVoiceMode,       // ORP127 G5: change a clip's voice policy (audio-thread state)
+    StopOthers,         // ORP127 G7: stop every voice except cmd.handle (choke primitive)
+    StartWithGroupChoke // Atomically admit start, then fade registered same-group peers
   };
 
   Type type;
@@ -249,6 +250,7 @@ public:
   SessionGraphError panic() override; // OCC155 Ask #5: hard-cut, no fade
   SessionGraphError stopAllInGroup(uint8_t groupIndex) override;
   SessionGraphError stopOtherClips(ClipHandle exceptHandle) override;
+  SessionGraphError startClipWithGroupChoke(ClipHandle handle) override;
   SessionGraphError setMaxVoicesPerClip(uint32_t maxVoices) override;
   uint32_t getMaxVoicesPerClip() const override;
   PlaybackState getClipState(ClipHandle handle) const override;
@@ -270,10 +272,9 @@ public:
   bool getClipStopOthersMode(ClipHandle handle) const override;
   SessionGraphError updateClipMetadata(ClipHandle handle, const ClipMetadata& metadata) override;
   std::optional<ClipMetadata> getClipMetadata(ClipHandle handle) const override;
-  SessionGraphError setGroupOutputBus(
-      RoutingGroupIndex group, const OutputBusRoute& route) override;
-  std::optional<OutputBusRoute>
-  getGroupOutputBus(RoutingGroupIndex group) const override;
+  SessionGraphError setGroupOutputBus(RoutingGroupIndex group,
+                                      const OutputBusRoute& route) override;
+  std::optional<OutputBusRoute> getGroupOutputBus(RoutingGroupIndex group) const override;
   void setSessionDefaults(const SessionDefaults& defaults) override;
   SessionDefaults getSessionDefaults() const override;
   bool isClipLooping(ClipHandle handle) const override;
@@ -290,7 +291,6 @@ public:
   std::vector<CuePoint> getCuePoints(ClipHandle handle) const override;
   SessionGraphError seekToCuePoint(ClipHandle handle, uint32_t cueIndex) override;
   SessionGraphError removeCuePoint(ClipHandle handle, uint32_t cueIndex) override;
-
 
   /// Register audio file for a clip (UI thread)
   /// @param handle Clip handle
@@ -330,6 +330,13 @@ private:
   /// Derive seconds/beats from the sample-canonical coordinate and current
   /// block-boundary tempo snapshot.
   TransportPosition positionAtSamples(int64_t samples) const;
+
+  /// Resolve and prepare immutable start state on the control thread.
+  ///
+  /// Group-choke starts require a registered, available source so every
+  /// pre-admission failure is reported before the atomic command is posted.
+  SessionGraphError makeStartContext(ClipHandle handle, bool requireRegisteredSource,
+                                     std::shared_ptr<ClipPlaybackContext>& context);
 
   /// Process pending commands from UI thread
   void processCommands();
@@ -528,10 +535,8 @@ private:
   // Routing matrix for final mix (audio thread processes, UI thread configures)
   std::unique_ptr<IRoutingMatrix> m_routingMatrix;
   static constexpr size_t MAX_LOGICAL_GROUPS = 32;
-  std::array<std::atomic<RoutingOutputIndex>, MAX_LOGICAL_GROUPS>
-      m_groupOutputStarts{};
-  std::array<std::atomic<uint16_t>, MAX_LOGICAL_GROUPS>
-      m_groupOutputWidths{};
+  std::array<std::atomic<RoutingOutputIndex>, MAX_LOGICAL_GROUPS> m_groupOutputStarts{};
+  std::array<std::atomic<uint16_t>, MAX_LOGICAL_GROUPS> m_groupOutputWidths{};
 
   // Fixed-capacity audio-thread → message-thread telemetry bridge.
   RealtimeTelemetry m_realtimeTelemetry{};

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -59,6 +59,11 @@ add_orpheus_fixture(orpheus_find_package_workflow_contracts workflow_contracts.c
 target_link_libraries(orpheus_find_package_workflow_contracts
   PRIVATE Orpheus::transport)
 
+add_orpheus_fixture(orpheus_find_package_legacy_transport
+  legacy_transport_implementation.cpp)
+target_link_libraries(orpheus_find_package_legacy_transport
+  PRIVATE Orpheus::transport)
+
 if(APPLE AND NOT TARGET Orpheus::audio_driver_coreaudio)
   message(FATAL_ERROR "macOS package is missing Orpheus::audio_driver_coreaudio")
 endif()

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -64,6 +64,11 @@ add_orpheus_fixture(orpheus_find_package_legacy_transport
 target_link_libraries(orpheus_find_package_legacy_transport
   PRIVATE Orpheus::transport)
 
+add_orpheus_fixture(orpheus_find_package_legacy_transport_defaults
+  legacy_transport_defaults.cpp)
+target_link_libraries(orpheus_find_package_legacy_transport_defaults
+  PRIVATE Orpheus::transport)
+
 if(APPLE AND NOT TARGET Orpheus::audio_driver_coreaudio)
   message(FATAL_ERROR "macOS package is missing Orpheus::audio_driver_coreaudio")
 endif()

--- a/tests/cmake/find_package/legacy_transport_defaults.cpp
+++ b/tests/cmake/find_package/legacy_transport_defaults.cpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/transport_controller.h>
+
+#include <type_traits>
+
+namespace {
+
+class LegacyTransportImplementation final : public orpheus::ITransportController {
+public:
+  orpheus::SessionGraphError startClip(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError stopClip(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError stopAllClips() override {
+    return ok;
+  }
+  orpheus::SessionGraphError panic() override {
+    return ok;
+  }
+  orpheus::SessionGraphError stopAllInGroup(uint8_t) override {
+    return ok;
+  }
+  orpheus::SessionGraphError stopOtherClips(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError setMaxVoicesPerClip(uint32_t) override {
+    return ok;
+  }
+  uint32_t getMaxVoicesPerClip() const override {
+    return 1;
+  }
+  orpheus::PlaybackState getClipState(orpheus::ClipHandle) const override {
+    return orpheus::PlaybackState::Stopped;
+  }
+  bool isClipPlaying(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::TransportPosition getCurrentPosition() const override {
+    return {};
+  }
+  orpheus::IRoutingMatrix* getRoutingMatrix() const override {
+    return nullptr;
+  }
+  void setCallback(orpheus::ITransportCallback*) override {}
+  orpheus::SessionGraphError registerClipAudio(orpheus::ClipHandle, const std::string&) override {
+    return ok;
+  }
+  orpheus::SessionGraphError prepareClipAudio(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError unregisterClipAudio(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError updateClipTrimPoints(orpheus::ClipHandle, int64_t, int64_t) override {
+    return ok;
+  }
+  orpheus::SessionGraphError updateClipFades(orpheus::ClipHandle, double, double,
+                                             orpheus::FadeCurve, orpheus::FadeCurve) override {
+    return ok;
+  }
+  orpheus::SessionGraphError getClipTrimPoints(orpheus::ClipHandle, int64_t&,
+                                               int64_t&) const override {
+    return ok;
+  }
+  orpheus::SessionGraphError updateClipGain(orpheus::ClipHandle, float) override {
+    return ok;
+  }
+  orpheus::SessionGraphError setClipLoopMode(orpheus::ClipHandle, bool) override {
+    return ok;
+  }
+  int64_t getClipPosition(orpheus::ClipHandle) const override {
+    return -1;
+  }
+  orpheus::SessionGraphError setClipStopOthersMode(orpheus::ClipHandle, bool) override {
+    return ok;
+  }
+  bool getClipStopOthersMode(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::SessionGraphError updateClipMetadata(orpheus::ClipHandle,
+                                                const orpheus::ClipMetadata&) override {
+    return ok;
+  }
+  std::optional<orpheus::ClipMetadata> getClipMetadata(orpheus::ClipHandle) const override {
+    return std::nullopt;
+  }
+  orpheus::SessionGraphError setGroupOutputBus(orpheus::RoutingGroupIndex,
+                                               const orpheus::OutputBusRoute&) override {
+    return ok;
+  }
+  std::optional<orpheus::OutputBusRoute>
+  getGroupOutputBus(orpheus::RoutingGroupIndex) const override {
+    return std::nullopt;
+  }
+  void setSessionDefaults(const orpheus::SessionDefaults&) override {}
+  orpheus::SessionDefaults getSessionDefaults() const override {
+    return {};
+  }
+  bool isClipLooping(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::SessionGraphError setClipVoiceMode(orpheus::ClipHandle, orpheus::VoiceMode) override {
+    return ok;
+  }
+  orpheus::VoiceMode getClipVoiceMode(orpheus::ClipHandle) const override {
+    return orpheus::VoiceMode::Polyphonic;
+  }
+  size_t getActiveVoiceCount(orpheus::ClipHandle) const override {
+    return 0;
+  }
+  size_t getTotalActiveVoiceCount() const override {
+    return 0;
+  }
+  orpheus::SessionGraphError restartClip(orpheus::ClipHandle) override {
+    return ok;
+  }
+  orpheus::SessionGraphError seekClip(orpheus::ClipHandle, int64_t) override {
+    return ok;
+  }
+  int addCuePoint(orpheus::ClipHandle, int64_t, const std::string&, uint32_t) override {
+    return 0;
+  }
+  std::vector<orpheus::CuePoint> getCuePoints(orpheus::ClipHandle) const override {
+    return {};
+  }
+  orpheus::SessionGraphError seekToCuePoint(orpheus::ClipHandle, uint32_t) override {
+    return ok;
+  }
+  orpheus::SessionGraphError removeCuePoint(orpheus::ClipHandle, uint32_t) override {
+    return ok;
+  }
+  orpheus::RealtimeTelemetry* getRealtimeTelemetry() noexcept override {
+    return nullptr;
+  }
+  orpheus::TransportConfig getRenderConfig() const noexcept override {
+    return {};
+  }
+  void processAudio(float* const*, size_t, size_t) noexcept override {}
+  void processCallbacks() override {}
+
+private:
+  static constexpr auto ok = orpheus::SessionGraphError::OK;
+};
+
+static_assert(!std::is_abstract_v<LegacyTransportImplementation>);
+
+} // namespace
+
+int main() {
+  LegacyTransportImplementation legacy;
+  const auto telemetry = legacy.getCallbackDeliveryTelemetry();
+  const auto snapshot = legacy.getActiveVoiceSnapshot();
+  return telemetry.lastAttemptedSequence == 0 && telemetry.cumulativeDroppedCount == 0 &&
+                 telemetry.activeVoiceSnapshotSequence == 0 && snapshot.entryCount == 0 &&
+                 snapshot.totalActiveVoiceCount == 0
+             ? 0
+             : 1;
+}

--- a/tests/cmake/find_package/legacy_transport_implementation.cpp
+++ b/tests/cmake/find_package/legacy_transport_implementation.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+
+#include <orpheus/transport_controller.h>
+
+#include <type_traits>
+
+namespace {
+
+class LegacyTransportImplementation final : public orpheus::ITransportController {
+public:
+  orpheus::SessionGraphError startClip(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError stopClip(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError stopAllClips() override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError panic() override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError stopAllInGroup(uint8_t) override {
+    return orpheus::SessionGraphError::NotSupported;
+  }
+  orpheus::SessionGraphError stopOtherClips(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError setMaxVoicesPerClip(uint32_t) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  uint32_t getMaxVoicesPerClip() const override {
+    return 1;
+  }
+  orpheus::PlaybackState getClipState(orpheus::ClipHandle) const override {
+    return orpheus::PlaybackState::Stopped;
+  }
+  bool isClipPlaying(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::TransportPosition getCurrentPosition() const override {
+    return {};
+  }
+  orpheus::IRoutingMatrix* getRoutingMatrix() const override {
+    return nullptr;
+  }
+  void setCallback(orpheus::ITransportCallback*) override {}
+  orpheus::SessionGraphError registerClipAudio(orpheus::ClipHandle, const std::string&) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError prepareClipAudio(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError unregisterClipAudio(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError updateClipTrimPoints(orpheus::ClipHandle, int64_t, int64_t) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError updateClipFades(orpheus::ClipHandle, double, double,
+                                             orpheus::FadeCurve, orpheus::FadeCurve) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError getClipTrimPoints(orpheus::ClipHandle, int64_t&,
+                                               int64_t&) const override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError updateClipGain(orpheus::ClipHandle, float) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError setClipLoopMode(orpheus::ClipHandle, bool) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  int64_t getClipPosition(orpheus::ClipHandle) const override {
+    return -1;
+  }
+  orpheus::SessionGraphError setClipStopOthersMode(orpheus::ClipHandle, bool) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  bool getClipStopOthersMode(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::SessionGraphError updateClipMetadata(orpheus::ClipHandle,
+                                                const orpheus::ClipMetadata&) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  std::optional<orpheus::ClipMetadata> getClipMetadata(orpheus::ClipHandle) const override {
+    return std::nullopt;
+  }
+  orpheus::SessionGraphError setGroupOutputBus(orpheus::RoutingGroupIndex,
+                                               const orpheus::OutputBusRoute&) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  std::optional<orpheus::OutputBusRoute>
+  getGroupOutputBus(orpheus::RoutingGroupIndex) const override {
+    return std::nullopt;
+  }
+  void setSessionDefaults(const orpheus::SessionDefaults&) override {}
+  orpheus::SessionDefaults getSessionDefaults() const override {
+    return {};
+  }
+  bool isClipLooping(orpheus::ClipHandle) const override {
+    return false;
+  }
+  orpheus::SessionGraphError setClipVoiceMode(orpheus::ClipHandle, orpheus::VoiceMode) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::VoiceMode getClipVoiceMode(orpheus::ClipHandle) const override {
+    return orpheus::VoiceMode::Polyphonic;
+  }
+  size_t getActiveVoiceCount(orpheus::ClipHandle) const override {
+    return 0;
+  }
+  size_t getTotalActiveVoiceCount() const override {
+    return 0;
+  }
+  orpheus::SessionGraphError restartClip(orpheus::ClipHandle) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  orpheus::SessionGraphError seekClip(orpheus::ClipHandle, int64_t) override {
+    return orpheus::SessionGraphError::OK;
+  }
+  int addCuePoint(orpheus::ClipHandle, int64_t, const std::string&, uint32_t) override {
+    return -1;
+  }
+  std::vector<orpheus::CuePoint> getCuePoints(orpheus::ClipHandle) const override {
+    return {};
+  }
+  orpheus::SessionGraphError seekToCuePoint(orpheus::ClipHandle, uint32_t) override {
+    return orpheus::SessionGraphError::NotSupported;
+  }
+  orpheus::SessionGraphError removeCuePoint(orpheus::ClipHandle, uint32_t) override {
+    return orpheus::SessionGraphError::NotSupported;
+  }
+  orpheus::RealtimeTelemetry* getRealtimeTelemetry() noexcept override {
+    return nullptr;
+  }
+  orpheus::TransportConfig getRenderConfig() const noexcept override {
+    return {};
+  }
+  void processAudio(float* const*, size_t, size_t) noexcept override {}
+  void processCallbacks() override {}
+
+  // Deliberately no startClipWithGroupChoke() override: this models a custom
+  // implementation written against the preceding public interface.
+};
+
+static_assert(!std::is_abstract_v<LegacyTransportImplementation>);
+
+} // namespace
+
+int main() {
+  LegacyTransportImplementation transport;
+  return transport.startClipWithGroupChoke(1) == orpheus::SessionGraphError::NotSupported ? 0 : 1;
+}

--- a/tests/cmake/find_package/transport_routing.cpp
+++ b/tests/cmake/find_package/transport_routing.cpp
@@ -2,7 +2,55 @@
 #include <orpheus/audio_driver_manager.h>
 #include <orpheus/routing_matrix.h>
 #include <orpheus/transport_controller.h>
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <type_traits>
 #include <vector>
+
+static_assert(std::is_trivially_copyable_v<orpheus::TransportCallbackTelemetry>);
+static_assert(std::is_standard_layout_v<orpheus::TransportCallbackTelemetry>);
+static_assert(std::is_trivially_copyable_v<orpheus::ActiveVoiceSnapshot>);
+static_assert(std::is_standard_layout_v<orpheus::ActiveVoiceSnapshot>);
+static_assert(orpheus::kActiveVoiceSnapshotCapacity == 32);
+
+namespace {
+
+std::filesystem::path writeFixtureWav() {
+  constexpr uint32_t sampleRate = 48000;
+  constexpr uint16_t channels = 2;
+  constexpr uint16_t bitsPerSample = 16;
+  constexpr uint16_t audioFormat = 1;
+  constexpr uint32_t frames = 128;
+  constexpr uint32_t dataSize = frames * channels * sizeof(int16_t);
+  constexpr uint32_t riffSize = 36 + dataSize;
+  constexpr uint32_t fmtSize = 16;
+  constexpr uint32_t byteRate = sampleRate * channels * sizeof(int16_t);
+  constexpr uint16_t blockAlign = channels * sizeof(int16_t);
+  const auto path = std::filesystem::temp_directory_path() / "orpheus-find-package-transport.wav";
+
+  std::ofstream file(path, std::ios::binary | std::ios::trunc);
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&riffSize), sizeof(riffSize));
+  file.write("WAVEfmt ", 8);
+  file.write(reinterpret_cast<const char*>(&fmtSize), sizeof(fmtSize));
+  file.write(reinterpret_cast<const char*>(&audioFormat), sizeof(audioFormat));
+  file.write(reinterpret_cast<const char*>(&channels), sizeof(channels));
+  file.write(reinterpret_cast<const char*>(&sampleRate), sizeof(sampleRate));
+  file.write(reinterpret_cast<const char*>(&byteRate), sizeof(byteRate));
+  file.write(reinterpret_cast<const char*>(&blockAlign), sizeof(blockAlign));
+  file.write(reinterpret_cast<const char*>(&bitsPerSample), sizeof(bitsPerSample));
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&dataSize), sizeof(dataSize));
+  std::array<int16_t, frames * channels> silence{};
+  file.write(reinterpret_cast<const char*>(silence.data()),
+             static_cast<std::streamsize>(silence.size() * sizeof(int16_t)));
+  return path;
+}
+
+} // namespace
 
 int main() {
   auto routing = orpheus::createRoutingMatrix();
@@ -27,15 +75,47 @@ int main() {
     return 2;
   }
 
-  auto transport = orpheus::createTransportController(
-      nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
-  auto manager = orpheus::createAudioDriverManager();
-  if (transport == nullptr || manager == nullptr || routing->maxBlockFrames() < 1) {
+  orpheus::TransportConfig transportConfig;
+  transportConfig.sampleRate = 48000;
+  transportConfig.outputChannels = 2;
+  transportConfig.maxBlockFrames = 64;
+  transportConfig.maxActiveVoices = 1;
+  auto transport = orpheus::createTransportController(nullptr, transportConfig);
+  if (transport == nullptr) {
     return 3;
   }
   if (transport->startClipWithGroupChoke(0) != orpheus::SessionGraphError::InvalidHandle ||
       transport->startClipWithGroupChoke(42) != orpheus::SessionGraphError::ClipNotRegistered) {
     return 4;
   }
-  return 0;
+
+  const auto wav = writeFixtureWav();
+  if (transport->registerClipAudio(77, wav.string()) != orpheus::SessionGraphError::OK ||
+      transport->startClip(77) != orpheus::SessionGraphError::OK) {
+    return 5;
+  }
+  std::array<float, 64> transportLeft{};
+  std::array<float, 64> transportRight{};
+  float* transportOutputs[2] = {transportLeft.data(), transportRight.data()};
+  transport->processAudio(transportOutputs, 2, transportLeft.size());
+
+  const orpheus::TransportCallbackTelemetry callbackTelemetry =
+      transport->getCallbackDeliveryTelemetry();
+  const orpheus::ActiveVoiceSnapshot activeVoices = transport->getActiveVoiceSnapshot();
+  std::error_code ignored;
+  std::filesystem::remove(wav, ignored);
+  if (callbackTelemetry.schemaVersion != orpheus::kTransportCallbackTelemetrySchemaVersion ||
+      callbackTelemetry.lastAttemptedSequence != 1 || callbackTelemetry.lastPostedSequence != 1 ||
+      callbackTelemetry.cumulativeDroppedCount != 0 ||
+      callbackTelemetry.activeVoiceSnapshotSequence != 1 ||
+      activeVoices.schemaVersion != orpheus::kActiveVoiceSnapshotSchemaVersion ||
+      activeVoices.publicationSequence != 1 || activeVoices.entryCount != 1 ||
+      activeVoices.totalActiveVoiceCount != 1 || activeVoices.entries[0].handle != 77 ||
+      activeVoices.entries[0].activeVoiceCount != 1 ||
+      activeVoices.entries[0].state != orpheus::PlaybackState::Playing) {
+    return 6;
+  }
+
+  auto manager = orpheus::createAudioDriverManager();
+  return manager != nullptr && routing->maxBlockFrames() >= 1 ? 0 : 1;
 }

--- a/tests/cmake/find_package/transport_routing.cpp
+++ b/tests/cmake/find_package/transport_routing.cpp
@@ -27,7 +27,15 @@ int main() {
     return 2;
   }
 
-  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
+  auto transport = orpheus::createTransportController(
+      nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   auto manager = orpheus::createAudioDriverManager();
-  return transport != nullptr && manager != nullptr && routing->maxBlockFrames() >= 1 ? 0 : 1;
+  if (transport == nullptr || manager == nullptr || routing->maxBlockFrames() < 1) {
+    return 3;
+  }
+  if (transport->startClipWithGroupChoke(0) != orpheus::SessionGraphError::InvalidHandle ||
+      transport->startClipWithGroupChoke(42) != orpheus::SessionGraphError::ClipNotRegistered) {
+    return 4;
+  }
+  return 0;
 }

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -605,6 +605,38 @@ if(TARGET orpheus_audio_io)
         COMMAND choke_and_voice_cap_test
     )
 
+    # ORP150: one-command atomic metadata-group start/choke admission.
+    add_executable(atomic_group_choke_test
+        atomic_group_choke_test.cpp
+    )
+
+    target_link_libraries(atomic_group_choke_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(atomic_group_choke_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(atomic_group_choke_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(atomic_group_choke_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+    )
+
+    add_test(
+        NAME atomic_group_choke_test
+        COMMAND atomic_group_choke_test
+    )
+
     # OCC155: SDK API requests — getRoutingMatrix / panic / unregisterClipAudio,
     # plus the fade-overlap re-fire independent-cursor regression (Ask #2).
     add_executable(occ155_api_test

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -443,6 +443,38 @@ if(TARGET orpheus_audio_io)
         COMMAND callback_queue_stress_test
     )
 
+    # ORP151: public callback-loss telemetry and coherent reconciliation snapshot.
+    add_executable(callback_loss_telemetry_test
+        callback_loss_telemetry_test.cpp
+    )
+
+    target_link_libraries(callback_loss_telemetry_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(callback_loss_telemetry_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(callback_loss_telemetry_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(callback_loss_telemetry_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+    )
+
+    add_test(
+        NAME callback_loss_telemetry_test
+        COMMAND callback_loss_telemetry_test
+    )
+
     # ORP127 T2: ThreadSanitizer stress harness for per-voice state.
     # Builds/runs under normal Debug too (liveness check); TSan is the verdict.
     add_executable(voice_state_tsan_test

--- a/tests/transport/atomic_group_choke_test.cpp
+++ b/tests/transport/atomic_group_choke_test.cpp
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <orpheus/transport_controller.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace orpheus;
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr size_t kBlockFrames = 64;
+constexpr double kPi = 3.14159265358979323846;
+
+std::string writeStereoSineWav(const std::filesystem::path& path, float frequency) {
+  constexpr uint16_t channels = 2;
+  constexpr uint16_t bitsPerSample = 16;
+  constexpr uint32_t durationFrames = kSampleRate * 2;
+  const uint16_t blockAlign = channels * (bitsPerSample / 8);
+  const uint32_t byteRate = kSampleRate * blockAlign;
+  const uint32_t dataSize = durationFrames * blockAlign;
+  const uint32_t riffSize = 36 + dataSize;
+  const uint32_t fmtSize = 16;
+  const uint16_t pcmFormat = 1;
+
+  std::ofstream file(path, std::ios::binary);
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&riffSize), sizeof(riffSize));
+  file.write("WAVEfmt ", 8);
+  file.write(reinterpret_cast<const char*>(&fmtSize), sizeof(fmtSize));
+  file.write(reinterpret_cast<const char*>(&pcmFormat), sizeof(pcmFormat));
+  file.write(reinterpret_cast<const char*>(&channels), sizeof(channels));
+  file.write(reinterpret_cast<const char*>(&kSampleRate), sizeof(kSampleRate));
+  file.write(reinterpret_cast<const char*>(&byteRate), sizeof(byteRate));
+  file.write(reinterpret_cast<const char*>(&blockAlign), sizeof(blockAlign));
+  file.write(reinterpret_cast<const char*>(&bitsPerSample), sizeof(bitsPerSample));
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&dataSize), sizeof(dataSize));
+
+  for (uint32_t frame = 0; frame < durationFrames; ++frame) {
+    const float phase = static_cast<float>(2.0 * kPi * frequency * frame / kSampleRate);
+    const int16_t sample = static_cast<int16_t>(std::sin(phase) * 12000.0f);
+    file.write(reinterpret_cast<const char*>(&sample), sizeof(sample));
+    file.write(reinterpret_cast<const char*>(&sample), sizeof(sample));
+  }
+  return path.string();
+}
+
+struct CallbackEvent {
+  enum class Type { Started, Stopped, Refused };
+  Type type;
+  ClipHandle handle;
+};
+
+class RecordingCallback final : public ITransportCallback {
+public:
+  void onClipStarted(ClipHandle handle, TransportPosition) override {
+    events.push_back({CallbackEvent::Type::Started, handle});
+  }
+  void onClipStopped(ClipHandle handle, TransportPosition) override {
+    events.push_back({CallbackEvent::Type::Stopped, handle});
+  }
+  void onClipLooped(ClipHandle, TransportPosition) override {}
+  void onBufferUnderrun(TransportPosition) override {}
+  void onActiveClipLimitReached(ClipHandle handle, TransportPosition) override {
+    events.push_back({CallbackEvent::Type::Refused, handle});
+  }
+
+  std::vector<CallbackEvent> events;
+};
+
+class AtomicGroupChokeTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    directory = std::filesystem::temp_directory_path() / "orp150_atomic_group_choke";
+    std::filesystem::create_directories(directory);
+    createTransport(8);
+  }
+
+  void TearDown() override {
+    transport.reset();
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+  }
+
+  void createTransport(uint32_t maxActiveVoices) {
+    TransportConfig config;
+    config.sampleRate = kSampleRate;
+    config.outputChannels = 4;
+    config.maxBlockFrames = 256;
+    config.maxActiveVoices = maxActiveVoices;
+    config.numGroups = 2;
+    config.maxSourceChannels = 2;
+    transport = createTransportController(nullptr, config);
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->setGroupOutputBus(0, OutputBusRoute{0, 2}), SessionGraphError::OK);
+    ASSERT_EQ(transport->setGroupOutputBus(1, OutputBusRoute{2, 2}), SessionGraphError::OK);
+    transport->setCallback(&callback);
+  }
+
+  void registerClip(ClipHandle handle, RoutingGroupIndex group,
+                    VoiceMode mode = VoiceMode::Polyphonic, double stopFadeSeconds = 0.02) {
+    const std::string file =
+        writeStereoSineWav(directory / ("clip-" + std::to_string(handle) + ".wav"),
+                           180.0f + static_cast<float>(handle) * 37.0f);
+    ASSERT_EQ(transport->registerClipAudio(handle, file), SessionGraphError::OK);
+    auto metadata = transport->getClipMetadata(handle);
+    ASSERT_TRUE(metadata.has_value());
+    metadata->routingGroup = group;
+    metadata->voiceMode = mode;
+    metadata->fadeOutSeconds = stopFadeSeconds;
+    ASSERT_EQ(transport->updateClipMetadata(handle, *metadata), SessionGraphError::OK);
+  }
+
+  std::array<double, 4> render(size_t blocks = 1) {
+    std::array<double, 4> energy{};
+    std::array<std::vector<float>, 4> channels;
+    std::array<float*, 4> pointers{};
+    for (size_t channel = 0; channel < channels.size(); ++channel) {
+      channels[channel].resize(kBlockFrames);
+      pointers[channel] = channels[channel].data();
+    }
+    for (size_t block = 0; block < blocks; ++block) {
+      for (auto& channel : channels) {
+        std::fill(channel.begin(), channel.end(), 0.0f);
+      }
+      transport->processAudio(pointers.data(), pointers.size(), kBlockFrames);
+      for (size_t channel = 0; channel < channels.size(); ++channel) {
+        for (float sample : channels[channel]) {
+          energy[channel] += std::abs(sample);
+        }
+      }
+    }
+    return energy;
+  }
+
+  void drainSetupCommands() {
+    render();
+    transport->processCallbacks();
+    callback.events.clear();
+  }
+
+  std::filesystem::path directory;
+  std::unique_ptr<ITransportController> transport;
+  RecordingCallback callback;
+};
+
+TEST_F(AtomicGroupChokeTest, AcceptedStartChokesAllAndOnlyRegisteredGroupPeers) {
+  registerClip(1, 0);
+  registerClip(2, 0);
+  registerClip(3, 1);
+  registerClip(4, 0, VoiceMode::MonoWithFadeOverlap);
+  drainSetupCommands();
+
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(2), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(3), SessionGraphError::OK);
+  render();
+  transport->processCallbacks();
+  callback.events.clear();
+
+  ASSERT_EQ(transport->startClipWithGroupChoke(4), SessionGraphError::OK);
+  const auto energy = render();
+  transport->processCallbacks();
+
+  EXPECT_EQ(transport->getClipState(1), PlaybackState::Stopping);
+  EXPECT_EQ(transport->getClipState(2), PlaybackState::Stopping);
+  EXPECT_EQ(transport->getClipState(3), PlaybackState::Playing);
+  EXPECT_EQ(transport->getClipState(4), PlaybackState::Playing);
+  EXPECT_GT(energy[2] + energy[3], 0.0) << "the other group must remain audible";
+
+  ASSERT_FALSE(callback.events.empty());
+  EXPECT_EQ(callback.events.front().type, CallbackEvent::Type::Started);
+  EXPECT_EQ(callback.events.front().handle, 4u);
+
+  render(20);
+  transport->processCallbacks();
+  ASSERT_GE(callback.events.size(), 3u);
+  std::set<ClipHandle> stopped;
+  for (size_t index = 1; index < callback.events.size(); ++index) {
+    EXPECT_NE(callback.events[index].type, CallbackEvent::Type::Started);
+    if (callback.events[index].type == CallbackEvent::Type::Stopped) {
+      stopped.insert(callback.events[index].handle);
+    }
+  }
+  EXPECT_EQ(stopped, (std::set<ClipHandle>{1, 2}));
+  EXPECT_EQ(transport->getClipState(3), PlaybackState::Playing);
+  EXPECT_EQ(transport->getClipState(4), PlaybackState::Playing);
+}
+
+TEST_F(AtomicGroupChokeTest, QueueFullRejectionNeverChangesPeersAndIsRepeatable) {
+  registerClip(1, 0);
+  registerClip(2, 1);
+  registerClip(3, 0);
+  drainSetupCommands();
+
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(2), SessionGraphError::OK);
+  render();
+  transport->processCallbacks();
+
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    for (size_t command = 0; command < 255; ++command) {
+      ASSERT_EQ(transport->stopClip(1000 + command), SessionGraphError::OK)
+          << "cycle " << cycle << ", command " << command;
+    }
+    EXPECT_EQ(transport->startClipWithGroupChoke(3), SessionGraphError::InternalError)
+        << "cycle " << cycle;
+
+    render();
+    EXPECT_EQ(transport->getClipState(1), PlaybackState::Playing);
+    EXPECT_EQ(transport->getClipState(2), PlaybackState::Playing);
+    EXPECT_EQ(transport->getClipState(3), PlaybackState::Stopped);
+  }
+}
+
+TEST_F(AtomicGroupChokeTest, MetadataQueueRejectionKeepsPersistentAndActiveGroupsAligned) {
+  registerClip(1, 0);
+  registerClip(2, 1);
+  drainSetupCommands();
+
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  render();
+
+  auto rejectedMetadata = transport->getClipMetadata(1);
+  ASSERT_TRUE(rejectedMetadata.has_value());
+  rejectedMetadata->routingGroup = 1;
+
+  for (size_t command = 0; command < 255; ++command) {
+    ASSERT_EQ(transport->stopClip(1000 + command), SessionGraphError::OK);
+  }
+  EXPECT_EQ(transport->updateClipMetadata(1, *rejectedMetadata), SessionGraphError::InternalError);
+
+  const auto persistentAfterRejection = transport->getClipMetadata(1);
+  ASSERT_TRUE(persistentAfterRejection.has_value());
+  EXPECT_EQ(persistentAfterRejection->routingGroup, 0u);
+
+  const auto rejectedRender = render();
+  EXPECT_GT(rejectedRender[0] + rejectedRender[1], 0.0);
+  EXPECT_DOUBLE_EQ(rejectedRender[2] + rejectedRender[3], 0.0);
+
+  auto acceptedMetadata = transport->getClipMetadata(1);
+  ASSERT_TRUE(acceptedMetadata.has_value());
+  acceptedMetadata->routingGroup = 1;
+  ASSERT_EQ(transport->updateClipMetadata(1, *acceptedMetadata), SessionGraphError::OK);
+
+  const auto persistentAfterSuccess = transport->getClipMetadata(1);
+  ASSERT_TRUE(persistentAfterSuccess.has_value());
+  EXPECT_EQ(persistentAfterSuccess->routingGroup, 1u);
+
+  const auto acceptedRender = render();
+  EXPECT_DOUBLE_EQ(acceptedRender[0] + acceptedRender[1], 0.0);
+  EXPECT_GT(acceptedRender[2] + acceptedRender[3], 0.0);
+
+  ASSERT_EQ(transport->startClipWithGroupChoke(2), SessionGraphError::OK);
+  render();
+  EXPECT_EQ(transport->getClipState(1), PlaybackState::Stopping);
+  EXPECT_EQ(transport->getClipState(2), PlaybackState::Playing);
+}
+
+TEST_F(AtomicGroupChokeTest, VoicePoolRejectionLeavesEveryPeerUntouched) {
+  transport.reset();
+  callback.events.clear();
+  createTransport(3);
+
+  registerClip(1, 0);
+  registerClip(2, 0);
+  registerClip(3, 1);
+  registerClip(4, 0);
+  drainSetupCommands();
+
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(2), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(3), SessionGraphError::OK);
+  render();
+  transport->processCallbacks();
+  callback.events.clear();
+
+  ASSERT_EQ(transport->startClipWithGroupChoke(4), SessionGraphError::OK);
+  render();
+  transport->processCallbacks();
+
+  EXPECT_EQ(transport->getClipState(1), PlaybackState::Playing);
+  EXPECT_EQ(transport->getClipState(2), PlaybackState::Playing);
+  EXPECT_EQ(transport->getClipState(3), PlaybackState::Playing);
+  EXPECT_EQ(transport->getClipState(4), PlaybackState::Stopped);
+  ASSERT_EQ(callback.events.size(), 1u);
+  EXPECT_EQ(callback.events[0].type, CallbackEvent::Type::Refused);
+  EXPECT_EQ(callback.events[0].handle, 4u);
+}
+
+TEST_F(AtomicGroupChokeTest, MonoRefirePreservesFadeOverlapCapAndSparesOwnTails) {
+  registerClip(1, 0);
+  registerClip(2, 0, VoiceMode::MonoWithFadeOverlap, 0.1);
+  drainSetupCommands();
+  ASSERT_EQ(transport->setMaxVoicesPerClip(2), SessionGraphError::OK);
+
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(2), SessionGraphError::OK);
+  render();
+  ASSERT_EQ(transport->stopClip(2), SessionGraphError::OK);
+  render();
+  ASSERT_EQ(transport->getClipState(2), PlaybackState::Stopping);
+
+  ASSERT_EQ(transport->startClipWithGroupChoke(2), SessionGraphError::OK);
+  render();
+  EXPECT_EQ(transport->getActiveVoiceCount(2), 2u);
+  EXPECT_EQ(transport->getClipState(1), PlaybackState::Stopping);
+
+  for (int refire = 0; refire < 8; ++refire) {
+    ASSERT_EQ(transport->startClipWithGroupChoke(2), SessionGraphError::OK);
+    render();
+    EXPECT_LE(transport->getActiveVoiceCount(2), 2u);
+    EXPECT_EQ(transport->getClipState(2), PlaybackState::Playing);
+  }
+}
+
+TEST_F(AtomicGroupChokeTest, PreAdmissionValidationRejectsWithoutPeerMutation) {
+  registerClip(1, 0);
+  drainSetupCommands();
+  ASSERT_EQ(transport->startClip(1), SessionGraphError::OK);
+  render();
+
+  EXPECT_EQ(transport->startClipWithGroupChoke(0), SessionGraphError::InvalidHandle);
+  EXPECT_EQ(transport->startClipWithGroupChoke(99), SessionGraphError::ClipNotRegistered);
+  render();
+  EXPECT_EQ(transport->getClipState(1), PlaybackState::Playing);
+}
+
+} // namespace

--- a/tests/transport/callback_loss_telemetry_test.cpp
+++ b/tests/transport/callback_loss_telemetry_test.cpp
@@ -254,6 +254,10 @@ TEST_F(CallbackLossTelemetryTest, ConcurrentSnapshotsRemainCoherentDuringPublica
       EXPECT_TRUE(entry.state == orpheus::PlaybackState::Playing ||
                   entry.state == orpheus::PlaybackState::Stopping);
       EXPECT_GE(entry.newestPosition.samples, 0);
+      const double expectedSeconds =
+          static_cast<double>(entry.newestPosition.samples) / static_cast<double>(kSampleRate);
+      EXPECT_DOUBLE_EQ(entry.newestPosition.seconds, expectedSeconds);
+      EXPECT_DOUBLE_EQ(entry.newestPosition.beats, expectedSeconds * 2.0);
       summedVoices += entry.activeVoiceCount;
       for (uint32_t other = index + 1; other < snapshot.entryCount; ++other) {
         EXPECT_NE(entry.handle, snapshot.entries[other].handle);
@@ -402,6 +406,59 @@ TEST_F(CallbackLossTelemetryTest, VoiceIdsWrapWithoutZeroCollisionAndSurviveComp
   EXPECT_EQ(restarted->newestVoiceId, 3u);
   EXPECT_EQ(restarted->state, orpheus::PlaybackState::Playing);
   EXPECT_EQ(snapshot.totalActiveVoiceCount, 4u);
+}
+
+TEST_F(CallbackLossTelemetryTest, SameSampleOrdinalWrapSelectsChronologicallyNewestVoice) {
+  orpheus::TransportConfig config;
+  config.sampleRate = kSampleRate;
+  config.outputChannels = 2;
+  config.maxBlockFrames = static_cast<uint32_t>(kBlockFrames);
+  config.maxActiveVoices = 2;
+  auto wrapped = std::make_unique<orpheus::TransportController>(nullptr, config);
+
+  constexpr orpheus::ClipHandle handle = 501;
+  ASSERT_EQ(wrapped->registerClipAudio(handle, audioPath), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(wrapped->prepareClipAudio(handle), orpheus::SessionGraphError::OK);
+
+  std::array<float, kBlockFrames> wrapLeft{};
+  std::array<float, kBlockFrames> wrapRight{};
+  auto renderWrapped = [&] {
+    float* outputs[2] = {wrapLeft.data(), wrapRight.data()};
+    wrapped->processAudio(outputs, 2, kBlockFrames);
+  };
+
+  wrapped->setNextVoiceIdForTesting(std::numeric_limits<uint32_t>::max());
+  wrapped->setNextVoiceStartOrdinalForTesting(std::numeric_limits<uint64_t>::max());
+  ASSERT_EQ(wrapped->startClip(handle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(wrapped->startClip(handle), orpheus::SessionGraphError::OK);
+  renderWrapped();
+
+  auto snapshot = wrapped->getActiveVoiceSnapshot();
+  const auto* aggregate = findEntry(snapshot, handle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 2u);
+  EXPECT_EQ(aggregate->newestStartSample, 0);
+  EXPECT_EQ(aggregate->newestVoiceId, 1u);
+
+  ASSERT_TRUE(wrapped->setVoiceSnapshotFieldsForTesting(std::numeric_limits<uint32_t>::max(), true,
+                                                        false, 10, 1000, 20));
+  ASSERT_TRUE(wrapped->setVoiceSnapshotFieldsForTesting(1, false, true, 30, 2000, 40));
+  renderWrapped();
+
+  snapshot = wrapped->getActiveVoiceSnapshot();
+  aggregate = findEntry(snapshot, handle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 2u);
+  EXPECT_EQ(aggregate->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(aggregate->newestVoiceId, 1u);
+  EXPECT_EQ(aggregate->newestVoiceStopping, 0u);
+  EXPECT_EQ(aggregate->newestVoiceLoopEnabled, 1u);
+  EXPECT_EQ(aggregate->newestTrimInSamples, 30);
+  EXPECT_EQ(aggregate->newestTrimOutSamples, 2000);
+  EXPECT_EQ(aggregate->newestPosition.samples, 104);
+  const double expectedSeconds = 104.0 / static_cast<double>(kSampleRate);
+  EXPECT_DOUBLE_EQ(aggregate->newestPosition.seconds, expectedSeconds);
+  EXPECT_DOUBLE_EQ(aggregate->newestPosition.beats, expectedSeconds * 2.0);
 }
 
 } // namespace

--- a/tests/transport/callback_loss_telemetry_test.cpp
+++ b/tests/transport/callback_loss_telemetry_test.cpp
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: MIT
+
+#include "../../src/core/transport/transport_controller.h"
+#include <orpheus/transport_controller.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr size_t kBlockFrames = 64;
+constexpr orpheus::ClipHandle kFirstHandle = 11;
+constexpr orpheus::ClipHandle kSecondHandle = 22;
+
+std::string writeSilentWav(const std::filesystem::path& path) {
+  constexpr uint16_t channels = 2;
+  constexpr uint16_t bitsPerSample = 16;
+  constexpr uint16_t audioFormat = 1;
+  constexpr uint32_t durationFrames = kSampleRate * 2;
+  constexpr uint32_t bytesPerSample = bitsPerSample / 8;
+  constexpr uint32_t dataSize = durationFrames * channels * bytesPerSample;
+  constexpr uint32_t riffSize = 36 + dataSize;
+  constexpr uint32_t fmtSize = 16;
+  constexpr uint32_t byteRate = kSampleRate * channels * bytesPerSample;
+  constexpr uint16_t blockAlign = channels * bytesPerSample;
+
+  std::ofstream file(path, std::ios::binary | std::ios::trunc);
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&riffSize), sizeof(riffSize));
+  file.write("WAVEfmt ", 8);
+  file.write(reinterpret_cast<const char*>(&fmtSize), sizeof(fmtSize));
+  file.write(reinterpret_cast<const char*>(&audioFormat), sizeof(audioFormat));
+  file.write(reinterpret_cast<const char*>(&channels), sizeof(channels));
+  file.write(reinterpret_cast<const char*>(&kSampleRate), sizeof(kSampleRate));
+  file.write(reinterpret_cast<const char*>(&byteRate), sizeof(byteRate));
+  file.write(reinterpret_cast<const char*>(&blockAlign), sizeof(blockAlign));
+  file.write(reinterpret_cast<const char*>(&bitsPerSample), sizeof(bitsPerSample));
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&dataSize), sizeof(dataSize));
+  std::vector<int16_t> silence(static_cast<size_t>(durationFrames) * channels, 0);
+  file.write(reinterpret_cast<const char*>(silence.data()),
+             static_cast<std::streamsize>(silence.size() * sizeof(int16_t)));
+  file.close();
+  return path.string();
+}
+
+class CountingCallback final : public orpheus::ITransportCallback {
+public:
+  void onClipStarted(orpheus::ClipHandle, orpheus::TransportPosition) override {
+    ++count;
+  }
+  void onClipStopped(orpheus::ClipHandle, orpheus::TransportPosition) override {
+    ++count;
+  }
+  void onClipLooped(orpheus::ClipHandle, orpheus::TransportPosition) override {
+    ++count;
+  }
+  void onClipRestarted(orpheus::ClipHandle, orpheus::TransportPosition) override {
+    ++count;
+  }
+  void onClipSeeked(orpheus::ClipHandle, orpheus::TransportPosition) override {
+    ++count;
+  }
+  void onBufferUnderrun(orpheus::TransportPosition) override {
+    ++count;
+  }
+
+  uint64_t count = 0;
+};
+
+const orpheus::ActiveVoiceSnapshotEntry* findEntry(const orpheus::ActiveVoiceSnapshot& snapshot,
+                                                   orpheus::ClipHandle handle) {
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    if (snapshot.entries[index].handle == handle) {
+      return &snapshot.entries[index];
+    }
+  }
+  return nullptr;
+}
+
+class CallbackLossTelemetryTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    directory =
+        std::filesystem::temp_directory_path() / ("orp151-callback-loss-" + std::to_string(suffix));
+    std::filesystem::create_directories(directory);
+    audioPath = writeSilentWav(directory / "voices.wav");
+
+    orpheus::TransportConfig config;
+    config.sampleRate = kSampleRate;
+    config.outputChannels = 2;
+    config.maxBlockFrames = static_cast<uint32_t>(kBlockFrames);
+    config.maxActiveVoices = 4;
+    transport = orpheus::createTransportController(nullptr, config);
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerClipAudio(kFirstHandle, audioPath),
+              orpheus::SessionGraphError::OK);
+    ASSERT_EQ(transport->registerClipAudio(kSecondHandle, audioPath),
+              orpheus::SessionGraphError::OK);
+    ASSERT_EQ(transport->prepareClipAudio(kFirstHandle), orpheus::SessionGraphError::OK);
+    ASSERT_EQ(transport->prepareClipAudio(kSecondHandle), orpheus::SessionGraphError::OK);
+    transport->setCallback(&callback);
+  }
+
+  void TearDown() override {
+    transport.reset();
+    std::error_code ignored;
+    std::filesystem::remove_all(directory, ignored);
+  }
+
+  void renderBlock() {
+    float* outputs[2] = {left.data(), right.data()};
+    transport->processAudio(outputs, 2, kBlockFrames);
+  }
+
+  std::filesystem::path directory;
+  std::string audioPath;
+  std::unique_ptr<orpheus::ITransportController> transport;
+  CountingCallback callback;
+  std::array<float, kBlockFrames> left{};
+  std::array<float, kBlockFrames> right{};
+};
+
+TEST_F(CallbackLossTelemetryTest, OverflowIsCumulativeAndSnapshotReconcilesSurvivingVoices) {
+  const auto initialTelemetry = transport->getCallbackDeliveryTelemetry();
+  EXPECT_EQ(initialTelemetry.lastAttemptedSequence, 0u);
+  EXPECT_EQ(initialTelemetry.lastPostedSequence, 0u);
+  EXPECT_EQ(initialTelemetry.cumulativeDroppedCount, 0u);
+  EXPECT_EQ(initialTelemetry.lastDroppedSequence, 0u);
+  EXPECT_EQ(initialTelemetry.activeVoiceSnapshotSequence, 0u);
+  EXPECT_EQ(transport->getActiveVoiceSnapshot().publicationSequence, 0u);
+
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kSecondHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+
+  constexpr uint64_t restartAttempts = 300;
+  for (uint64_t attempt = 0; attempt < restartAttempts; ++attempt) {
+    ASSERT_EQ(transport->restartClip(kFirstHandle), orpheus::SessionGraphError::OK);
+    renderBlock();
+  }
+
+  const auto overflowTelemetry = transport->getCallbackDeliveryTelemetry();
+  EXPECT_EQ(overflowTelemetry.lastAttemptedSequence, 302u);
+  EXPECT_EQ(overflowTelemetry.lastPostedSequence, 255u);
+  EXPECT_EQ(overflowTelemetry.cumulativeDroppedCount, 47u);
+  EXPECT_EQ(overflowTelemetry.lastDroppedSequence, 302u);
+  EXPECT_EQ(overflowTelemetry.activeVoiceSnapshotSequence, 301u);
+
+  const auto snapshot = transport->getActiveVoiceSnapshot();
+  EXPECT_EQ(snapshot.publicationSequence, 301u);
+  EXPECT_GE(snapshot.publicationSequence, overflowTelemetry.activeVoiceSnapshotSequence);
+  EXPECT_EQ(snapshot.entryCount, 2u);
+  EXPECT_EQ(snapshot.totalActiveVoiceCount, 2u);
+
+  const auto* first = findEntry(snapshot, kFirstHandle);
+  const auto* second = findEntry(snapshot, kSecondHandle);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(first->activeVoiceCount, 1u);
+  EXPECT_EQ(first->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(first->newestPosition.samples, static_cast<int64_t>(kBlockFrames));
+  EXPECT_EQ(second->activeVoiceCount, 1u);
+  EXPECT_EQ(second->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(second->newestPosition.samples, static_cast<int64_t>(kBlockFrames * 301));
+
+  transport->processCallbacks();
+  EXPECT_EQ(callback.count, 255u);
+  EXPECT_EQ(transport->getCallbackDeliveryTelemetry().cumulativeDroppedCount, 47u);
+
+  ASSERT_EQ(transport->restartClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+  const auto recoveredTelemetry = transport->getCallbackDeliveryTelemetry();
+  EXPECT_EQ(recoveredTelemetry.lastAttemptedSequence, 303u);
+  EXPECT_EQ(recoveredTelemetry.lastPostedSequence, 303u);
+  EXPECT_EQ(recoveredTelemetry.cumulativeDroppedCount, 47u);
+  EXPECT_EQ(recoveredTelemetry.lastDroppedSequence, 302u);
+  EXPECT_EQ(recoveredTelemetry.activeVoiceSnapshotSequence, 302u);
+  transport->processCallbacks();
+  EXPECT_EQ(callback.count, 256u);
+}
+
+TEST_F(CallbackLossTelemetryTest, HealthyDrainHasNoDropsAndStaysMonotonic) {
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kSecondHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+
+  auto telemetry = transport->getCallbackDeliveryTelemetry();
+  EXPECT_EQ(telemetry.lastAttemptedSequence, 2u);
+  EXPECT_EQ(telemetry.lastPostedSequence, 2u);
+  EXPECT_EQ(telemetry.cumulativeDroppedCount, 0u);
+  EXPECT_EQ(telemetry.lastDroppedSequence, 0u);
+  EXPECT_EQ(telemetry.activeVoiceSnapshotSequence, 1u);
+  transport->processCallbacks();
+  EXPECT_EQ(callback.count, 2u);
+
+  ASSERT_EQ(transport->restartClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+  telemetry = transport->getCallbackDeliveryTelemetry();
+  EXPECT_EQ(telemetry.lastAttemptedSequence, 3u);
+  EXPECT_EQ(telemetry.lastPostedSequence, 3u);
+  EXPECT_EQ(telemetry.cumulativeDroppedCount, 0u);
+  EXPECT_EQ(telemetry.lastDroppedSequence, 0u);
+  EXPECT_EQ(telemetry.activeVoiceSnapshotSequence, 2u);
+  transport->processCallbacks();
+  EXPECT_EQ(callback.count, 3u);
+
+  const auto snapshot = transport->getActiveVoiceSnapshot();
+  EXPECT_EQ(snapshot.entryCount, 2u);
+  EXPECT_EQ(snapshot.totalActiveVoiceCount, 2u);
+  EXPECT_EQ(snapshot.publicationSequence, 2u);
+}
+
+TEST_F(CallbackLossTelemetryTest, ConcurrentSnapshotsRemainCoherentDuringPublication) {
+  ASSERT_EQ(transport->setClipLoopMode(kFirstHandle, true), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->setClipLoopMode(kSecondHandle, true), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kSecondHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+
+  std::atomic<bool> stop{false};
+  std::thread audioThread([this, &stop] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      renderBlock();
+    }
+  });
+
+  uint64_t previousPublication = 0;
+  for (size_t iteration = 0; iteration < 2000; ++iteration) {
+    const auto telemetry = transport->getCallbackDeliveryTelemetry();
+    const auto snapshot = transport->getActiveVoiceSnapshot();
+    EXPECT_LE(snapshot.entryCount, orpheus::kActiveVoiceSnapshotCapacity);
+    EXPECT_GE(snapshot.publicationSequence, previousPublication);
+    previousPublication = snapshot.publicationSequence;
+
+    uint32_t summedVoices = 0;
+    for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+      const auto& entry = snapshot.entries[index];
+      EXPECT_NE(entry.handle, 0u);
+      EXPECT_NE(entry.newestVoiceId, 0u);
+      EXPECT_GT(entry.activeVoiceCount, 0u);
+      EXPECT_TRUE(entry.state == orpheus::PlaybackState::Playing ||
+                  entry.state == orpheus::PlaybackState::Stopping);
+      EXPECT_GE(entry.newestPosition.samples, 0);
+      summedVoices += entry.activeVoiceCount;
+      for (uint32_t other = index + 1; other < snapshot.entryCount; ++other) {
+        EXPECT_NE(entry.handle, snapshot.entries[other].handle);
+      }
+    }
+    EXPECT_EQ(snapshot.totalActiveVoiceCount, summedVoices);
+    EXPECT_GE(snapshot.publicationSequence, telemetry.activeVoiceSnapshotSequence);
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  audioThread.join();
+}
+
+TEST_F(CallbackLossTelemetryTest, SingleHandleAggregatesTailsStateTieBreakAndCompaction) {
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+
+  auto snapshot = transport->getActiveVoiceSnapshot();
+  const auto* aggregate = findEntry(snapshot, kFirstHandle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 2u);
+  EXPECT_EQ(aggregate->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(aggregate->newestVoiceId, 2u);
+  EXPECT_EQ(aggregate->newestStartSample, 0);
+  EXPECT_EQ(aggregate->newestPosition.samples, static_cast<int64_t>(kBlockFrames));
+
+  ASSERT_EQ(transport->stopClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+  snapshot = transport->getActiveVoiceSnapshot();
+  aggregate = findEntry(snapshot, kFirstHandle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 2u);
+  EXPECT_EQ(aggregate->state, orpheus::PlaybackState::Stopping);
+  EXPECT_EQ(aggregate->newestVoiceStopping, 1u);
+
+  ASSERT_EQ(transport->setClipVoiceMode(kFirstHandle, orpheus::VoiceMode::MonoWithFadeOverlap),
+            orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+  snapshot = transport->getActiveVoiceSnapshot();
+  aggregate = findEntry(snapshot, kFirstHandle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 3u);
+  EXPECT_EQ(aggregate->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(aggregate->newestVoiceId, 3u);
+  EXPECT_EQ(aggregate->newestVoiceStopping, 0u);
+  EXPECT_EQ(aggregate->newestVoiceLoopEnabled, 0u);
+  EXPECT_EQ(aggregate->newestStartSample, static_cast<int64_t>(kBlockFrames * 2));
+  EXPECT_EQ(aggregate->newestPosition.samples, static_cast<int64_t>(kBlockFrames));
+  EXPECT_EQ(aggregate->newestTrimInSamples, 0);
+  EXPECT_EQ(aggregate->newestTrimOutSamples, static_cast<int64_t>(kSampleRate * 2));
+
+  ASSERT_EQ(transport->stopClip(kFirstHandle), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(kSecondHandle), orpheus::SessionGraphError::OK);
+  renderBlock();
+  snapshot = transport->getActiveVoiceSnapshot();
+  aggregate = findEntry(snapshot, kFirstHandle);
+  ASSERT_NE(aggregate, nullptr);
+  EXPECT_EQ(aggregate->activeVoiceCount, 3u);
+  EXPECT_EQ(aggregate->state, orpheus::PlaybackState::Stopping);
+  ASSERT_NE(findEntry(snapshot, kSecondHandle), nullptr);
+
+  for (size_t block = 0; block < 8; ++block) {
+    renderBlock();
+  }
+  snapshot = transport->getActiveVoiceSnapshot();
+  EXPECT_EQ(findEntry(snapshot, kFirstHandle), nullptr);
+  const auto* survivor = findEntry(snapshot, kSecondHandle);
+  ASSERT_NE(survivor, nullptr);
+  EXPECT_EQ(snapshot.entryCount, 1u);
+  EXPECT_EQ(snapshot.totalActiveVoiceCount, 1u);
+  EXPECT_EQ(survivor->activeVoiceCount, 1u);
+  EXPECT_EQ(survivor->state, orpheus::PlaybackState::Playing);
+}
+
+TEST_F(CallbackLossTelemetryTest, VoiceIdsWrapWithoutZeroCollisionAndSurviveCompaction) {
+  orpheus::TransportConfig config;
+  config.sampleRate = kSampleRate;
+  config.outputChannels = 2;
+  config.maxBlockFrames = static_cast<uint32_t>(kBlockFrames);
+  config.maxActiveVoices = 4;
+  auto wrapped = std::make_unique<orpheus::TransportController>(nullptr, config);
+
+  constexpr std::array<orpheus::ClipHandle, 4> handles = {101, 102, 103, 104};
+  for (const auto handle : handles) {
+    ASSERT_EQ(wrapped->registerClipAudio(handle, audioPath), orpheus::SessionGraphError::OK);
+    ASSERT_EQ(wrapped->prepareClipAudio(handle), orpheus::SessionGraphError::OK);
+  }
+
+  std::array<float, kBlockFrames> wrapLeft{};
+  std::array<float, kBlockFrames> wrapRight{};
+  auto renderWrapped = [&] {
+    float* outputs[2] = {wrapLeft.data(), wrapRight.data()};
+    wrapped->processAudio(outputs, 2, kBlockFrames);
+  };
+
+  wrapped->setNextVoiceIdForTesting(std::numeric_limits<uint32_t>::max() - 1);
+  ASSERT_EQ(wrapped->startClip(handles[0]), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(wrapped->startClip(handles[1]), orpheus::SessionGraphError::OK);
+  ASSERT_EQ(wrapped->startClip(handles[2]), orpheus::SessionGraphError::OK);
+  renderWrapped();
+
+  auto snapshot = wrapped->getActiveVoiceSnapshot();
+  ASSERT_NE(findEntry(snapshot, handles[0]), nullptr);
+  ASSERT_NE(findEntry(snapshot, handles[1]), nullptr);
+  ASSERT_NE(findEntry(snapshot, handles[2]), nullptr);
+  EXPECT_EQ(findEntry(snapshot, handles[0])->newestVoiceId,
+            std::numeric_limits<uint32_t>::max() - 1);
+  EXPECT_EQ(findEntry(snapshot, handles[1])->newestVoiceId, std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(findEntry(snapshot, handles[2])->newestVoiceId, 1u);
+
+  wrapped->setNextVoiceIdForTesting(std::numeric_limits<uint32_t>::max());
+  ASSERT_EQ(wrapped->startClip(handles[3]), orpheus::SessionGraphError::OK);
+  renderWrapped();
+  snapshot = wrapped->getActiveVoiceSnapshot();
+  ASSERT_NE(findEntry(snapshot, handles[3]), nullptr);
+  EXPECT_EQ(findEntry(snapshot, handles[3])->newestVoiceId, 2u);
+  for (uint32_t index = 0; index < snapshot.entryCount; ++index) {
+    EXPECT_NE(snapshot.entries[index].newestVoiceId, 0u);
+    for (uint32_t other = index + 1; other < snapshot.entryCount; ++other) {
+      EXPECT_NE(snapshot.entries[index].newestVoiceId, snapshot.entries[other].newestVoiceId);
+    }
+  }
+
+  ASSERT_EQ(wrapped->stopClip(handles[1]), orpheus::SessionGraphError::OK);
+  for (size_t block = 0; block < 8; ++block) {
+    renderWrapped();
+  }
+  snapshot = wrapped->getActiveVoiceSnapshot();
+  EXPECT_EQ(findEntry(snapshot, handles[1]), nullptr);
+  EXPECT_EQ(snapshot.totalActiveVoiceCount, 3u);
+  ASSERT_NE(findEntry(snapshot, handles[0]), nullptr);
+  ASSERT_NE(findEntry(snapshot, handles[2]), nullptr);
+  ASSERT_NE(findEntry(snapshot, handles[3]), nullptr);
+  EXPECT_EQ(findEntry(snapshot, handles[0])->newestVoiceId,
+            std::numeric_limits<uint32_t>::max() - 1);
+  EXPECT_EQ(findEntry(snapshot, handles[2])->newestVoiceId, 1u);
+  EXPECT_EQ(findEntry(snapshot, handles[3])->newestVoiceId, 2u);
+
+  ASSERT_EQ(wrapped->startClip(handles[1]), orpheus::SessionGraphError::OK);
+  renderWrapped();
+  snapshot = wrapped->getActiveVoiceSnapshot();
+  const auto* restarted = findEntry(snapshot, handles[1]);
+  ASSERT_NE(restarted, nullptr);
+  EXPECT_EQ(restarted->newestVoiceId, 3u);
+  EXPECT_EQ(restarted->state, orpheus::PlaybackState::Playing);
+  EXPECT_EQ(snapshot.totalActiveVoiceCount, 4u);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- add failure-atomic metadata-group choke admission
- expose cumulative callback-loss telemetry and coherent active-voice reconciliation
- make metadata mutation transactional and harden voice ordering across ID wrap
- publish 0.5.1 package/version/documentation truth

## Verification
- complete SDK CTest: 149/149 passed
- installed find_package and runtime consumers passed
- ABI-link, realtime static/runtime, docs, and version gates passed
- pre-release qcheck: PASS