### PR TITLE
chore(release): publish Orpheus SDK 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-07-16
+
+Patch release for host-correct route-latency placement and isolated per-channel
+routing meters. Public C and C++ interfaces remain source-compatible.
+
 ### Fixed
 
 - CoreAudio round-trip latency now queries the active physical input/output
   routes live, including device and stream latency, safety offsets, actual I/O
   buffer depth, and AudioUnit processing latency. Private aggregate endpoints no
   longer hide high-latency consumer outputs such as Bluetooth headsets.
+- `IRoutingMatrix::getChannelMeter(i)` now reports channel \(i\)'s isolated
+  effective contribution after gain, pan, mute, and channel-solo logic instead
+  of the shared group accumulator. Null, unrouted, and effectively muted
+  channels publish silence in the current processing call.
+- Channel-meter stereo reduction is defined as maximum lane peak and RMS over
+  the mean power of both lanes. Group and master meters retain their summed-stage
+  behavior.
+
+### Verification
+
+- All 149 configured SDK tests pass.
+- All 39 routing-matrix tests pass, including source-order, distinct gain/pan,
+  mute, solo, null-input, and group/master stage regressions.
+- All changed C++ ranges pass `clang-format --dry-run --Werror`. The
+  repository-wide formatting audit still reports pre-existing drift in
+  unrelated files.
 
 ## [0.5.2] - 2026-07-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.5.2 LANGUAGES CXX)
+project(orpheus VERSION 0.5.3 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.5.2 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.5.3 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -3,8 +3,8 @@
 This index catalogs public entry points exposed by the Orpheus SDK workspace. Update this document whenever new packages or
 notable APIs are added.
 
-**Last Updated:** 2026-07-15 (ORP151 callback-loss reconciliation)
-**SDK Version:** 0.5.2 — the authoritative version is `project(orpheus VERSION ...)`
+**Last Updated:** 2026-07-16 (isolated channel-meter contract)
+**SDK Version:** 0.5.3 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.2
+**SDK Version:** 0.5.3
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.2
+**SDK Version:** 0.5.3

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.2
+**SDK Version:** 0.5.3

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.2
+**SDK Version:** 0.5.3


### PR DESCRIPTION
## Summary

Publish SDK v0.5.3 with:

- active-route CoreAudio round-trip latency detection
- isolated `getChannelMeter(i)` contributions with current-callback mute/solo/null silence
- source-order, gain/pan, and summed-stage meter regressions

Public C and C++ interfaces remain source-compatible.

## Verification

- clean Debug configure/build
- all 149 configured SDK tests pass
- all 39 routing-matrix tests pass
- version contract passes for 0.5.3