### PR TITLE
fix(routing): isolate channel meter contributions

### DIFF
--- a/include/orpheus/routing_matrix.h
+++ b/include/orpheus/routing_matrix.h
@@ -395,9 +395,16 @@ public:
   /// @return True if effectively muted
   virtual bool isGroupMuted(RoutingGroupIndex group_index) const = 0;
 
-  /// Get channel meter
+  /// Get one channel's isolated effective contribution meter.
+  ///
+  /// The reading is taken after channel gain smoothing, pan, mute, and
+  /// effective channel-solo logic, but before unrelated channels are summed
+  /// and before group or master processing. Stereo peak is the maximum lane
+  /// peak; RMS is the square root of the mean power across both lanes. A null,
+  /// unrouted, or effectively muted channel publishes silence in the current
+  /// processRouting() call. clip_count remains cumulative until reset.
   /// @param channel_index Channel index [0, num_channels)
-  /// @return Audio meter (peak, RMS, clipping)
+  /// @return Isolated channel meter (peak, RMS, clipping)
   virtual AudioMeter getChannelMeter(RoutingChannelIndex channel_index) const = 0;
 
   /// Get group meter

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -62,6 +62,10 @@ SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config) {
     buffer.resize(config.num_outputs, MAX_BUFFER_SIZE);
   }
 
+  // One reusable stereo scratch buffer keeps channel meters isolated from the
+  // shared group accumulators without allocating in processRouting().
+  m_channel_meter_buffer.resize(2, MAX_BUFFER_SIZE);
+
   m_temp_buffer.clear();
   m_temp_buffer.resize(MAX_BUFFER_SIZE, 0.0f);
 
@@ -640,12 +644,21 @@ SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel
     const RoutingGroupIndex group_index = channel.group_index;
 
     if (group_index == UNASSIGNED_GROUP || group_index >= config.num_groups) {
+      if (config.enable_metering) {
+        publishChannelMeterSilence(channel);
+      }
       continue;
     }
 
     const float* input = channel_inputs ? channel_inputs[channel_index] : nullptr;
     const bool muted = isChannelMuted(channel_index) || input == nullptr;
     auto& group_buffer = m_group_buffers[group_index];
+    auto& meter_left = m_channel_meter_buffer.channels[0];
+    auto& meter_right = m_channel_meter_buffer.channels[1];
+    if (config.enable_metering) {
+      std::fill_n(meter_left.begin(), num_frames, 0.0f);
+      std::fill_n(meter_right.begin(), num_frames, 0.0f);
+    }
 
     RoutingOutputIndex discrete_output = channel.config.output_channel;
     if (discrete_output >= config.num_outputs) {
@@ -664,25 +677,47 @@ SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel
       switch (config.source_channel_policy) {
       case SourceChannelPolicy::Discrete:
         group_buffer.channels[discrete_output][frame] += sample;
-        break;
-      case SourceChannelPolicy::StereoPairs:
-        group_buffer.channels[0][frame] += sample * pan_left;
-        if (config.num_outputs > 1) {
-          group_buffer.channels[1][frame] += sample * pan_right;
+        if (config.enable_metering) {
+          meter_left[frame] = sample;
         }
         break;
+      case SourceChannelPolicy::StereoPairs: {
+        const float left = sample * pan_left;
+        group_buffer.channels[0][frame] += left;
+        if (config.enable_metering) {
+          meter_left[frame] = left;
+        }
+        if (config.num_outputs > 1) {
+          const float right = sample * pan_right;
+          group_buffer.channels[1][frame] += right;
+          if (config.enable_metering) {
+            meter_right[frame] = right;
+          }
+        }
+        break;
+      }
       case SourceChannelPolicy::MonoFoldDown:
         group_buffer.channels[0][frame] += sample;
+        if (config.enable_metering) {
+          meter_left[frame] = sample;
+        }
         break;
       }
     }
 
-    if (config.enable_metering && !muted) {
-      const float* right =
-          config.num_outputs > 1 ? group_buffer.channels[1].data() : nullptr;
-      processStereoMetering(group_buffer.channels[0].data(), right, num_frames,
-                            channel.true_peak_meters, channel.peak_level, channel.rms_level);
-      if (detectClipping(group_buffer.channels[discrete_output].data(), num_frames)) {
+    if (config.enable_metering) {
+      if (muted) {
+        publishChannelMeterSilence(channel);
+        continue;
+      }
+
+      const bool stereo = config.source_channel_policy == SourceChannelPolicy::StereoPairs &&
+                          config.num_outputs > 1;
+      const float* right = stereo ? meter_right.data() : nullptr;
+      processStereoMetering(meter_left.data(), right, num_frames, channel.true_peak_meters,
+                            channel.peak_level, channel.rms_level);
+      if (detectClipping(meter_left.data(), num_frames) ||
+          (right != nullptr && detectClipping(meter_right.data(), num_frames))) {
         channel.clip_count.fetch_add(1, std::memory_order_relaxed);
       }
     }
@@ -951,6 +986,14 @@ void RoutingMatrix::processStereoMetering(const float* left, const float* right,
       static_cast<float>(std::sqrt(sum_squares / static_cast<double>(num_frames * 2)));
   peak.store(peak_value, std::memory_order_release);
   rms.store(rms_value, std::memory_order_release);
+}
+
+void RoutingMatrix::publishChannelMeterSilence(ChannelState& channel) {
+  channel.peak_level.store(0.0f, std::memory_order_release);
+  channel.rms_level.store(0.0f, std::memory_order_release);
+  for (auto& meter : channel.true_peak_meters) {
+    meter.reset();
+  }
 }
 
 bool RoutingMatrix::detectClipping(float* buffer, size_t num_frames) {

--- a/src/core/routing/routing_matrix.h
+++ b/src/core/routing/routing_matrix.h
@@ -190,6 +190,7 @@ private:
   void processStereoMetering(const float* left, const float* right, size_t num_frames,
                              std::array<TruePeakMeter, 2>& true_peak_meters,
                              std::atomic<float>& peak, std::atomic<float>& rms);
+  void publishChannelMeterSilence(ChannelState& channel);
   bool detectClipping(float* buffer, size_t num_frames);
 
   // Configuration (lock-free double-buffer pattern)
@@ -222,6 +223,7 @@ private:
 
   // Audio processing buffers, allocated once during initialize().
   std::vector<MultichannelGroupBuffer> m_group_buffers;
+  MultichannelGroupBuffer m_channel_meter_buffer;
   std::vector<float> m_temp_buffer;
 
   // FTR028: Internal slice size. Kept in lock-step with the public

--- a/tests/routing/routing_matrix_test.cpp
+++ b/tests/routing/routing_matrix_test.cpp
@@ -458,6 +458,117 @@ TEST_F(RoutingMatrixTest, StereoMetersIncludeRightOnlySignal) {
   EXPECT_GT(groupMeter.rms_db, -10.0f);
 }
 
+TEST_F(RoutingMatrixTest, ChannelMetersReportIsolatedEffectiveContributions) {
+  config.num_channels = 2;
+  config.num_groups = 1;
+  config.num_outputs = 2;
+  config.gain_smoothing_ms = 0.0f;
+
+  const auto render = [&](bool reverse_channels) {
+    auto routed = createRoutingMatrix();
+    EXPECT_EQ(routed->initialize(config), SessionGraphError::OK);
+
+    std::array<std::array<float, BUFFER_SIZE>, 2> input{};
+    for (RoutingChannelIndex channel = 0; channel < 2; ++channel) {
+      const bool source_a = reverse_channels ? channel == 1 : channel == 0;
+      input[channel].fill(source_a ? 0.8f : 0.5f);
+      EXPECT_EQ(routed->setChannelGroup(channel, 0), SessionGraphError::OK);
+      EXPECT_EQ(routed->setChannelGain(channel, source_a ? -6.0f : -12.0f), SessionGraphError::OK);
+      EXPECT_EQ(routed->setChannelPan(channel, source_a ? -1.0f : 1.0f), SessionGraphError::OK);
+    }
+
+    const float* inputs[] = {input[0].data(), input[1].data()};
+    std::array<float, BUFFER_SIZE> left{};
+    std::array<float, BUFFER_SIZE> right{};
+    float* outputs[] = {left.data(), right.data()};
+    EXPECT_EQ(routed->processRouting(inputs, outputs, BUFFER_SIZE), SessionGraphError::OK);
+
+    std::array<AudioMeter, 2> readings = {routed->getChannelMeter(0), routed->getChannelMeter(1)};
+    if (reverse_channels) {
+      std::swap(readings[0], readings[1]);
+    }
+    return readings;
+  };
+
+  const auto forward = render(false);
+  const auto reversed = render(true);
+  const float source_a_peak = 0.8f * std::pow(10.0f, -6.0f / 20.0f);
+  const float source_b_peak = 0.5f * std::pow(10.0f, -12.0f / 20.0f);
+  const auto to_db = [](float linear) { return 20.0f * std::log10(linear); };
+
+  EXPECT_NEAR(forward[0].peak_db, to_db(source_a_peak), 0.01f);
+  EXPECT_NEAR(forward[0].rms_db, to_db(source_a_peak / std::sqrt(2.0f)), 0.01f);
+  EXPECT_NEAR(forward[1].peak_db, to_db(source_b_peak), 0.01f);
+  EXPECT_NEAR(forward[1].rms_db, to_db(source_b_peak / std::sqrt(2.0f)), 0.01f);
+  EXPECT_NEAR(reversed[0].peak_db, forward[0].peak_db, 0.0001f);
+  EXPECT_NEAR(reversed[0].rms_db, forward[0].rms_db, 0.0001f);
+  EXPECT_NEAR(reversed[1].peak_db, forward[1].peak_db, 0.0001f);
+  EXPECT_NEAR(reversed[1].rms_db, forward[1].rms_db, 0.0001f);
+}
+
+TEST_F(RoutingMatrixTest, ChannelMetersPublishCurrentSilenceForMuteSoloAndNullInput) {
+  config.num_channels = 2;
+  config.num_groups = 1;
+  config.gain_smoothing_ms = 0.0f;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+
+  std::array<float, BUFFER_SIZE> source_a{};
+  std::array<float, BUFFER_SIZE> source_b{};
+  source_a.fill(0.4f);
+  source_b.fill(0.3f);
+  std::array<float, BUFFER_SIZE> left{};
+  std::array<float, BUFFER_SIZE> right{};
+  float* outputs[] = {left.data(), right.data()};
+  const float* inputs[] = {source_a.data(), source_b.data()};
+
+  ASSERT_EQ(matrix->processRouting(inputs, outputs, BUFFER_SIZE), SessionGraphError::OK);
+  EXPECT_GT(matrix->getChannelMeter(1).peak_db, -100.0f);
+
+  ASSERT_EQ(matrix->setChannelMute(1, true), SessionGraphError::OK);
+  ASSERT_EQ(matrix->processRouting(inputs, outputs, BUFFER_SIZE), SessionGraphError::OK);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).peak_db, -100.0f);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).rms_db, -100.0f);
+  EXPECT_GT(matrix->getGroupMeter(0).peak_db, -100.0f);
+  EXPECT_GT(matrix->getMasterMeter().peak_db, -100.0f);
+
+  ASSERT_EQ(matrix->setChannelMute(1, false), SessionGraphError::OK);
+  ASSERT_EQ(matrix->setChannelSolo(0, true), SessionGraphError::OK);
+  ASSERT_EQ(matrix->processRouting(inputs, outputs, BUFFER_SIZE), SessionGraphError::OK);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).peak_db, -100.0f);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).rms_db, -100.0f);
+
+  ASSERT_EQ(matrix->setChannelSolo(0, false), SessionGraphError::OK);
+  const float* null_input[] = {source_a.data(), nullptr};
+  ASSERT_EQ(matrix->processRouting(null_input, outputs, BUFFER_SIZE), SessionGraphError::OK);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).peak_db, -100.0f);
+  EXPECT_FLOAT_EQ(matrix->getChannelMeter(1).rms_db, -100.0f);
+}
+
+TEST_F(RoutingMatrixTest, GroupAndMasterMetersRetainSummedStageReadings) {
+  config.num_channels = 2;
+  config.num_groups = 1;
+  config.gain_smoothing_ms = 0.0f;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+
+  std::array<float, BUFFER_SIZE> source_a{};
+  std::array<float, BUFFER_SIZE> source_b{};
+  source_a.fill(0.25f);
+  source_b.fill(0.25f);
+  const float* inputs[] = {source_a.data(), source_b.data()};
+  std::array<float, BUFFER_SIZE> left{};
+  std::array<float, BUFFER_SIZE> right{};
+  float* outputs[] = {left.data(), right.data()};
+  ASSERT_EQ(matrix->processRouting(inputs, outputs, BUFFER_SIZE), SessionGraphError::OK);
+
+  const AudioMeter channel = matrix->getChannelMeter(0);
+  const AudioMeter group = matrix->getGroupMeter(0);
+  const AudioMeter master = matrix->getMasterMeter();
+  EXPECT_NEAR(group.peak_db - channel.peak_db, 6.0206f, 0.01f);
+  EXPECT_NEAR(group.rms_db - channel.rms_db, 6.0206f, 0.01f);
+  EXPECT_NEAR(master.peak_db, group.peak_db, 0.01f);
+  EXPECT_NEAR(master.rms_db, group.rms_db, 0.01f);
+}
+
 // ============================================================================
 // Snapshot Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- meter each channel from a reusable isolated stereo scratch buffer rather than the shared group accumulator
- define peak/RMS lane reduction and current-callback silence for null, unrouted, muted, and effectively solo-muted channels
- preserve group/master summed-stage meters and cumulative clip counts

## Verification

- `routing_matrix_test`: all 39 tests pass, including new source-order, gain, pan, mute, solo, null-input, and summed-stage regressions
- complete configured SDK suite: all 149 tests pass
- new/changed C++ ranges pass clang-format checks

Closes #214