### PR TITLE
feat(transport): add clip playback controls

### DIFF
--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -10,6 +10,7 @@ Project documentation index for orpheus-sdk.
 
 - [[ORP150 Atomic Clip-Group Choke Admission]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
+- [[ORP152 Clip Playback Controls]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP124 Architecture Cross-Reference Matrix]]
@@ -68,6 +69,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP140 FreqFinder Architecture Revision - SDK Integration Confirmed]]
 - [[ORP150 Atomic Clip-Group Choke Admission]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
+- [[ORP152 Clip Playback Controls]]
 
 ## Archived Documents
 
@@ -102,4 +104,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-07-15
+**Last Generated:** 2026-07-16

--- a/docs/orp/ORP.md
+++ b/docs/orp/ORP.md
@@ -13,6 +13,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP148 Game-Audio Developer Opportunity Research]]
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
+- [[ORP152 Clip Playback Controls]]
 
 - [[ORP131 Clip Composer Subdirectory Archival]]
 - [[ORP130 CoreAudio Input Capture]]
@@ -114,6 +115,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP148 Game-Audio Developer Opportunity Research]]
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
+- [[ORP152 Clip Playback Controls]]
 
 ## Archived Documents
 
@@ -131,4 +133,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-07-15
+**Last Generated:** 2026-07-16

--- a/docs/orp/ORP152 Clip Playback Controls.md
+++ b/docs/orp/ORP152 Clip Playback Controls.md
@@ -82,12 +82,13 @@ source-to-output mapping; only their first stereo pair receives a balance gain.
 1. round-trip persistence and transactional rejection of invalid control
    values;
 2. session-default normalization and propagation to a newly registered clip;
-3. delay without source-cursor advancement;
-4. mute-to-silence while preserving transport advancement, and hard-left
-   suppression of the right output;
-5. variable-rate source-cursor advancement, including an active rate change;
+3. delay without source-cursor advancement and immediate cancellation of a
+   still-delayed voice;
+4. smoothed live mute while preserving transport advancement and gain metadata;
+5. hard-left stereo balance plus constant-power mono center placement;
+6. variable-rate source-cursor advancement, including an active rate change;
    and
-6. independent, output-frame-counted operator-stop fades.
+7. independent, output-frame-counted operator-stop fades.
 
 The pre-existing stop-fade and transport tests remain the regression coverage
 for trim boundaries, restart, loop behavior, routing, voice ownership, and

--- a/docs/orp/ORP152 Clip Playback Controls.md
+++ b/docs/orp/ORP152 Clip Playback Controls.md
@@ -1,0 +1,94 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP152 — Clip Playback Controls
+
+**Document type:** Public transport contract and implementation record  
+**Version target:** Unreleased  
+**Status:** Implemented; focused contract tests verified  
+**Date:** 2026-07-16
+
+---
+
+## Scope
+
+ORP152 completes the host-neutral clip controls represented by
+`ClipMetadata` and `SessionDefaults` in
+`include/orpheus/transport_controller.h`:
+
+- independent operator-stop fade duration and curve;
+- mute that preserves the configured `gainDb` value;
+- stereo balance;
+- forward varispeed playback; and
+- trigger-to-audible delay.
+
+The controls are metadata, not UI policy. Button layouts, labels, show
+programming, ducking, time-stretch/pitch preservation, reverse playback, and
+surround panning remain application or future-SDK concerns.
+
+## Public contract
+
+`ClipMetadata` is the atomic update payload and `SessionDefaults` supplies the
+same values when `registerClipAudio()` creates a new registry entry. Changing
+session defaults does not mutate an existing clip.
+
+`setSessionDefaults()` normalizes pan, playback rate, and delay to the public
+bounds. When a session default stop fade exceeds a newly registered clip's
+duration, the effective per-clip value is clamped to that duration.
+
+| Field | Valid range | Semantics |
+|---|---:|---|
+| `stopFadeOutSeconds` | finite, `0` through trimmed duration | Fade used by `stopClip()`, `stopAllClips()`, `stopOtherClips()`, and atomic group choke. |
+| `stopFadeOutCurve` | `FadeCurve` | Curve for that operator stop fade. |
+| `muted` | boolean | Ramps output to silence through the existing gain smoother without changing persisted `gainDb`; unmuting ramps back to that gain target. |
+| `pan` | finite, `[-1, +1]` | Mono uses a constant-power left/right law. Stereo and wider sources use an equal-power balance taper that preserves both first-pair channels at center. Mono sources are duplicated to the first two lanes when available. |
+| `playbackRate` | finite, `[0.25, 4.0]` | Forward, pitch-coupled varispeed multiplier. `1.0` is normal speed. |
+| `playDelaySeconds` | finite, `[0, 99.9]` | Output-frame delay from accepted start/restart to the first audible sample. The source cursor does not advance during the delay. |
+
+The existing `fadeOutSeconds` and `fadeOutCurve` remain the natural trim-OUT
+end envelope; they are not reused for an operator request to stop a clip.
+
+`updateClipMetadata()` validates all fields before it posts its one
+control-to-audio command. Validation failure leaves both persistent metadata
+and active voices unchanged. Active voices apply the new control values when
+that command is consumed; stopped clips capture them at their next start.
+
+For source compatibility, `updateClipFades()` sets both the natural-END and
+operator-stop fade-out fields to its `fadeOut*` arguments. Hosts that need
+different envelopes use `updateClipMetadata()`.
+
+No transport virtual method was added. `ClipMetadata` and `SessionDefaults`
+are public C++ structures, so consumers that compile against their full
+layouts must recompile with this SDK revision. This does not change the stable
+C ABI version.
+
+## Realtime behavior
+
+The audio thread receives a fixed snapshot of the controls with its start
+context and applies later batch updates through the existing bounded SPSC
+command ring. Varispeed uses the voice's fractional source cursor, linear
+interpolation, and the preallocated read buffer sized for the maximum $4\times$
+rate plus interpolation guard frames. Delay advances no source state while it
+emits silence. These paths allocate neither memory nor perform blocking I/O in
+`processAudio()`.
+
+A mono source is duplicated to the first two discrete lanes when available, so
+pan can create a real left/right placement. Wider sources retain their existing
+source-to-output mapping; only their first stereo pair receives a balance gain.
+
+## Verification
+
+`clip_controls_test` covers:
+
+1. round-trip persistence and transactional rejection of invalid control
+   values;
+2. session-default normalization and propagation to a newly registered clip;
+3. delay without source-cursor advancement;
+4. mute-to-silence while preserving transport advancement, and hard-left
+   suppression of the right output;
+5. variable-rate source-cursor advancement, including an active rate change;
+   and
+6. independent, output-frame-counted operator-stop fades.
+
+The pre-existing stop-fade and transport tests remain the regression coverage
+for trim boundaries, restart, loop behavior, routing, voice ownership, and
+callback delivery.

--- a/docs/orp/ORP153 Clip Composer Routing State Snapshot Adoption Handoff.md
+++ b/docs/orp/ORP153 Clip Composer Routing State Snapshot Adoption Handoff.md
@@ -1,0 +1,219 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP153 — Clip Composer Routing State Snapshot Adoption Handoff
+
+**Document type:** Downstream adoption handoff  
+**Owning implementation team:** Clip Composer  
+**Issuing repository:** Orpheus SDK  
+**Status:** Dependency-blocked; schedule after the SDK routing-state contract ships  
+**Date:** 2026-07-16  
+**Related SDK direction:** [[ORP147 SDK Customer-Fit Gap Register and Incremental Build Guide]]
+
+---
+
+## 1. Purpose
+
+This document hands one child-application task to the Clip Composer team: remove
+its shadow copy of SDK routing gain, mute, and solo state after Orpheus publishes
+a coherent routing-state query contract.
+
+This is downstream adoption work. Orpheus owns the prerequisite public API,
+realtime publication model, package fixture, and SDK contract tests. Clip
+Composer owns its SDK pin, app-side migration, UI projection, and application
+verification.
+
+Do not begin the migration against the current SDK API. `IRoutingMatrix` does
+not yet provide the required coherent configured-state query.
+
+---
+
+## 2. Current downstream state
+
+Clip Composer currently reaches the public routing matrix through
+`ITransportController::getRoutingMatrix()`, but it cannot read all configured
+group controls from that interface:
+
+- `IRoutingMatrix::isGroupMuted()` returns effective mute state;
+- no public query returns a group's configured solo flag; and
+- no public query returns a group's configured gain in decibels.
+
+The application therefore maintains three four-element shadow arrays in
+`Source/Audio/AudioEngine.h`:
+
+- `m_groupMuteCache`;
+- `m_groupSoloCache`; and
+- `m_groupGainDbCache`.
+
+`AudioEngine::setGroupMute()`, `setGroupSolo()`, `setGroupGain()`, and
+`applyGroupMixProfile()` update these arrays after SDK writes. The routing
+inspector and operational snapshots then read the cached values through
+`isGroupMuted()`, `isGroupSoloed()`, and `getGroupGainDb()`.
+
+Observed consumers include:
+
+- the routing-inspector projection in `Source/MainComponent.cpp`; and
+- operational snapshot construction in `Source/MainComponent.cpp`.
+
+The cache is currently necessary, but it creates two authorities for the same
+routing controls. A change applied by scene recall, transport rehydration, or a
+future SDK control path can leave the application projection stale.
+
+---
+
+## 3. SDK prerequisite
+
+The Orpheus team must ship and package a public routing-state contract before
+this handoff becomes actionable. The final SDK symbol names are intentionally
+not prescribed here, but the contract must provide one coherent control-thread
+value containing, for every configured group:
+
+- group index or stable group identity;
+- configured gain in decibels;
+- configured mute flag;
+- configured solo flag;
+- output start and width, when those fields remain SDK-owned; and
+- a revision or equivalent coherence marker.
+
+The contract must distinguish a group's configured mute flag from effective
+mute caused by another group's solo state. It must not require Clip Composer to
+call the allocating scene-capture API on every UI poll.
+
+For rollback-safe profile application, the SDK must also provide either:
+
+1. one validated batch mutation that publishes all group controls atomically at
+   a render boundary; or
+2. a documented snapshot-restore transaction whose failure semantics prevent a
+   partially applied live routing configuration.
+
+The SDK prerequisite is complete only when all of the following are true:
+
+- the contract is declared in installed public headers;
+- `Orpheus::routing` and `Orpheus::transport` package consumers can use it
+  without a private header or concrete-controller downcast;
+- concurrent control/render behavior is covered under ThreadSanitizer;
+- an SDK test proves coherent gain/mute/solo readback after mutation and
+  rollback; and
+- the SDK release or candidate version containing the contract is identified.
+
+---
+
+## 4. Clip Composer implementation handoff
+
+After the SDK prerequisite ships, perform a clean application cutover:
+
+1. Advance the Clip Composer SDK pin in a dedicated child-app change.
+2. Add one `AudioEngine` routing-state query that projects the SDK value into the
+   application-facing inspector shape.
+3. Read one SDK snapshot per inspector/operational-snapshot refresh rather than
+   issuing independent per-field reads.
+4. Make `isGroupMuted()`, `isGroupSoloed()`, and `getGroupGainDb()` read from that
+   SDK-derived projection.
+5. Delete `m_groupMuteCache`, `m_groupSoloCache`, and `m_groupGainDbCache`.
+6. Remove cache mutation and cache rollback from `setGroupMute()`,
+   `setGroupSolo()`, `setGroupGain()`, and `applyGroupMixProfile()`.
+7. Apply group profiles through the SDK's validated batch or documented
+   transaction contract. Do not rebuild an app-local partial-rollback scheme.
+8. Refresh routing state after transport recreation, device reconfiguration,
+   scene recall, and profile application.
+9. Keep all SDK routing reads and mutations on Clip Composer's existing
+   message/control-thread ownership path.
+10. Retain only application-owned presentation state locally.
+
+The cutover must leave no compatibility cache, fallback read path, or private
+SDK access in the application.
+
+---
+
+## 5. State that remains application-owned
+
+This handoff does not move presentation or product policy into Orpheus. Clip
+Composer continues to own:
+
+- group display names and operator-facing output labels;
+- routing-inspector rows, polling cadence, and JUCE view models;
+- device-selection and dialog state;
+- Cue/PFL workflow policy;
+- session persistence and undo policy outside the SDK routing contract; and
+- operator error presentation.
+
+`m_groupOutputProfile` and `m_cueOutputBus` remain local unless a separately
+approved SDK contract explicitly assumes ownership of those concepts.
+
+---
+
+## 6. Required application tests
+
+Add or update observable application tests for these contracts:
+
+1. **SDK readback:** accepted gain, mute, and solo writes are returned through
+   the SDK-derived `AudioEngine` query.
+2. **No shadow authority:** a routing change made through another supported SDK
+   path is visible without calling the matching `AudioEngine::setGroup*()`
+   wrapper first.
+3. **Configured versus effective mute:** soloing one group does not overwrite
+   another group's configured mute flag in the inspector projection.
+4. **Atomic profile application:** a valid four-group profile appears as one
+   coherent state; a rejected profile preserves the prior SDK and inspector
+   state.
+5. **Transport recreation:** device reconfiguration and transport replacement
+   rehydrate the inspector from the new SDK controller rather than stale app
+   memory.
+6. **Scene/recall integration:** any supported SDK scene or routing restore is
+   reflected in the next application snapshot.
+7. **Audio behavior:** preserve the existing
+   `PlaybackDispatcherTest.GroupBusesRouteMuteAndSoloIndependently` content
+   assertions.
+8. **Public consumption:** the application continues to build without private
+   Orpheus headers or concrete transport downcasts.
+
+Recommended focused verification after the child-app change:
+
+```bash
+cmake --build build-spoton-debug --target clip_composer_tests --parallel
+ctest --test-dir build-spoton-debug --output-on-failure \
+  -R 'GroupBusesRouteMuteAndSoloIndependently|Routing|DeviceSwap|SdkAdoption'
+```
+
+Run the repository's normal full Clip Composer suite and application smoke path
+before advancing its SDK pin.
+
+---
+
+## 7. Acceptance criteria
+
+The handoff is complete when:
+
+- the Clip Composer repository resolves the identified SDK version;
+- all routing inspector gain/mute/solo values originate from one coherent SDK
+  state value;
+- the three app shadow arrays and every write/rollback site for them are gone;
+- profile failure cannot expose a partially applied group state;
+- transport recreation and supported SDK restore paths cannot leave stale
+  inspector state;
+- focused routing, device-reconfiguration, SDK-adoption, full application, and
+  smoke checks pass; and
+- the child-app change records its tested SDK revision.
+
+No Clip Composer source change, SDK-pin change, build result, or runtime result
+is claimed by this document.
+
+---
+
+## 8. Non-goals
+
+- Redesigning the routing inspector.
+- Moving group names, Cue/PFL policy, or device UI into the SDK.
+- Adding a general plugin or DSP graph.
+- Changing the application's audio-thread ownership model.
+- Prescribing the final SDK C++ symbol names before the Orpheus routing contract
+  is reviewed.
+
+---
+
+## 9. Dispatch state
+
+**Pass to:** Clip Composer team.  
+**Start condition:** Orpheus publishes the prerequisite coherent routing-state
+and rollback-safe batch contract.  
+**Current action:** retain this handoff in the Clip Composer backlog; do not
+implement against the current SDK surface.

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -173,18 +173,27 @@ struct OutputBusRoute {
   bool operator==(const OutputBusRoute&) const = default;
 };
 
-/// Clip metadata for batch updates
-/// Contains all configurable playback parameters for a clip
+/// Clip metadata for batch updates.
+///
+/// `fadeOut*` defines the envelope at a natural trim-OUT boundary. The
+/// `stopFadeOut*` fields independently define the envelope for an operator
+/// stop: stopClip(), stopAllClips(), stopOtherClips(), or group choke.
 struct ClipMetadata {
   int64_t trimInSamples = 0;                  ///< Trim IN point in samples (0 = start of file)
   int64_t trimOutSamples = 0;                 ///< Trim OUT point in samples (0 = use file duration)
   double fadeInSeconds = 0.0;                 ///< Fade-in duration in seconds
-  double fadeOutSeconds = 0.0;                ///< Fade-out duration in seconds
+  double fadeOutSeconds = 0.0;                ///< Natural-END fade duration in seconds
   FadeCurve fadeInCurve = FadeCurve::Linear;  ///< Fade-in curve type
-  FadeCurve fadeOutCurve = FadeCurve::Linear; ///< Fade-out curve type
-  bool loopEnabled = false;                   ///< true = loop indefinitely
-  bool stopOthersOnPlay = false;              ///< true = stop other clips on play
-  float gainDb = 0.0f;                        ///< Gain in decibels (0 = unity)
+  FadeCurve fadeOutCurve = FadeCurve::Linear; ///< Natural-END fade curve type
+  double stopFadeOutSeconds = 0.01;           ///< Operator-stop fade duration in seconds
+  FadeCurve stopFadeOutCurve = FadeCurve::Linear; ///< Operator-stop fade curve type
+  bool loopEnabled = false;                       ///< true = loop indefinitely
+  bool stopOthersOnPlay = false;                  ///< true = stop other clips on play
+  float gainDb = 0.0f;                            ///< Gain in decibels (0 = unity)
+  bool muted = false;            ///< Silence the clip while preserving gainDb for later unmute
+  float pan = 0.0f;              ///< Stereo balance [-1, +1]; center preserves source channel level
+  double playbackRate = 1.0;     ///< Forward varispeed multiplier [0.25, 4.0], pitch-coupled
+  double playDelaySeconds = 0.0; ///< Trigger-to-audible delay [0, 99.9] seconds
   VoiceMode voiceMode = VoiceMode::Polyphonic;             ///< Voice allocation policy (ORP127 G5)
   RoutingGroupIndex routingGroup = 0;                      ///< Logical bus assignment
   ChannelLayout sourceLayout = ChannelLayout::Unspecified; ///< Explicit source channel meaning
@@ -193,17 +202,26 @@ struct ClipMetadata {
                                          Speaker::None, Speaker::None, Speaker::None,
                                          Speaker::None, Speaker::None};
 };
-
 /// Session-level default metadata for new clips.
-/// These defaults are applied when registerClipAudio() is called.
+///
+/// These values are copied when registerClipAudio() creates a registry entry;
+/// later default changes do not mutate existing clips. The setter normalizes
+/// pan, rate, and delay to their ClipMetadata bounds; an operator-stop default
+/// longer than a new clip is clamped to that clip's duration.
 struct SessionDefaults {
-  double fadeInSeconds = 0.0;                 ///< Default fade-in time (0.0 = no fade)
-  double fadeOutSeconds = 0.0;                ///< Default fade-out time (0.0 = no fade)
-  FadeCurve fadeInCurve = FadeCurve::Linear;  ///< Default fade-in curve
-  FadeCurve fadeOutCurve = FadeCurve::Linear; ///< Default fade-out curve
-  bool loopEnabled = false;                   ///< Default loop mode
-  bool stopOthersOnPlay = false;              ///< Default "stop others" mode
-  float gainDb = 0.0f;                        ///< Default gain in dB (0.0 = unity)
+  double fadeInSeconds = 0.0;                     ///< Default fade-in time (0.0 = no fade)
+  double fadeOutSeconds = 0.0;                    ///< Default natural-END fade time
+  FadeCurve fadeInCurve = FadeCurve::Linear;      ///< Default fade-in curve
+  FadeCurve fadeOutCurve = FadeCurve::Linear;     ///< Default natural-END fade curve
+  double stopFadeOutSeconds = 0.01;               ///< Default operator-stop fade duration
+  FadeCurve stopFadeOutCurve = FadeCurve::Linear; ///< Default operator-stop fade curve
+  bool loopEnabled = false;                       ///< Default loop mode
+  bool stopOthersOnPlay = false;                  ///< Default "stop others" mode
+  float gainDb = 0.0f;                            ///< Default gain in dB (0.0 = unity)
+  bool muted = false;                             ///< Default mute state
+  float pan = 0.0f;                               ///< Default stereo balance
+  double playbackRate = 1.0;                      ///< Default forward varispeed multiplier
+  double playDelaySeconds = 0.0;                  ///< Default trigger-to-audible delay
 
   // Note: Color is not part of SDK metadata; hosts store presentation state
   // (color, labels, etc.) separately.
@@ -515,13 +533,14 @@ public:
   /// @param fadeOutCurve Fade-out curve type (Linear, EqualPower, Exponential)
   /// @return SessionGraphError::OK on success, error code on failure
   ///
-  /// Thread-safe: Can be called from UI thread
-  /// Takes effect: On next clip start (does not affect currently playing clips)
+  /// Thread-safe: Can be called from UI thread.
+  /// Takes effect: on command consumption for active clips and at the next
+  /// start for stopped clips.
   ///
-  /// Fade behavior:
-  /// - Fade-in: Applied from trimInSamples (0.0 → 1.0 gain over N seconds)
-  /// - Fade-out: Applied before trimOutSamples (1.0 → 0.0 gain over N seconds)
-  /// - Fade curves:
+  /// Compatibility: this legacy convenience method sets both the natural-END
+  /// fade-out and the operator-stop fade-out to its `fadeOut*` arguments. Use
+  /// updateClipMetadata() when those envelopes must differ.
+  /// Fade curve shape:
   ///   - Linear: y = x
   ///   - EqualPower: y = sin(x * π/2)  [smooth crossfades]
   ///   - Exponential: y = x²  [dramatic effect]
@@ -639,8 +658,12 @@ public:
   /// Takes effect: Immediately for active clips (where applicable), on next start for stopped clips
   ///
   /// Validation:
-  /// - All validation rules from individual update methods apply
-  /// - If any validation fails, NO changes are applied (atomic operation)
+  /// - All validation rules from individual update methods apply.
+  /// - stopFadeOutSeconds is finite, non-negative, and no longer than the
+  ///   trimmed clip duration.
+  /// - pan is finite and in [-1, +1]; playbackRate is finite and in
+  ///   [0.25, 4.0]; playDelaySeconds is finite and in [0, 99.9].
+  /// - If any validation fails, NO changes are applied (atomic operation).
   virtual SessionGraphError updateClipMetadata(ClipHandle handle, const ClipMetadata& metadata) = 0;
 
   /// Get all clip metadata in a single query

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -173,6 +173,22 @@ struct OutputBusRoute {
   bool operator==(const OutputBusRoute&) const = default;
 };
 
+inline constexpr uint32_t kMaxClipPlaybackSegments = 64;
+inline constexpr uint32_t kMaxClipSegmentRepeatCount = 9999;
+
+/// One source-range entry in a clip's bounded realtime segment program.
+///
+/// Segment programs are host-authored control metadata. Stable segment IDs and
+/// source-identity reconciliation remain host/session concerns; the transport
+/// consumes only validated sample windows and repeat counts.
+struct ClipPlaybackSegment {
+  int64_t startSample = 0;
+  int64_t endSample = 0;
+  uint32_t repeatCount = 1;
+
+  bool operator==(const ClipPlaybackSegment&) const = default;
+};
+
 /// Clip metadata for batch updates.
 ///
 /// `fadeOut*` defines the envelope at a natural trim-OUT boundary. The
@@ -201,6 +217,8 @@ struct ClipMetadata {
   std::array<Speaker, 8> speakerPatch = {Speaker::None, Speaker::None, Speaker::None,
                                          Speaker::None, Speaker::None, Speaker::None,
                                          Speaker::None, Speaker::None};
+  uint32_t segmentCount = 0; ///< Valid entries in segments; zero uses trim IN/OUT
+  std::array<ClipPlaybackSegment, kMaxClipPlaybackSegments> segments{};
 };
 /// Session-level default metadata for new clips.
 ///

--- a/include/orpheus/transport_controller.h
+++ b/include/orpheus/transport_controller.h
@@ -191,7 +191,7 @@ struct ClipMetadata {
   bool stopOthersOnPlay = false;                  ///< true = stop other clips on play
   float gainDb = 0.0f;                            ///< Gain in decibels (0 = unity)
   bool muted = false;            ///< Silence the clip while preserving gainDb for later unmute
-  float pan = 0.0f;              ///< Stereo balance [-1, +1]; center preserves source channel level
+  float pan = 0.0f;              ///< Normalized mono pan / stereo balance [-1, +1]
   double playbackRate = 1.0;     ///< Forward varispeed multiplier [0.25, 4.0], pitch-coupled
   double playDelaySeconds = 0.0; ///< Trigger-to-audible delay [0, 99.9] seconds
   VoiceMode voiceMode = VoiceMode::Polyphonic;             ///< Voice allocation policy (ORP127 G5)

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -101,6 +101,20 @@ bool isLaterStartOrdinal(uint64_t candidate, uint64_t reference) noexcept {
   const uint64_t delta = candidate - reference;
   return delta != 0 && delta < (uint64_t{1} << 63);
 }
+std::pair<float, float> panGains(float pan, uint16_t numChannels) noexcept {
+  const float normalized = std::clamp(pan, -1.0f, 1.0f);
+  if (numChannels == 1) {
+    const double angle =
+        (static_cast<double>(normalized) + 1.0) * (static_cast<double>(M_PI_2) * 0.5);
+    return {static_cast<float>(std::cos(angle)), static_cast<float>(std::sin(angle))};
+  }
+
+  const double leftAngle =
+      static_cast<double>(std::max(normalized, 0.0f)) * static_cast<double>(M_PI_2);
+  const double rightAngle =
+      static_cast<double>(std::max(-normalized, 0.0f)) * static_cast<double>(M_PI_2);
+  return {static_cast<float>(std::cos(leftAngle)), static_cast<float>(std::cos(rightAngle))};
+}
 
 } // namespace
 
@@ -161,9 +175,13 @@ TransportController::TransportController(core::SessionGraph* sessionGraph,
                                                static_cast<uint16_t>(m_config.outputChannels));
   }
 
+  constexpr size_t kMaxPlaybackRate = 4;
+  constexpr size_t kInterpolationGuardFrames = 2;
   m_clipReadBuffers.resize(m_config.maxActiveVoices);
   for (auto& buffer : m_clipReadBuffers) {
-    buffer.resize(static_cast<size_t>(m_config.maxBlockFrames) * m_config.maxSourceChannels, 0.0f);
+    const size_t inputFrames =
+        static_cast<size_t>(m_config.maxBlockFrames) * kMaxPlaybackRate + kInterpolationGuardFrames;
+    buffer.resize(inputFrames * m_config.maxSourceChannels, 0.0f);
   }
 
   m_clipChannelBuffers.resize(routingLaneCount);
@@ -213,9 +231,19 @@ TransportController::makeStartContext(ClipHandle handle, bool requireRegisteredS
       context->source = entry.source;
       context->numChannels = entry.metadata.num_channels;
       context->trimInSamples = entry.trimInSamples;
+      context->stopFadeOutSeconds = entry.stopFadeOutSeconds;
+      context->stopFadeOutCurve = entry.stopFadeOutCurve;
       context->fileLengthSamples = entry.metadata.duration_samples;
       context->trimOutSamples =
           entry.trimOutSamples == 0 ? entry.metadata.duration_samples : entry.trimOutSamples;
+      context->muted = entry.muted;
+      context->pan = entry.pan;
+      const auto [leftGain, rightGain] = panGains(entry.pan, entry.metadata.num_channels);
+      context->panLeftGain = leftGain;
+      context->panRightGain = rightGain;
+      context->playbackRate = entry.playbackRate;
+      context->playDelayFrames =
+          static_cast<int64_t>(entry.playDelaySeconds * static_cast<double>(m_sampleRate));
       context->fadeInSeconds = entry.fadeInSeconds;
       context->fadeOutSeconds = entry.fadeOutSeconds;
       context->fadeInCurve = entry.fadeInCurve;
@@ -236,8 +264,17 @@ TransportController::makeStartContext(ClipHandle handle, bool requireRegisteredS
     // Preserve the historical source-less test/default start contract.
     context->source = nullptr;
     context->numChannels = 2;
+    context->stopFadeOutSeconds = 0.01;
+    context->stopFadeOutCurve = FadeCurve::Linear;
     context->trimInSamples = 0;
     context->trimOutSamples = 48000 * 60;
+    context->muted = false;
+    context->pan = 0.0f;
+    const auto [leftGain, rightGain] = panGains(0.0f, 2);
+    context->panLeftGain = leftGain;
+    context->panRightGain = rightGain;
+    context->playbackRate = 1.0;
+    context->playDelayFrames = 0;
     context->fileLengthSamples = 48000 * 60;
     context->fadeInSeconds = 0.0;
     context->fadeOutSeconds = 0.0;
@@ -419,275 +456,251 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
     std::memset(lane.data(), 0, numFrames * sizeof(float));
   }
 
-  // ORP127 G2: The stop fade-out is now computed per sample inside the render
-  // loop (see below), so no per-buffer fadeOutGain pre-pass is needed. This
-  // both removes the F-SDK-2 staircase and drops a redundant loop.
-
-  // Render each active clip to its own channel buffer
-  for (size_t i = 0; i < m_activeClipCount; ++i) {
-    ActiveClip& clip = m_activeClips[i];
-
-    // Skip if no audio source prepared (unregistered/test clips)
+  // Render each active voice into its preallocated routing lanes. Playback
+  // delay is measured in output frames; playback rate advances the fractional
+  // source cursor and uses linear interpolation without allocating or blocking.
+  for (size_t voiceIndex = 0; voiceIndex < m_activeClipCount; ++voiceIndex) {
+    ActiveClip& clip = m_activeClips[voiceIndex];
     if (!clip.source) {
       continue;
     }
 
-    // Load trim and fade settings (atomic read for thread safety)
-    int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
-    int64_t trimOut = clip.trimOutSamples.load(std::memory_order_acquire);
-    int64_t fadeInSampleCount = clip.fadeInSamples.load(std::memory_order_acquire);
-    int64_t fadeOutSampleCount = clip.fadeOutSamples.load(std::memory_order_acquire);
-    FadeCurve fadeInCurveType = clip.fadeInCurve.load(std::memory_order_acquire);
-    FadeCurve fadeOutCurveType = clip.fadeOutCurve.load(std::memory_order_acquire);
+    const int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
+    const int64_t trimOut = clip.trimOutSamples.load(std::memory_order_acquire);
+    const int64_t fadeInSampleCount = clip.fadeInSamples.load(std::memory_order_acquire);
+    const int64_t fadeOutSampleCount = clip.fadeOutSamples.load(std::memory_order_acquire);
+    const FadeCurve fadeInCurveType = clip.fadeInCurve.load(std::memory_order_acquire);
+    const FadeCurve fadeOutCurveType = clip.fadeOutCurve.load(std::memory_order_acquire);
+    const int64_t operatorStopFadeSamples = clip.stopFadeOutSamples.load(std::memory_order_acquire);
+    const FadeCurve operatorStopFadeCurve = clip.stopFadeOutCurve.load(std::memory_order_acquire);
+    const bool loopEnabled = clip.loopEnabled.load(std::memory_order_acquire);
+    const double playbackRate = clip.playbackRate.load(std::memory_order_acquire);
+    const bool muted = clip.muted.load(std::memory_order_acquire);
+    const float panLeft = clip.panLeftGain.load(std::memory_order_acquire);
+    const float panRight = clip.panRightGain.load(std::memory_order_acquire);
+    const float clipGainTarget = muted ? 0.0f : clip.gainLinear.load(std::memory_order_acquire);
+    const size_t numFileChannels = clip.numChannels;
+    const size_t laneBase = voiceIndex * m_config.maxSourceChannels;
+    float* const clipReadBuffer = m_clipReadBuffers[voiceIndex].data();
+    const size_t clipReadBufferSize = m_clipReadBuffers[voiceIndex].size();
 
-    // ORP093: Enforce trim boundaries BEFORE rendering (prevents position escape bug)
-    // CRITICAL: Clamp position to [trimIn, trimOut) range to maintain edit laws
-    // This ensures getClipPosition() never returns values outside user-defined boundaries
-    if (clip.currentSample < trimIn) {
-      // Position below IN point - clamp to IN (enforce Edit Law #1).
-      // ORP134 G1: sources are position-explicit — no reader seek; just hint
-      // the streaming prefetcher.
-      clip.currentSample = trimIn;
-      clip.source->setDemand(trimIn);
-    } else if (clip.currentSample >= trimOut) {
-      // Position at or past OUT point - handle loop or stop
-      const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
-      if (shouldLoop) {
-        // Loop mode: restart from IN point
+    size_t outputFrame = 0;
+    if (clip.playDelayFramesRemaining > 0) {
+      const size_t delayedFrames = static_cast<size_t>(
+          std::min<int64_t>(clip.playDelayFramesRemaining, static_cast<int64_t>(numFrames)));
+      clip.playDelayFramesRemaining -= static_cast<int64_t>(delayedFrames);
+      outputFrame += delayedFrames;
+    }
+
+    while (outputFrame < numFrames) {
+      if (clip.sourcePosition < static_cast<double>(trimIn)) {
+        clip.sourcePosition = static_cast<double>(trimIn);
         clip.currentSample = trimIn;
         clip.source->setDemand(trimIn);
-
-        // ORP097 Bug 7 Fix: Mark that clip has looped
-        clip.hasLoopedOnce = true;
-      } else {
-        // Non-loop mode: trigger stop fade-out when reaching OUT point.
-        // ORP127 G3: Keep the reader alive and let the per-sample stop fade
-        // (T4) render REAL audio through the fade tail, instead of nulling the
-        // reader and fading silence — which produced a click at OUT. Reading
-        // continues past trimOut only for the fade duration, bounded by the
-        // true file length (below), so libsndfile never wraps past EOF.
-        if (!clip.isStopping) {
-          clip.isStopping = true;
-          clip.fadeOutGain = 1.0f;
-          clip.fadeOutStartPos = clip.currentSample;
-        }
-      }
-    } else if (!clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping &&
-               (clip.currentSample + static_cast<int64_t>(numFrames)) > trimOut) {
-      // ORP127 G3: This buffer will CROSS trimOut mid-way. Start the stop fade
-      // now, anchored exactly at trimOut, so the fade renders continuously from
-      // the OUT sample within this same buffer — previously the read was capped
-      // at trimOut and the rest of the buffer rendered as (cleared) silence,
-      // producing a hard cut. The reader stays alive; the read horizon below is
-      // extended to cover the fade tail.
-      clip.isStopping = true;
-      clip.fadeOutGain = 1.0f;
-      clip.fadeOutStartPos = trimOut;
-    }
-
-    // ORP127 G3: When stopping (e.g. after OUT), extend the read horizon past
-    // trimOut for the remaining fade tail so the fade applies to real audio.
-    // Otherwise the read is bounded by trimOut as before. Everything is clamped
-    // to the true file length so we never read past EOF.
-    int64_t readHorizon = trimOut;
-    if (clip.isStopping) {
-      int64_t stopFadeSamples = fadeOutSampleCount;
-      if (stopFadeSamples == 0) {
-        stopFadeSamples = static_cast<int64_t>(m_fadeOutSamples);
-      }
-      int64_t fadeEnd = clip.fadeOutStartPos + stopFadeSamples;
-      readHorizon = std::max(readHorizon, fadeEnd);
-    }
-    if (clip.fileLengthSamples > 0) {
-      readHorizon = std::min(readHorizon, clip.fileLengthSamples);
-    }
-
-    // Calculate how many frames to read (respecting the read horizon)
-    int64_t framesUntilEnd = readHorizon - clip.currentSample;
-    if (framesUntilEnd <= 0) {
-      // ORP127 G3: Past the read horizon (e.g. OUT tail reached EOF) but the
-      // reader is still held. Advance position by the buffer so the stop fade
-      // can still complete — the reader-less advance loop below only handles
-      // clips whose reader is already null.
-      if (clip.isStopping) {
-        clip.currentSample += static_cast<int64_t>(numFrames);
-      }
-      continue;
-    }
-
-    size_t framesToRead =
-        static_cast<size_t>(std::min(static_cast<int64_t>(numFrames), framesUntilEnd));
-
-    // ORP134 G1: reads are position-explicit against the prepared/streamed
-    // source — the audio thread never touches a file reader or a shared
-    // cursor. (This also makes multi-voice playback of one clip correct:
-    // every voice reads at its own currentSample.)
-    size_t numFileChannels = clip.numChannels;
-
-    // Use this clip's dedicated read buffer (no shared buffer conflicts!)
-    float* clipReadBuffer = m_clipReadBuffers[i].data();
-    size_t clipReadBufferSize = m_clipReadBuffers[i].size();
-
-    // Check if read fits in pre-allocated buffer
-    size_t samplesNeeded = framesToRead * numFileChannels;
-    if (samplesNeeded > clipReadBufferSize) {
-      // Clip too large for buffer - skip (should not happen with reasonable buffer size)
-      continue;
-    }
-
-    // Copy decoded PCM from this clip's source into THIS clip's buffer.
-    // A streaming cache miss NEVER blocks: the clip renders silence for this
-    // buffer, the transport reports a BufferUnderrun, and the position still
-    // advances so the timeline keeps moving while the worker catches up.
-    size_t framesRead = 0;
-    if (!clip.source->read(clip.currentSample, clipReadBuffer, framesToRead, framesRead)) {
-      TransportEvent event{};
-      event.type = TransportEventType::BufferUnderrun;
-      event.handle = clip.handle;
-      event.voiceId = clip.voiceId;
-      event.position = getCurrentPosition();
-      postTransportEvent(event);
-      m_realtimeTelemetry.reportUnderrunFromRealtime();
-
-      clip.source->setDemand(clip.currentSample);
-      clip.currentSample += static_cast<int64_t>(framesToRead);
-      continue;
-    }
-
-    if (framesRead == 0) {
-      // Past EOF (e.g. OUT-tail horizon beyond the file). Advance so stop
-      // fades can complete, mirroring the source-less advance path.
-      if (clip.isStopping) {
-        clip.currentSample += static_cast<int64_t>(numFrames);
-      }
-      continue;
-    }
-
-    // ORP121 A-01: Stereo output to L/R channel buffers (indices i*2 and i*2+1)
-    // No mono sum - preserves source channel separation per ST2110-30
-
-    // Load the clip gain TARGET (atomic read, no pow() in the audio thread).
-    // ORP127 G4: gainCurrent ramps toward this target per sample below.
-    float clipGainTarget = clip.gainLinear.load(std::memory_order_acquire);
-
-    for (size_t frame = 0; frame < framesRead; ++frame) {
-      // Calculate base gain (starts at 1.0)
-      float gain = 1.0f;
-
-      // ORP127 G4: ramp the smoothed clip gain toward the target by at most
-      // gainRampIncrement per sample, so fader drags apply as a short ramp
-      // instead of a per-buffer step (no zipper noise).
-      if (clip.gainCurrent < clipGainTarget) {
-        clip.gainCurrent = std::min(clipGainTarget, clip.gainCurrent + clip.gainRampIncrement);
-      } else if (clip.gainCurrent > clipGainTarget) {
-        clip.gainCurrent = std::max(clipGainTarget, clip.gainCurrent - clip.gainRampIncrement);
       }
 
-      // Apply the smoothed clip gain (from gainDb setting)
-      gain *= clip.gainCurrent;
+      if (!clip.isStopping && clip.sourcePosition >= static_cast<double>(trimOut)) {
+        if (loopEnabled) {
+          clip.sourcePosition = static_cast<double>(trimIn);
+          clip.currentSample = trimIn;
+          clip.source->setDemand(trimIn);
+          clip.hasLoopedOnce = true;
 
-      // Apply broadcast-safe restart crossfade (5ms linear fade-in)
-      if (clip.isRestarting && clip.restartFadeFramesRemaining > 0) {
-        // Calculate fade-in gain (0.0 → 1.0 over restartCrossfadeSamples)
-        int64_t fadeProgress =
-            static_cast<int64_t>(m_restartCrossfadeSamples) - clip.restartFadeFramesRemaining;
-        float restartFadeGain =
-            static_cast<float>(fadeProgress) / static_cast<float>(m_restartCrossfadeSamples);
-        gain *= restartFadeGain; // Linear fade-in
-
-        // Decrement remaining frames (will be disabled when reaches 0)
-        clip.restartFadeFramesRemaining--;
-        if (clip.restartFadeFramesRemaining == 0) {
-          clip.isRestarting = false; // Crossfade complete
-        }
-      }
-
-      // ORP127 G2: Apply the stop fade-out PER SAMPLE. Previously a single
-      // fadeOutGain scalar was computed once per buffer (F-SDK-2), which turned
-      // short fades (e.g. 10ms @ 512-sample buffers) into a 1-2 step staircase —
-      // audible as bitcrush when many clips stop at once. Now each sample's fade
-      // position is computed from its own offset into the fade, matching the
-      // per-sample fade-in / clip-fade-out envelopes below.
-      if (clip.isStopping) {
-        int64_t stopFadeSamples = fadeOutSampleCount;
-        if (stopFadeSamples == 0) {
-          stopFadeSamples = static_cast<int64_t>(m_fadeOutSamples); // default 10ms
-        }
-        int64_t stopFadeProgress =
-            (clip.currentSample + static_cast<int64_t>(frame)) - clip.fadeOutStartPos;
-        float stopFadePos =
-            static_cast<float>(stopFadeProgress) / static_cast<float>(stopFadeSamples);
-        stopFadePos = std::clamp(stopFadePos, 0.0f, 1.0f);
-        float stopFadeGain = 1.0f - calculateFadeGain(stopFadePos, fadeOutCurveType);
-        gain *= std::max(0.0f, stopFadeGain);
-      }
-
-      // ORP097 Fix: Only apply clip fade-in/out for NON-LOOPED clips
-      // Looped clips should have seamless loops with no fades at boundaries
-      // Note: STOP fades (when clip.isStopping) are applied separately and work for all clips
-      bool isLooped = clip.loopEnabled.load(std::memory_order_acquire);
-      if (!isLooped) {
-        // Apply clip fade-in (first N samples from trim IN)
-        int64_t relativePos = clip.currentSample + static_cast<int64_t>(frame) - trimIn;
-        if (fadeInSampleCount > 0 && relativePos >= 0 && relativePos < fadeInSampleCount) {
-          float fadeInPos = static_cast<float>(relativePos) / static_cast<float>(fadeInSampleCount);
-          gain *= calculateFadeGain(fadeInPos, fadeInCurveType);
-        }
-
-        // Apply clip fade-out (last N samples before trim OUT)
-        int64_t trimmedDuration = trimOut - trimIn;
-        if (fadeOutSampleCount > 0 && relativePos >= (trimmedDuration - fadeOutSampleCount)) {
-          int64_t fadeOutRelativePos = relativePos - (trimmedDuration - fadeOutSampleCount);
-          float fadeOutPos =
-              static_cast<float>(fadeOutRelativePos) / static_cast<float>(fadeOutSampleCount);
-          // ORP127 G3: clamp to [0,1]. With the OUT-tail read horizon, relativePos
-          // can exceed trimmedDuration; without clamping calculateFadeGain(>1)
-          // would drive the multiplier negative (phase flip).
-          fadeOutPos = std::clamp(fadeOutPos, 0.0f, 1.0f);
-          gain *= (1.0f - calculateFadeGain(fadeOutPos, fadeOutCurveType));
-        }
-      }
-
-      const size_t laneBase = i * m_config.maxSourceChannels;
-      if (m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete) {
-        for (size_t channel = 0; channel < numFileChannels; ++channel) {
-          m_clipChannelBuffers[laneBase + channel][frame] =
-              clipReadBuffer[frame * numFileChannels + channel] * gain;
-        }
-      } else {
-        float left = 0.0f;
-        float right = 0.0f;
-        if (numFileChannels == 1) {
-          left = clipReadBuffer[frame];
-          right = left;
-        } else if (numFileChannels == 2) {
-          left = clipReadBuffer[frame * 2];
-          right = clipReadBuffer[frame * 2 + 1];
+          TransportEvent event{};
+          event.type = TransportEventType::ClipLooped;
+          event.handle = clip.handle;
+          event.voiceId = clip.voiceId;
+          event.position = getCurrentPosition();
+          postTransportEvent(event);
         } else {
-          left = applyDownmixLeft(clipReadBuffer, frame, numFileChannels);
-          right = applyDownmixRight(clipReadBuffer, frame, numFileChannels);
-        }
-        m_clipChannelBuffers[laneBase][frame] = left * gain;
-        if (m_config.maxSourceChannels > 1) {
-          m_clipChannelBuffers[laneBase + 1][frame] = right * gain;
+          clip.isStopping = true;
+          clip.isNaturalEnding = true;
+          clip.fadeOutGain = 1.0f;
+          clip.fadeOutStartPos = trimOut;
+          clip.stopFadeFramesElapsed = 0;
         }
       }
-    }
 
-    // Advance clip position by actual frames read (not buffer size!)
-    // CRITICAL (Copilot feedback): This must happen AFTER fade processing, not before
-    // Previously this was at line 341 (before fade loop), causing fade timing to be off by one
-    // buffer
-    clip.currentSample += static_cast<int64_t>(framesRead);
+      int64_t activeStopFadeSamples = 0;
+      FadeCurve activeStopFadeCurve = operatorStopFadeCurve;
+      if (clip.isStopping) {
+        if (clip.isNaturalEnding) {
+          activeStopFadeSamples = fadeOutSampleCount;
+          if (activeStopFadeSamples == 0) {
+            activeStopFadeSamples = static_cast<int64_t>(m_fadeOutSamples);
+          }
+          activeStopFadeCurve = fadeOutCurveType;
+        } else {
+          activeStopFadeSamples = operatorStopFadeSamples;
+        }
+
+        if (activeStopFadeSamples <= 0 || clip.stopFadeFramesElapsed >= activeStopFadeSamples) {
+          clip.stopFadeFramesElapsed = std::max<int64_t>(activeStopFadeSamples, 0);
+          break;
+        }
+      }
+
+      size_t segmentFrames = numFrames - outputFrame;
+      if (clip.isStopping) {
+        segmentFrames = std::min(
+            segmentFrames, static_cast<size_t>(activeStopFadeSamples - clip.stopFadeFramesElapsed));
+      } else {
+        const double sourceFramesToOut = static_cast<double>(trimOut) - clip.sourcePosition;
+        const size_t outputFramesToOut =
+            static_cast<size_t>(std::max(1.0, std::ceil(sourceFramesToOut / playbackRate)));
+        segmentFrames = std::min(segmentFrames, outputFramesToOut);
+      }
+
+      const int64_t readStart = static_cast<int64_t>(std::floor(clip.sourcePosition));
+      const double lastSourcePosition =
+          clip.sourcePosition + playbackRate * static_cast<double>(segmentFrames - 1);
+      const size_t requestedInputFrames =
+          static_cast<size_t>(std::floor(lastSourcePosition - static_cast<double>(readStart))) + 2;
+      const size_t samplesNeeded = requestedInputFrames * numFileChannels;
+
+      size_t framesRead = 0;
+      bool readSucceeded = true;
+      if (readStart < clip.fileLengthSamples && samplesNeeded <= clipReadBufferSize) {
+        readSucceeded =
+            clip.source->read(readStart, clipReadBuffer, requestedInputFrames, framesRead);
+      }
+
+      if (!readSucceeded) {
+        TransportEvent event{};
+        event.type = TransportEventType::BufferUnderrun;
+        event.handle = clip.handle;
+        event.voiceId = clip.voiceId;
+        event.position = getCurrentPosition();
+        postTransportEvent(event);
+        m_realtimeTelemetry.reportUnderrunFromRealtime();
+        clip.source->setDemand(readStart);
+        framesRead = 0;
+      }
+
+      for (size_t frame = 0; frame < segmentFrames; ++frame) {
+        if (clip.gainCurrent < clipGainTarget) {
+          clip.gainCurrent = std::min(clipGainTarget, clip.gainCurrent + clip.gainRampIncrement);
+        } else if (clip.gainCurrent > clipGainTarget) {
+          clip.gainCurrent = std::max(clipGainTarget, clip.gainCurrent - clip.gainRampIncrement);
+        }
+
+        float gain = clip.gainCurrent;
+        if (clip.isRestarting && clip.restartFadeFramesRemaining > 0) {
+          const int64_t fadeProgress =
+              static_cast<int64_t>(m_restartCrossfadeSamples) - clip.restartFadeFramesRemaining;
+          gain *= static_cast<float>(fadeProgress) / static_cast<float>(m_restartCrossfadeSamples);
+          --clip.restartFadeFramesRemaining;
+          if (clip.restartFadeFramesRemaining == 0) {
+            clip.isRestarting = false;
+          }
+        }
+
+        if (clip.isStopping) {
+          const float stopFadePosition = std::clamp(
+              static_cast<float>(clip.stopFadeFramesElapsed + static_cast<int64_t>(frame)) /
+                  static_cast<float>(activeStopFadeSamples),
+              0.0f, 1.0f);
+          gain *= std::max(0.0f, 1.0f - calculateFadeGain(stopFadePosition, activeStopFadeCurve));
+        }
+
+        const double frameSourcePosition =
+            clip.sourcePosition + playbackRate * static_cast<double>(frame);
+        const double localPosition = frameSourcePosition - static_cast<double>(readStart);
+        const size_t firstInputFrame = static_cast<size_t>(std::floor(localPosition));
+        if (firstInputFrame >= framesRead) {
+          continue;
+        }
+        const size_t secondInputFrame = std::min(firstInputFrame + 1, framesRead - 1);
+        const float fraction =
+            static_cast<float>(localPosition - static_cast<double>(firstInputFrame));
+
+        const int64_t relativePosition =
+            static_cast<int64_t>(std::floor(frameSourcePosition)) - trimIn;
+        if (!loopEnabled) {
+          if (fadeInSampleCount > 0 && relativePosition >= 0 &&
+              relativePosition < fadeInSampleCount) {
+            const float fadePosition =
+                static_cast<float>(relativePosition) / static_cast<float>(fadeInSampleCount);
+            gain *= calculateFadeGain(fadePosition, fadeInCurveType);
+          }
+
+          const int64_t trimmedDuration = trimOut - trimIn;
+          if (fadeOutSampleCount > 0 && relativePosition >= trimmedDuration - fadeOutSampleCount) {
+            const float fadePosition = std::clamp(
+                static_cast<float>(relativePosition - (trimmedDuration - fadeOutSampleCount)) /
+                    static_cast<float>(fadeOutSampleCount),
+                0.0f, 1.0f);
+            gain *= 1.0f - calculateFadeGain(fadePosition, fadeOutCurveType);
+          }
+        }
+
+        std::array<float, 8> sourceFrame{};
+        for (size_t channel = 0; channel < numFileChannels; ++channel) {
+          const float first = clipReadBuffer[firstInputFrame * numFileChannels + channel];
+          const float second = clipReadBuffer[secondInputFrame * numFileChannels + channel];
+          sourceFrame[channel] = first + (second - first) * fraction;
+        }
+
+        const size_t destinationFrame = outputFrame + frame;
+        if (m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete) {
+          if (numFileChannels == 1 && m_config.maxSourceChannels > 1) {
+            m_clipChannelBuffers[laneBase][destinationFrame] = sourceFrame[0] * gain * panLeft;
+            m_clipChannelBuffers[laneBase + 1][destinationFrame] = sourceFrame[0] * gain * panRight;
+          } else {
+            for (size_t channel = 0; channel < numFileChannels; ++channel) {
+              const float panGain = channel == 0 ? panLeft : (channel == 1 ? panRight : 1.0f);
+              m_clipChannelBuffers[laneBase + channel][destinationFrame] =
+                  sourceFrame[channel] * gain * panGain;
+            }
+          }
+        } else {
+          float left = 0.0f;
+          float right = 0.0f;
+          if (numFileChannels == 1) {
+            left = sourceFrame[0];
+            right = left;
+          } else if (numFileChannels == 2) {
+            left = sourceFrame[0];
+            right = sourceFrame[1];
+          } else {
+            left = applyDownmixLeft(sourceFrame.data(), 0, numFileChannels);
+            right = applyDownmixRight(sourceFrame.data(), 0, numFileChannels);
+          }
+          m_clipChannelBuffers[laneBase][destinationFrame] = left * gain * panLeft;
+          if (m_config.maxSourceChannels > 1) {
+            m_clipChannelBuffers[laneBase + 1][destinationFrame] = right * gain * panRight;
+          }
+        }
+      }
+
+      clip.sourcePosition += playbackRate * static_cast<double>(segmentFrames);
+      clip.currentSample = static_cast<int64_t>(std::floor(clip.sourcePosition));
+      if (clip.isStopping) {
+        clip.stopFadeFramesElapsed += static_cast<int64_t>(segmentFrames);
+      }
+      outputFrame += segmentFrames;
+    }
   }
 
-  // Multi-voice fix: Advance position for clips WITHOUT sources (test clips)
-  // This ensures fade-outs complete properly even when no audio is being rendered
-  for (size_t i = 0; i < m_activeClipCount; ++i) {
-    ActiveClip& clip = m_activeClips[i];
-    if (!clip.source) {
-      // Clip has no source - advance position by buffer size so fades can complete
-      clip.currentSample += static_cast<int64_t>(numFrames);
+  // Source-less voices exist only in transport tests. Keep their clocks and
+  // stop envelopes moving without introducing a fake render source.
+  for (size_t voiceIndex = 0; voiceIndex < m_activeClipCount; ++voiceIndex) {
+    ActiveClip& clip = m_activeClips[voiceIndex];
+    if (clip.source) {
+      continue;
+    }
+    size_t activeFrames = numFrames;
+    if (clip.playDelayFramesRemaining > 0) {
+      const size_t delayedFrames = static_cast<size_t>(
+          std::min<int64_t>(clip.playDelayFramesRemaining, static_cast<int64_t>(numFrames)));
+      clip.playDelayFramesRemaining -= static_cast<int64_t>(delayedFrames);
+      activeFrames -= delayedFrames;
+    }
+    const double playbackRate = clip.playbackRate.load(std::memory_order_acquire);
+    clip.sourcePosition += playbackRate * static_cast<double>(activeFrames);
+    clip.currentSample = static_cast<int64_t>(std::floor(clip.sourcePosition));
+    if (clip.isStopping) {
+      clip.stopFadeFramesElapsed += static_cast<int64_t>(activeFrames);
     }
   }
 
@@ -700,18 +713,15 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
   while (i < m_activeClipCount) {
     ActiveClip& clip = m_activeClips[i];
 
-    // Check if fade-out is complete (fadeOutGain was pre-computed in pre-render loop)
     if (clip.isStopping) {
-      int64_t fadeOutSampleCount = clip.fadeOutSamples.load(std::memory_order_acquire);
-
-      // If no fade-out configured, use default 10ms fade
-      if (fadeOutSampleCount == 0) {
-        fadeOutSampleCount = static_cast<int64_t>(m_fadeOutSamples);
+      int64_t stopFadeSamples = clip.isNaturalEnding
+                                    ? clip.fadeOutSamples.load(std::memory_order_acquire)
+                                    : clip.stopFadeOutSamples.load(std::memory_order_acquire);
+      if (clip.isNaturalEnding && stopFadeSamples == 0) {
+        stopFadeSamples = static_cast<int64_t>(m_fadeOutSamples);
       }
 
-      int64_t fadeProgress = clip.currentSample - clip.fadeOutStartPos;
-
-      if (fadeProgress >= fadeOutSampleCount) {
+      if (clip.stopFadeFramesElapsed >= stopFadeSamples) {
         const ClipHandle stoppedHandle = clip.handle;
         const uint32_t stoppedVoiceId = clip.voiceId;
         removeActiveVoice(stoppedVoiceId);
@@ -729,53 +739,38 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
         }
         continue;
       }
+
+      ++i;
+      continue;
     }
 
-    // Check if clip reached trim OUT point
-    int64_t clipTrimOut = clip.trimOutSamples.load(std::memory_order_acquire);
+    const int64_t clipTrimOut = clip.trimOutSamples.load(std::memory_order_acquire);
     if (clip.currentSample >= clipTrimOut) {
-      // Check if clip should loop
-      const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire) && !clip.isStopping;
-
+      const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
       if (shouldLoop) {
-        // Loop: jump back to trim IN point (works even without a source)
-        int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
+        const int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
+        clip.currentSample = trimIn;
+        clip.sourcePosition = static_cast<double>(trimIn);
         if (clip.source) {
           clip.source->setDemand(trimIn);
         }
-        clip.currentSample = trimIn;
-
-        // ORP097 Bug 7 Fix: Mark that clip has looped (prevents fade-in/out on subsequent loops)
         clip.hasLoopedOnce = true;
 
-        // Post loop event
         TransportEvent event{};
         event.type = TransportEventType::ClipLooped;
         event.handle = clip.handle;
         event.voiceId = clip.voiceId;
         event.position = getCurrentPosition();
         postTransportEvent(event);
-
-        // Continue playback (don't remove clip, don't increment i)
-        ++i;
       } else {
-        // Non-loop mode: Clip reached OUT point.
-        // ORP127 G3: Trigger the stop fade but KEEP the reader so the in-render
-        // OUT-tail path (bounded by file length) can render real audio through
-        // the fade — no hard cut, no click. The reader is released naturally
-        // when the fade completes (removeActiveClip) or when the read horizon
-        // reaches EOF (the reader-less advance loop then finishes the fade).
-        if (!clip.isStopping) {
-          clip.isStopping = true;
-          clip.fadeOutGain = 1.0f;
-          clip.fadeOutStartPos = clip.currentSample;
-        }
-        // Continue rendering with fade-out (normal fade-out completion logic will remove clip)
-        ++i;
+        clip.isStopping = true;
+        clip.isNaturalEnding = true;
+        clip.fadeOutGain = 1.0f;
+        clip.fadeOutStartPos = clipTrimOut;
+        clip.stopFadeFramesElapsed = 0;
       }
-    } else {
-      ++i;
     }
+    ++i;
   }
 
   // Update transport position
@@ -844,6 +839,8 @@ void TransportController::processCommands() {
             peer.isStopping = true;
             peer.fadeOutGain = 1.0f;
             peer.fadeOutStartPos = peer.currentSample;
+            peer.stopFadeFramesElapsed = 0;
+            peer.isNaturalEnding = false;
           }
         }
       }
@@ -857,6 +854,8 @@ void TransportController::processCommands() {
           m_activeClips[i].fadeOutGain = 1.0f;
           m_activeClips[i].fadeOutStartPos =
               m_activeClips[i].currentSample; // Record position when fade-out started
+          m_activeClips[i].stopFadeFramesElapsed = 0;
+          m_activeClips[i].isNaturalEnding = false;
         }
       }
     } break;
@@ -867,6 +866,8 @@ void TransportController::processCommands() {
         m_activeClips[i].fadeOutGain = 1.0f;
         m_activeClips[i].fadeOutStartPos =
             m_activeClips[i].currentSample; // Record position when fade-out started
+        m_activeClips[i].stopFadeFramesElapsed = 0;
+        m_activeClips[i].isNaturalEnding = false;
       }
       break;
 
@@ -901,6 +902,8 @@ void TransportController::processCommands() {
           m_activeClips[i].isStopping = true;
           m_activeClips[i].fadeOutGain = 1.0f;
           m_activeClips[i].fadeOutStartPos = m_activeClips[i].currentSample;
+          m_activeClips[i].stopFadeFramesElapsed = 0;
+          m_activeClips[i].isNaturalEnding = false;
         }
       }
       break;
@@ -919,11 +922,13 @@ void TransportController::processCommands() {
           // This prevents fade calculation overflow in processAudio()
           if (m_activeClips[i].currentSample < trimIn) {
             m_activeClips[i].currentSample = trimIn;
+            m_activeClips[i].sourcePosition = static_cast<double>(trimIn);
             if (m_activeClips[i].source) {
               m_activeClips[i].source->setDemand(trimIn);
             }
           } else if (m_activeClips[i].currentSample >= trimOut) {
             m_activeClips[i].currentSample = trimOut;
+            m_activeClips[i].sourcePosition = static_cast<double>(trimOut);
             // Position clamps to OUT; playback stops naturally in processAudio.
           }
         }
@@ -947,6 +952,13 @@ void TransportController::processCommands() {
 
           m_activeClips[i].fadeInSamples.store(inSamples, std::memory_order_release);
           m_activeClips[i].fadeOutSamples.store(outSamples, std::memory_order_release);
+          // Preserve updateClipFades()'s historical meaning for callers that
+          // predate the independently configurable operator-stop fields.
+          m_activeClips[i].stopFadeOutSeconds.store(cmd.data.fade.outSeconds,
+                                                    std::memory_order_release);
+          m_activeClips[i].stopFadeOutCurve.store(cmd.data.fade.outCurve,
+                                                  std::memory_order_release);
+          m_activeClips[i].stopFadeOutSamples.store(outSamples, std::memory_order_release);
         }
       }
       break;
@@ -986,6 +998,9 @@ void TransportController::processCommands() {
 
           trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
           clip.currentSample = trimIn;
+          clip.sourcePosition = static_cast<double>(trimIn);
+          clip.playDelayFramesRemaining = clip.playDelayFrames.load(std::memory_order_relaxed);
+          clip.isNaturalEnding = false;
           if (clip.source) {
             clip.source->setDemand(trimIn);
           }
@@ -1023,6 +1038,7 @@ void TransportController::processCommands() {
           foundAnyVoice = true;
           ActiveClip& clip = m_activeClips[i];
           clip.currentSample = position;
+          clip.sourcePosition = static_cast<double>(position);
           if (clip.source) {
             clip.source->setDemand(position);
           }
@@ -1052,9 +1068,24 @@ void TransportController::processCommands() {
           clip.fadeOutCurve.store(cmd.data.metadata.fadeOutCurve, std::memory_order_release);
           clip.fadeInSamples.store(cmd.data.metadata.fadeInSamples, std::memory_order_release);
           clip.fadeOutSamples.store(cmd.data.metadata.fadeOutSamples, std::memory_order_release);
+          clip.stopFadeOutSamples.store(cmd.data.metadata.stopFadeOutSamples,
+                                        std::memory_order_release);
+          clip.stopFadeOutSeconds.store(cmd.data.metadata.stopFadeOutSeconds,
+                                        std::memory_order_release);
+          clip.stopFadeOutCurve.store(cmd.data.metadata.stopFadeOutCurve,
+                                      std::memory_order_release);
           clip.loopEnabled.store(cmd.data.metadata.loopEnabled, std::memory_order_release);
           clip.gainDb.store(cmd.data.metadata.gainDb, std::memory_order_release);
           clip.gainLinear.store(cmd.data.metadata.gainLinear, std::memory_order_release);
+          clip.muted.store(cmd.data.metadata.muted, std::memory_order_release);
+          clip.pan.store(cmd.data.metadata.pan, std::memory_order_release);
+          clip.panLeftGain.store(cmd.data.metadata.panLeftGain, std::memory_order_release);
+          clip.panRightGain.store(cmd.data.metadata.panRightGain, std::memory_order_release);
+          clip.playbackRate.store(cmd.data.metadata.playbackRate, std::memory_order_release);
+          clip.playDelayFrames.store(cmd.data.metadata.playDelayFrames, std::memory_order_release);
+          if (clip.playDelayFramesRemaining > 0) {
+            clip.playDelayFramesRemaining = cmd.data.metadata.playDelayFrames;
+          }
           clip.routingGroup = cmd.data.metadata.routingGroup;
           configureVoiceRouting(i, clip.routingGroup, clip.numChannels);
         }
@@ -1149,11 +1180,13 @@ uint64_t TransportController::allocateVoiceStartOrdinal() noexcept {
   ++m_nextVoiceStartOrdinal;
   return ordinal;
 }
-
 void TransportController::restartVoiceInPlace(ActiveClip& clip) {
   // ORP127 G5: reset a live voice to its trim IN for an in-place restart.
   int64_t trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
   clip.currentSample = trimIn;
+  clip.sourcePosition = static_cast<double>(trimIn);
+  clip.playDelayFramesRemaining = clip.playDelayFrames.load(std::memory_order_relaxed);
+  clip.isNaturalEnding = false;
   if (clip.source) {
     clip.source->setDemand(trimIn);
   }
@@ -1204,6 +1237,9 @@ bool TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
 
     const int64_t trimIn = primary->trimInSamples.load(std::memory_order_relaxed);
     primary->currentSample = trimIn;
+    primary->sourcePosition = static_cast<double>(trimIn);
+    primary->playDelayFramesRemaining = primary->playDelayFrames.load(std::memory_order_relaxed);
+    primary->isNaturalEnding = false;
     if (primary->source)
       primary->source->setDemand(trimIn);
     primary->isStopping = false;
@@ -1238,8 +1274,12 @@ bool TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
 void TransportController::configureVoiceRouting(size_t voiceIndex, RoutingGroupIndex group,
                                                 uint16_t numChannels) noexcept {
   const size_t laneBase = voiceIndex * m_config.maxSourceChannels;
+  const bool panMonoToStereo = numChannels == 1 && m_config.maxSourceChannels > 1 &&
+                               group < m_config.numGroups &&
+                               m_groupOutputWidths[group].load(std::memory_order_relaxed) >= 2;
+  const uint16_t renderedChannels = panMonoToStereo ? 2 : numChannels;
   for (uint32_t lane = 0; lane < m_config.maxSourceChannels; ++lane) {
-    const bool activeLane = lane < numChannels;
+    const bool activeLane = lane < renderedChannels;
     const auto routeGroup = activeLane ? group : UNASSIGNED_GROUP;
     const auto output =
         activeLane ? static_cast<RoutingOutputIndex>(lane) : static_cast<RoutingOutputIndex>(0);
@@ -1286,6 +1326,7 @@ bool TransportController::setVoiceSnapshotFieldsForTesting(uint32_t voiceId, boo
     voice.trimInSamples.store(trimIn, std::memory_order_relaxed);
     voice.trimOutSamples.store(trimOut, std::memory_order_relaxed);
     voice.currentSample = currentSample;
+    voice.sourcePosition = static_cast<double>(currentSample);
     return true;
   }
   return false;
@@ -1329,6 +1370,7 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   // Initialize clip with immutable context - NO MUTEX NEEDED HERE
   const size_t voiceIndex = m_activeClipCount++;
   ActiveClip& clip = m_activeClips[voiceIndex];
+  clip.sourcePosition = static_cast<double>(context->trimInSamples);
   clip.handle = handle;
   clip.voiceId = voiceId;
   clip.startOrdinal = startOrdinal;
@@ -1345,22 +1387,34 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   clip.fadeInCurve.store(context->fadeInCurve, std::memory_order_release);
   clip.fadeOutCurve.store(context->fadeOutCurve, std::memory_order_release);
 
-  // Calculate and store fade sample counts
-  int64_t fadeInSampleCount =
+  // Calculate and store fade sample counts.
+  const int64_t fadeInSampleCount =
       static_cast<int64_t>(context->fadeInSeconds * static_cast<double>(m_sampleRate));
-  int64_t fadeOutSampleCount =
+  const int64_t fadeOutSampleCount =
       static_cast<int64_t>(context->fadeOutSeconds * static_cast<double>(m_sampleRate));
+  const int64_t stopFadeOutSampleCount =
+      static_cast<int64_t>(context->stopFadeOutSeconds * static_cast<double>(m_sampleRate));
   clip.fadeInSamples.store(fadeInSampleCount, std::memory_order_release);
   clip.fadeOutSamples.store(fadeOutSampleCount, std::memory_order_release);
+  clip.stopFadeOutSeconds.store(context->stopFadeOutSeconds, std::memory_order_release);
+  clip.stopFadeOutCurve.store(context->stopFadeOutCurve, std::memory_order_release);
+  clip.stopFadeOutSamples.store(stopFadeOutSampleCount, std::memory_order_release);
 
-  // Initialize gain (start the smoother AT the target so the clip opens at its
-  // configured gain with no initial ramp — ORP127 G4).
+  // A muted start must remain silent from its first frame. Unmuting later
+  // ramps from zero through the normal gain-smoothing path.
   clip.gainDb.store(context->gainDb, std::memory_order_release);
   clip.gainLinear.store(context->gainLinear, std::memory_order_release);
-  clip.gainCurrent = context->gainLinear;
+  clip.gainCurrent = context->muted ? 0.0f : context->gainLinear;
   clip.gainRampIncrement = m_clipGainRampIncrement;
 
   // Initialize loop mode
+  clip.muted.store(context->muted, std::memory_order_release);
+  clip.pan.store(context->pan, std::memory_order_release);
+  clip.panLeftGain.store(context->panLeftGain, std::memory_order_release);
+  clip.panRightGain.store(context->panRightGain, std::memory_order_release);
+  clip.playbackRate.store(context->playbackRate, std::memory_order_release);
+  clip.playDelayFrames.store(context->playDelayFrames, std::memory_order_release);
+  clip.playDelayFramesRemaining = context->playDelayFrames;
   clip.loopEnabled.store(context->loopEnabled, std::memory_order_release);
 
   clip.source = context->source; // Store shared_ptr (maintains reference count)
@@ -1375,6 +1429,7 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
 
   // Initialize restart crossfade state
   clip.isRestarting = false;
+  clip.isNaturalEnding = false;
   clip.restartFadeFramesRemaining = 0;
 
   // ORP097 Bug 7 Fix: Initialize loop state
@@ -1402,6 +1457,7 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
         dest.startOrdinal = src.startOrdinal;
         dest.startSample = src.startSample;
         dest.currentSample = src.currentSample;
+        dest.sourcePosition = src.sourcePosition;
         dest.trimInSamples.store(src.trimInSamples.load(std::memory_order_relaxed),
                                  std::memory_order_relaxed);
         dest.trimOutSamples.store(src.trimOutSamples.load(std::memory_order_relaxed),
@@ -1418,6 +1474,13 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
                                  std::memory_order_relaxed);
         dest.fadeOutSamples.store(src.fadeOutSamples.load(std::memory_order_relaxed),
                                   std::memory_order_relaxed);
+        dest.stopFadeOutSeconds.store(src.stopFadeOutSeconds.load(std::memory_order_relaxed),
+                                      std::memory_order_relaxed);
+        dest.stopFadeOutCurve.store(src.stopFadeOutCurve.load(std::memory_order_relaxed),
+                                    std::memory_order_relaxed);
+        dest.stopFadeOutSamples.store(src.stopFadeOutSamples.load(std::memory_order_relaxed),
+                                      std::memory_order_relaxed);
+        dest.stopFadeFramesElapsed = src.stopFadeFramesElapsed;
         dest.gainDb.store(src.gainDb.load(std::memory_order_relaxed), std::memory_order_relaxed);
         // ORP127 G4: carry the linear gain target + smoothing ramp state across
         // the slot move (gainLinear was previously not copied here).
@@ -1425,11 +1488,23 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
                               std::memory_order_relaxed);
         dest.gainCurrent = src.gainCurrent;
         dest.gainRampIncrement = src.gainRampIncrement;
+        dest.muted.store(src.muted.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        dest.pan.store(src.pan.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        dest.panLeftGain.store(src.panLeftGain.load(std::memory_order_relaxed),
+                               std::memory_order_relaxed);
+        dest.panRightGain.store(src.panRightGain.load(std::memory_order_relaxed),
+                                std::memory_order_relaxed);
+        dest.playbackRate.store(src.playbackRate.load(std::memory_order_relaxed),
+                                std::memory_order_relaxed);
+        dest.playDelayFrames.store(src.playDelayFrames.load(std::memory_order_relaxed),
+                                   std::memory_order_relaxed);
+        dest.playDelayFramesRemaining = src.playDelayFramesRemaining;
         dest.loopEnabled.store(src.loopEnabled.load(std::memory_order_relaxed),
                                std::memory_order_relaxed);
         dest.fadeOutGain = src.fadeOutGain;
         dest.isStopping = src.isStopping;
         dest.fadeOutStartPos = src.fadeOutStartPos;
+        dest.isNaturalEnding = src.isNaturalEnding;
         dest.isRestarting = src.isRestarting;
         dest.restartFadeFramesRemaining = src.restartFadeFramesRemaining;
         dest.hasLoopedOnce = src.hasLoopedOnce;
@@ -1441,6 +1516,7 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
         configureVoiceRouting(i, dest.routingGroup, dest.numChannels);
       }
       configureVoiceRouting(m_activeClipCount - 1, UNASSIGNED_GROUP, 0);
+      m_activeClips[m_activeClipCount - 1].source.reset();
       --m_activeClipCount;
       return;
     }
@@ -1448,60 +1524,9 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
 }
 
 void TransportController::removeActiveClip(ClipHandle handle) {
-  // Multi-voice: This removes FIRST instance found (deprecated - use removeActiveVoice)
-  for (size_t i = 0; i < m_activeClipCount; ++i) {
-    if (m_activeClips[i].handle == handle) {
-      // Remove by moving last clip into this slot (manual field-by-field copy since atomic fields
-      // can't be copied)
-      if (i < m_activeClipCount - 1) {
-        ActiveClip& dest = m_activeClips[i];
-        ActiveClip& src = m_activeClips[m_activeClipCount - 1];
-
-        dest.handle = src.handle;
-        dest.voiceId = src.voiceId; // Multi-voice: copy voice ID
-        dest.startOrdinal = src.startOrdinal;
-        dest.startSample = src.startSample;
-        dest.currentSample = src.currentSample;
-        dest.trimInSamples.store(src.trimInSamples.load(std::memory_order_relaxed),
-                                 std::memory_order_relaxed);
-        dest.trimOutSamples.store(src.trimOutSamples.load(std::memory_order_relaxed),
-                                  std::memory_order_relaxed);
-        dest.fadeInSeconds.store(src.fadeInSeconds.load(std::memory_order_relaxed),
-                                 std::memory_order_relaxed);
-        dest.fadeOutSeconds.store(src.fadeOutSeconds.load(std::memory_order_relaxed),
-                                  std::memory_order_relaxed);
-        dest.fadeInCurve.store(src.fadeInCurve.load(std::memory_order_relaxed),
-                               std::memory_order_relaxed);
-        dest.fadeOutCurve.store(src.fadeOutCurve.load(std::memory_order_relaxed),
-                                std::memory_order_relaxed);
-        dest.fadeInSamples.store(src.fadeInSamples.load(std::memory_order_relaxed),
-                                 std::memory_order_relaxed);
-        dest.fadeOutSamples.store(src.fadeOutSamples.load(std::memory_order_relaxed),
-                                  std::memory_order_relaxed);
-        dest.gainDb.store(src.gainDb.load(std::memory_order_relaxed), std::memory_order_relaxed);
-        // ORP127 G4: carry the linear gain target + smoothing ramp state across
-        // the slot move (gainLinear was previously not copied here).
-        dest.gainLinear.store(src.gainLinear.load(std::memory_order_relaxed),
-                              std::memory_order_relaxed);
-        dest.gainCurrent = src.gainCurrent;
-        dest.gainRampIncrement = src.gainRampIncrement;
-        dest.loopEnabled.store(src.loopEnabled.load(std::memory_order_relaxed),
-                               std::memory_order_relaxed);
-        dest.fadeOutGain = src.fadeOutGain;
-        dest.isStopping = src.isStopping;
-        dest.fadeOutStartPos = src.fadeOutStartPos;
-        dest.isRestarting = src.isRestarting;
-        dest.restartFadeFramesRemaining = src.restartFadeFramesRemaining;
-        dest.hasLoopedOnce = src.hasLoopedOnce; // ORP097 Bug 7 Fix
-        dest.source = src.source;               // Copy shared_ptr (atomic refcount increment)
-        dest.numChannels = src.numChannels;
-        dest.fileLengthSamples = src.fileLengthSamples;
-        dest.voiceMode = src.voiceMode;
-        dest.routingGroup = src.routingGroup;
-        configureVoiceRouting(i, dest.routingGroup, dest.numChannels);
-      }
-      configureVoiceRouting(m_activeClipCount - 1, UNASSIGNED_GROUP, 0);
-      --m_activeClipCount;
+  for (size_t index = 0; index < m_activeClipCount; ++index) {
+    if (m_activeClips[index].handle == handle) {
+      removeActiveVoice(m_activeClips[index].voiceId);
       return;
     }
   }
@@ -1782,8 +1807,16 @@ SessionGraphError TransportController::registerClipAudio(ClipHandle handle,
     entry.speakerPatchSize = inferred->num_channels;
     std::copy_n(inferred->channel_map.begin(), inferred->num_channels, entry.speakerPatch.begin());
   }
+  const double clipDurationSeconds =
+      static_cast<double>(entry.metadata.duration_samples) / static_cast<double>(m_sampleRate);
+  entry.stopFadeOutSeconds = std::min(m_sessionDefaults.stopFadeOutSeconds, clipDurationSeconds);
+  entry.stopFadeOutCurve = m_sessionDefaults.stopFadeOutCurve;
 
   // Apply session defaults to new clip
+  entry.muted = m_sessionDefaults.muted;
+  entry.pan = m_sessionDefaults.pan;
+  entry.playbackRate = m_sessionDefaults.playbackRate;
+  entry.playDelaySeconds = m_sessionDefaults.playDelaySeconds;
   entry.fadeInSeconds = m_sessionDefaults.fadeInSeconds;
   entry.fadeOutSeconds = m_sessionDefaults.fadeOutSeconds;
   entry.fadeInCurve = m_sessionDefaults.fadeInCurve;
@@ -1991,6 +2024,8 @@ SessionGraphError TransportController::updateClipFades(ClipHandle handle, double
       it->second.fadeOutSeconds = fadeOutSeconds;
       it->second.fadeInCurve = fadeInCurve;
       it->second.fadeOutCurve = fadeOutCurve;
+      it->second.stopFadeOutSeconds = fadeOutSeconds;
+      it->second.stopFadeOutCurve = fadeOutCurve;
     }
   }
 
@@ -2185,9 +2220,19 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   if (metadata.fadeOutSeconds < 0.0 || metadata.fadeOutSeconds > clipDurationSeconds) {
     return SessionGraphError::InvalidFadeDuration;
   }
+  if (!std::isfinite(metadata.stopFadeOutSeconds) || metadata.stopFadeOutSeconds < 0.0 ||
+      metadata.stopFadeOutSeconds > clipDurationSeconds) {
+    return SessionGraphError::InvalidFadeDuration;
+  }
 
   // Validate gain
   if (!std::isfinite(metadata.gainDb)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  if (!std::isfinite(metadata.pan) || metadata.pan < -1.0f || metadata.pan > 1.0f ||
+      !std::isfinite(metadata.playbackRate) || metadata.playbackRate < 0.25 ||
+      metadata.playbackRate > 4.0 || !std::isfinite(metadata.playDelaySeconds) ||
+      metadata.playDelaySeconds < 0.0 || metadata.playDelaySeconds > 99.9) {
     return SessionGraphError::InvalidParameter;
   }
 
@@ -2206,6 +2251,11 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
       static_cast<int64_t>(metadata.fadeInSeconds * static_cast<double>(m_sampleRate));
   int64_t fadeOutSampleCount =
       static_cast<int64_t>(metadata.fadeOutSeconds * static_cast<double>(m_sampleRate));
+  const int64_t stopFadeOutSampleCount =
+      static_cast<int64_t>(metadata.stopFadeOutSeconds * static_cast<double>(m_sampleRate));
+  const int64_t playDelayFrames =
+      static_cast<int64_t>(metadata.playDelaySeconds * static_cast<double>(m_sampleRate));
+  const auto [panLeftGain, panRightGain] = panGains(metadata.pan, fileChannels);
 
   // ORP127 G1: Apply to active voices via a command on the audio thread — no
   // direct writes to the live voice array from the UI thread. Precompute linear
@@ -2221,9 +2271,18 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   cmd.data.metadata.fadeOutSeconds = metadata.fadeOutSeconds;
   cmd.data.metadata.fadeInCurve = metadata.fadeInCurve;
   cmd.data.metadata.fadeOutCurve = metadata.fadeOutCurve;
+  cmd.data.metadata.stopFadeOutSamples = stopFadeOutSampleCount;
+  cmd.data.metadata.stopFadeOutSeconds = metadata.stopFadeOutSeconds;
+  cmd.data.metadata.stopFadeOutCurve = metadata.stopFadeOutCurve;
   cmd.data.metadata.loopEnabled = metadata.loopEnabled;
   cmd.data.metadata.gainDb = metadata.gainDb;
   cmd.data.metadata.gainLinear = std::pow(10.0f, metadata.gainDb / 20.0f);
+  cmd.data.metadata.muted = metadata.muted;
+  cmd.data.metadata.pan = metadata.pan;
+  cmd.data.metadata.panLeftGain = panLeftGain;
+  cmd.data.metadata.panRightGain = panRightGain;
+  cmd.data.metadata.playbackRate = metadata.playbackRate;
+  cmd.data.metadata.playDelayFrames = playDelayFrames;
   cmd.data.metadata.routingGroup = metadata.routingGroup;
 
   // Queue admission precedes the persistent commit. A full ring therefore
@@ -2246,10 +2305,16 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
     it->second.fadeOutSeconds = metadata.fadeOutSeconds;
     it->second.fadeInCurve = metadata.fadeInCurve;
     it->second.fadeOutCurve = metadata.fadeOutCurve;
+    it->second.stopFadeOutSeconds = metadata.stopFadeOutSeconds;
+    it->second.stopFadeOutCurve = metadata.stopFadeOutCurve;
     it->second.loopEnabled = metadata.loopEnabled;
     it->second.stopOthersOnPlay = metadata.stopOthersOnPlay;
     it->second.voiceMode = metadata.voiceMode;
     it->second.gainDb = metadata.gainDb;
+    it->second.muted = metadata.muted;
+    it->second.pan = metadata.pan;
+    it->second.playbackRate = metadata.playbackRate;
+    it->second.playDelaySeconds = metadata.playDelaySeconds;
     it->second.routingGroup = metadata.routingGroup;
     it->second.sourceLayout = metadata.sourceLayout;
     it->second.speakerPatchSize = metadata.speakerPatchSize;
@@ -2278,10 +2343,16 @@ std::optional<ClipMetadata> TransportController::getClipMetadata(ClipHandle hand
   metadata.fadeOutSeconds = it->second.fadeOutSeconds;
   metadata.fadeInCurve = it->second.fadeInCurve;
   metadata.fadeOutCurve = it->second.fadeOutCurve;
+  metadata.stopFadeOutSeconds = it->second.stopFadeOutSeconds;
+  metadata.stopFadeOutCurve = it->second.stopFadeOutCurve;
   metadata.loopEnabled = it->second.loopEnabled;
   metadata.stopOthersOnPlay = it->second.stopOthersOnPlay;
   metadata.voiceMode = it->second.voiceMode; // ORP127 G5
   metadata.gainDb = it->second.gainDb;
+  metadata.muted = it->second.muted;
+  metadata.pan = it->second.pan;
+  metadata.playbackRate = it->second.playbackRate;
+  metadata.playDelaySeconds = it->second.playDelaySeconds;
   metadata.routingGroup = it->second.routingGroup;
   metadata.sourceLayout = it->second.sourceLayout;
   metadata.speakerPatchSize = it->second.speakerPatchSize;
@@ -2345,8 +2416,19 @@ float TransportController::calculateFadeGain(float normalizedPosition, FadeCurve
 }
 
 void TransportController::setSessionDefaults(const SessionDefaults& defaults) {
+  SessionDefaults sanitized = defaults;
+  if (!std::isfinite(sanitized.stopFadeOutSeconds) || sanitized.stopFadeOutSeconds < 0.0) {
+    sanitized.stopFadeOutSeconds = 0.01;
+  }
+  sanitized.pan = std::isfinite(sanitized.pan) ? std::clamp(sanitized.pan, -1.0f, 1.0f) : 0.0f;
+  sanitized.playbackRate =
+      std::isfinite(sanitized.playbackRate) ? std::clamp(sanitized.playbackRate, 0.25, 4.0) : 1.0;
+  sanitized.playDelaySeconds = std::isfinite(sanitized.playDelaySeconds)
+                                   ? std::clamp(sanitized.playDelaySeconds, 0.0, 99.9)
+                                   : 0.0;
+
   std::lock_guard<std::mutex> lock(m_audioFilesMutex);
-  m_sessionDefaults = defaults;
+  m_sessionDefaults = sanitized;
 }
 
 SessionDefaults TransportController::getSessionDefaults() const {

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -128,6 +128,42 @@ void beginOperatorStop(ActiveClip& clip) noexcept {
           : 0;
 }
 
+enum class PlaybackBoundaryAction : uint8_t { Ended, Advanced, Looped };
+
+int64_t playbackWindowStart(const ActiveClip& clip) noexcept {
+  return clip.segmentCount == 0 ? clip.trimInSamples.load(std::memory_order_relaxed)
+                                : clip.segments[clip.segmentIndex].startSample;
+}
+
+int64_t playbackWindowEnd(const ActiveClip& clip) noexcept {
+  return clip.segmentCount == 0 ? clip.trimOutSamples.load(std::memory_order_relaxed)
+                                : clip.segments[clip.segmentIndex].endSample;
+}
+
+void resetSegmentCursor(ActiveClip& clip) noexcept {
+  clip.segmentIndex = 0;
+  clip.segmentRepeatsRemaining = clip.segmentCount == 0 ? 0 : clip.segments[0].repeatCount;
+}
+
+PlaybackBoundaryAction advancePlaybackWindow(ActiveClip& clip, bool loopEnabled) noexcept {
+  if (clip.segmentCount != 0) {
+    if (clip.segmentRepeatsRemaining > 1) {
+      --clip.segmentRepeatsRemaining;
+      return PlaybackBoundaryAction::Advanced;
+    }
+    if (clip.segmentIndex + 1 < clip.segmentCount) {
+      ++clip.segmentIndex;
+      clip.segmentRepeatsRemaining = clip.segments[clip.segmentIndex].repeatCount;
+      return PlaybackBoundaryAction::Advanced;
+    }
+    if (!loopEnabled)
+      return PlaybackBoundaryAction::Ended;
+    resetSegmentCursor(clip);
+    return PlaybackBoundaryAction::Looped;
+  }
+  return loopEnabled ? PlaybackBoundaryAction::Looped : PlaybackBoundaryAction::Ended;
+}
+
 } // namespace
 
 TransportController::TransportController(core::SessionGraph* sessionGraph,
@@ -263,6 +299,8 @@ TransportController::makeStartContext(ClipHandle handle, bool requireRegisteredS
       context->gainDb = entry.gainDb;
       context->gainLinear = std::pow(10.0f, entry.gainDb / 20.0f);
       context->loopEnabled = entry.loopEnabled;
+      context->segmentCount = entry.segmentCount;
+      context->segments = entry.segments;
       context->routingGroup = entry.routingGroup;
       context->voiceMode = entry.voiceMode;
       return SessionGraphError::OK;
@@ -477,8 +515,6 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
       continue;
     }
 
-    const int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
-    const int64_t trimOut = clip.trimOutSamples.load(std::memory_order_acquire);
     const int64_t fadeInSampleCount = clip.fadeInSamples.load(std::memory_order_acquire);
     const int64_t fadeOutSampleCount = clip.fadeOutSamples.load(std::memory_order_acquire);
     const FadeCurve fadeInCurveType = clip.fadeInCurve.load(std::memory_order_acquire);
@@ -505,33 +541,47 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
     }
 
     while (outputFrame < numFrames) {
-      if (clip.sourcePosition < static_cast<double>(trimIn)) {
-        clip.sourcePosition = static_cast<double>(trimIn);
-        clip.currentSample = trimIn;
-        clip.source->setDemand(trimIn);
+      int64_t activeWindowStart = playbackWindowStart(clip);
+      int64_t activeWindowEnd = playbackWindowEnd(clip);
+      if (clip.sourcePosition < static_cast<double>(activeWindowStart)) {
+        clip.sourcePosition = static_cast<double>(activeWindowStart);
+        clip.currentSample = activeWindowStart;
+        clip.source->setDemand(activeWindowStart);
       }
 
-      if (!clip.isStopping && clip.sourcePosition >= static_cast<double>(trimOut)) {
-        if (loopEnabled) {
-          clip.sourcePosition = static_cast<double>(trimIn);
-          clip.currentSample = trimIn;
-          clip.source->setDemand(trimIn);
+      if (!clip.isStopping && clip.sourcePosition >= static_cast<double>(activeWindowEnd)) {
+        const auto boundary = advancePlaybackWindow(clip, loopEnabled);
+        if (boundary != PlaybackBoundaryAction::Ended) {
+          activeWindowStart = playbackWindowStart(clip);
+          activeWindowEnd = playbackWindowEnd(clip);
+          clip.sourcePosition = static_cast<double>(activeWindowStart);
+          clip.currentSample = activeWindowStart;
+          clip.source->setDemand(activeWindowStart);
           clip.hasLoopedOnce = true;
 
-          TransportEvent event{};
-          event.type = TransportEventType::ClipLooped;
-          event.handle = clip.handle;
-          event.voiceId = clip.voiceId;
-          event.position = getCurrentPosition();
-          postTransportEvent(event);
+          if (boundary == PlaybackBoundaryAction::Looped) {
+            TransportEvent event{};
+            event.type = TransportEventType::ClipLooped;
+            event.handle = clip.handle;
+            event.voiceId = clip.voiceId;
+            event.position = getCurrentPosition();
+            postTransportEvent(event);
+          }
         } else {
           clip.isStopping = true;
           clip.isNaturalEnding = true;
           clip.fadeOutGain = 1.0f;
-          clip.fadeOutStartPos = trimOut;
+          clip.fadeOutStartPos = activeWindowEnd;
           clip.stopFadeFramesElapsed = 0;
         }
       }
+
+      const bool atProgramStart =
+          clip.segmentCount == 0 ||
+          (clip.segmentIndex == 0 && clip.segmentRepeatsRemaining == clip.segments[0].repeatCount);
+      const bool atProgramEnd =
+          clip.segmentCount == 0 ||
+          (clip.segmentIndex + 1 == clip.segmentCount && clip.segmentRepeatsRemaining == 1);
 
       int64_t activeStopFadeSamples = 0;
       FadeCurve activeStopFadeCurve = operatorStopFadeCurve;
@@ -557,7 +607,7 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
         segmentFrames = std::min(
             segmentFrames, static_cast<size_t>(activeStopFadeSamples - clip.stopFadeFramesElapsed));
       } else {
-        const double sourceFramesToOut = static_cast<double>(trimOut) - clip.sourcePosition;
+        const double sourceFramesToOut = static_cast<double>(activeWindowEnd) - clip.sourcePosition;
         const size_t outputFramesToOut =
             static_cast<size_t>(std::max(1.0, std::ceil(sourceFramesToOut / playbackRate)));
         segmentFrames = std::min(segmentFrames, outputFramesToOut);
@@ -590,13 +640,14 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
       }
       std::array<float, 8> loopStartFrame{};
       bool hasLoopStartFrame = false;
-      if (loopEnabled && readStart + static_cast<int64_t>(requestedInputFrames) > trimOut) {
+      if (clip.segmentCount == 0 && loopEnabled &&
+          readStart + static_cast<int64_t>(requestedInputFrames) > activeWindowEnd) {
         size_t loopStartFramesRead = 0;
         hasLoopStartFrame =
-            clip.source->read(trimIn, loopStartFrame.data(), 1, loopStartFramesRead) &&
+            clip.source->read(activeWindowStart, loopStartFrame.data(), 1, loopStartFramesRead) &&
             loopStartFramesRead == 1;
         if (!hasLoopStartFrame) {
-          clip.source->setDemand(trimIn);
+          clip.source->setDemand(activeWindowStart);
         }
       }
 
@@ -638,19 +689,20 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
             static_cast<float>(localPosition - static_cast<double>(firstInputFrame));
 
         const int64_t relativePosition =
-            static_cast<int64_t>(std::floor(frameSourcePosition)) - trimIn;
+            static_cast<int64_t>(std::floor(frameSourcePosition)) - activeWindowStart;
         if (!loopEnabled) {
-          if (fadeInSampleCount > 0 && relativePosition >= 0 &&
+          if (atProgramStart && fadeInSampleCount > 0 && relativePosition >= 0 &&
               relativePosition < fadeInSampleCount) {
             const float fadePosition =
                 static_cast<float>(relativePosition) / static_cast<float>(fadeInSampleCount);
             gain *= calculateFadeGain(fadePosition, fadeInCurveType);
           }
 
-          const int64_t trimmedDuration = trimOut - trimIn;
-          if (fadeOutSampleCount > 0 && relativePosition >= trimmedDuration - fadeOutSampleCount) {
+          const int64_t activeWindowDuration = activeWindowEnd - activeWindowStart;
+          if (atProgramEnd && fadeOutSampleCount > 0 &&
+              relativePosition >= activeWindowDuration - fadeOutSampleCount) {
             const float fadePosition = std::clamp(
-                static_cast<float>(relativePosition - (trimmedDuration - fadeOutSampleCount)) /
+                static_cast<float>(relativePosition - (activeWindowDuration - fadeOutSampleCount)) /
                     static_cast<float>(fadeOutSampleCount),
                 0.0f, 1.0f);
             gain *= 1.0f - calculateFadeGain(fadePosition, fadeOutCurveType);
@@ -660,11 +712,14 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
         std::array<float, 8> sourceFrame{};
         for (size_t channel = 0; channel < numFileChannels; ++channel) {
           const float first = clipReadBuffer[firstInputFrame * numFileChannels + channel];
-          const bool secondFrameWraps =
-              loopEnabled && readStart + static_cast<int64_t>(secondInputFrame) >= trimOut;
-          const float second = secondFrameWraps
-                                   ? (hasLoopStartFrame ? loopStartFrame[channel] : first)
-                                   : clipReadBuffer[secondInputFrame * numFileChannels + channel];
+          const bool secondFrameCrossesWindow =
+              readStart + static_cast<int64_t>(secondInputFrame) >= activeWindowEnd;
+          const float second =
+              secondFrameCrossesWindow && clip.segmentCount != 0
+                  ? first
+                  : (secondFrameCrossesWindow && loopEnabled
+                         ? (hasLoopStartFrame ? loopStartFrame[channel] : first)
+                         : clipReadBuffer[secondInputFrame * numFileChannels + channel]);
           sourceFrame[channel] = first + (second - first) * fraction;
         }
 
@@ -771,29 +826,32 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
       continue;
     }
 
-    const int64_t clipTrimOut = clip.trimOutSamples.load(std::memory_order_acquire);
-    if (clip.currentSample >= clipTrimOut) {
+    const int64_t activeWindowEnd = playbackWindowEnd(clip);
+    if (clip.currentSample >= activeWindowEnd) {
       const bool shouldLoop = clip.loopEnabled.load(std::memory_order_acquire);
-      if (shouldLoop) {
-        const int64_t trimIn = clip.trimInSamples.load(std::memory_order_acquire);
-        clip.currentSample = trimIn;
-        clip.sourcePosition = static_cast<double>(trimIn);
+      const auto boundary = advancePlaybackWindow(clip, shouldLoop);
+      if (boundary != PlaybackBoundaryAction::Ended) {
+        const int64_t nextStart = playbackWindowStart(clip);
+        clip.currentSample = nextStart;
+        clip.sourcePosition = static_cast<double>(nextStart);
         if (clip.source) {
-          clip.source->setDemand(trimIn);
+          clip.source->setDemand(nextStart);
         }
         clip.hasLoopedOnce = true;
 
-        TransportEvent event{};
-        event.type = TransportEventType::ClipLooped;
-        event.handle = clip.handle;
-        event.voiceId = clip.voiceId;
-        event.position = getCurrentPosition();
-        postTransportEvent(event);
+        if (boundary == PlaybackBoundaryAction::Looped) {
+          TransportEvent event{};
+          event.type = TransportEventType::ClipLooped;
+          event.handle = clip.handle;
+          event.voiceId = clip.voiceId;
+          event.position = getCurrentPosition();
+          postTransportEvent(event);
+        }
       } else {
         clip.isStopping = true;
         clip.isNaturalEnding = true;
         clip.fadeOutGain = 1.0f;
-        clip.fadeOutStartPos = clipTrimOut;
+        clip.fadeOutStartPos = activeWindowEnd;
         clip.stopFadeFramesElapsed = 0;
       }
     }
@@ -998,20 +1056,21 @@ void TransportController::processCommands() {
       // ORP127 G1: Restart moved onto the audio thread (was a UI-thread mutation
       // of currentSample/reader/isStopping/hasLoopedOnce). Restart ALL voices
       // for the handle back to trim IN, applying the broadcast-safe crossfade.
-      int64_t trimIn = 0;
+      int64_t startPosition = 0;
       bool foundAnyVoice = false;
       for (size_t i = 0; i < m_activeClipCount; ++i) {
         if (m_activeClips[i].handle == cmd.handle) {
           foundAnyVoice = true;
           ActiveClip& clip = m_activeClips[i];
 
-          trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
-          clip.currentSample = trimIn;
-          clip.sourcePosition = static_cast<double>(trimIn);
+          resetSegmentCursor(clip);
+          startPosition = playbackWindowStart(clip);
+          clip.currentSample = startPosition;
+          clip.sourcePosition = static_cast<double>(startPosition);
           clip.playDelayFramesRemaining = clip.playDelayFrames.load(std::memory_order_relaxed);
           clip.isNaturalEnding = false;
           if (clip.source) {
-            clip.source->setDemand(trimIn);
+            clip.source->setDemand(startPosition);
           }
 
           // Cancel any fade-out in progress.
@@ -1032,7 +1091,7 @@ void TransportController::processCommands() {
         TransportEvent event{};
         event.type = TransportEventType::ClipRestarted;
         event.handle = cmd.handle;
-        event.position = positionAtSamples(trimIn);
+        event.position = positionAtSamples(startPosition);
         postTransportEvent(event);
       }
     } break;
@@ -1069,6 +1128,26 @@ void TransportController::processCommands() {
       for (size_t i = 0; i < m_activeClipCount; ++i) {
         if (m_activeClips[i].handle == cmd.handle) {
           ActiveClip& clip = m_activeClips[i];
+          const bool segmentProgramChanged =
+              clip.segmentCount != cmd.data.metadata.segmentCount ||
+              !std::equal(clip.segments.begin(),
+                          clip.segments.begin() +
+                              std::min(clip.segmentCount, cmd.data.metadata.segmentCount),
+                          cmd.data.metadata.segments.begin());
+          if (segmentProgramChanged) {
+            clip.segmentCount = cmd.data.metadata.segmentCount;
+            clip.segments = cmd.data.metadata.segments;
+            resetSegmentCursor(clip);
+            const int64_t startPosition =
+                clip.segmentCount == 0 ? cmd.data.metadata.trimIn : clip.segments[0].startSample;
+            clip.currentSample = startPosition;
+            clip.sourcePosition = static_cast<double>(startPosition);
+            clip.isStopping = false;
+            clip.isNaturalEnding = false;
+            if (clip.source) {
+              clip.source->setDemand(startPosition);
+            }
+          }
           clip.trimInSamples.store(cmd.data.metadata.trimIn, std::memory_order_release);
           clip.trimOutSamples.store(cmd.data.metadata.trimOut, std::memory_order_release);
           clip.fadeInSeconds.store(cmd.data.metadata.fadeInSeconds, std::memory_order_release);
@@ -1190,14 +1269,15 @@ uint64_t TransportController::allocateVoiceStartOrdinal() noexcept {
   return ordinal;
 }
 void TransportController::restartVoiceInPlace(ActiveClip& clip) {
-  // ORP127 G5: reset a live voice to its trim IN for an in-place restart.
-  int64_t trimIn = clip.trimInSamples.load(std::memory_order_relaxed);
-  clip.currentSample = trimIn;
-  clip.sourcePosition = static_cast<double>(trimIn);
+  // ORP127 G5: reset a live voice to its first programmed source window.
+  resetSegmentCursor(clip);
+  const int64_t startPosition = playbackWindowStart(clip);
+  clip.currentSample = startPosition;
+  clip.sourcePosition = static_cast<double>(startPosition);
   clip.playDelayFramesRemaining = clip.playDelayFrames.load(std::memory_order_relaxed);
   clip.isNaturalEnding = false;
   if (clip.source) {
-    clip.source->setDemand(trimIn);
+    clip.source->setDemand(startPosition);
   }
   clip.isStopping = false;
   clip.fadeOutGain = 1.0f;
@@ -1244,13 +1324,14 @@ bool TransportController::startVoiceWithMode(const std::shared_ptr<ClipPlaybackC
     if (!primary)
       return addActiveClip(context);
 
-    const int64_t trimIn = primary->trimInSamples.load(std::memory_order_relaxed);
-    primary->currentSample = trimIn;
-    primary->sourcePosition = static_cast<double>(trimIn);
+    resetSegmentCursor(*primary);
+    const int64_t startPosition = playbackWindowStart(*primary);
+    primary->currentSample = startPosition;
+    primary->sourcePosition = static_cast<double>(startPosition);
     primary->playDelayFramesRemaining = primary->playDelayFrames.load(std::memory_order_relaxed);
     primary->isNaturalEnding = false;
     if (primary->source)
-      primary->source->setDemand(trimIn);
+      primary->source->setDemand(startPosition);
     primary->isStopping = false;
     primary->fadeOutGain = 1.0f;
     primary->hasLoopedOnce = false;
@@ -1379,12 +1460,17 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   // Initialize clip with immutable context - NO MUTEX NEEDED HERE
   const size_t voiceIndex = m_activeClipCount++;
   ActiveClip& clip = m_activeClips[voiceIndex];
-  clip.sourcePosition = static_cast<double>(context->trimInSamples);
+  clip.segmentCount = context->segmentCount;
+  clip.segments = context->segments;
+  resetSegmentCursor(clip);
+  const int64_t startPosition =
+      clip.segmentCount == 0 ? context->trimInSamples : clip.segments[0].startSample;
+  clip.sourcePosition = static_cast<double>(startPosition);
   clip.handle = handle;
   clip.voiceId = voiceId;
   clip.startOrdinal = startOrdinal;
   clip.startSample = m_currentSample.load(std::memory_order_relaxed);
-  clip.currentSample = context->trimInSamples; // CRITICAL: Start from IN point
+  clip.currentSample = startPosition;
 
   // Initialize trim points
   clip.trimInSamples.store(context->trimInSamples, std::memory_order_release);
@@ -1444,10 +1530,10 @@ bool TransportController::addActiveClip(const std::shared_ptr<ClipPlaybackContex
   // ORP097 Bug 7 Fix: Initialize loop state
   clip.hasLoopedOnce = false;
 
-  // Prime the streaming prefetcher at the trim IN point (no-op for prepared
-  // sources; sources are position-explicit so there is nothing to seek).
+  // Prime the streaming prefetcher at the first programmed source window
+  // (no-op for prepared sources; reads remain position-explicit).
   if (clip.source) {
-    clip.source->setDemand(context->trimInSamples);
+    clip.source->setDemand(startPosition);
   }
   return true;
 }
@@ -1510,6 +1596,10 @@ void TransportController::removeActiveVoice(uint32_t voiceId) {
         dest.playDelayFramesRemaining = src.playDelayFramesRemaining;
         dest.loopEnabled.store(src.loopEnabled.load(std::memory_order_relaxed),
                                std::memory_order_relaxed);
+        dest.segmentCount = src.segmentCount;
+        dest.segmentIndex = src.segmentIndex;
+        dest.segmentRepeatsRemaining = src.segmentRepeatsRemaining;
+        dest.segments = src.segments;
         dest.fadeOutGain = src.fadeOutGain;
         dest.isStopping = src.isStopping;
         dest.fadeOutStartPos = src.fadeOutStartPos;
@@ -1943,6 +2033,12 @@ SessionGraphError TransportController::updateClipTrimPoints(ClipHandle handle,
       return SessionGraphError::ClipNotRegistered;
     }
     fileDurationSamples = it->second.metadata.duration_samples;
+    for (uint32_t index = 0; index < it->second.segmentCount; ++index) {
+      const auto& segment = it->second.segments[index];
+      if (segment.startSample < trimInSamples || segment.endSample > trimOutSamples) {
+        return SessionGraphError::InvalidClipTrimPoints;
+      }
+    }
   }
 
   // Validate trim points
@@ -2117,6 +2213,7 @@ SessionGraphError TransportController::updateClipGain(ClipHandle handle, float g
 }
 
 SessionGraphError TransportController::setClipLoopMode(ClipHandle handle, bool shouldLoop) {
+
   if (handle == 0) {
     return SessionGraphError::InvalidHandle;
   }
@@ -2217,6 +2314,18 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
     return SessionGraphError::InvalidClipTrimPoints;
   }
 
+  if (metadata.segmentCount > kMaxClipPlaybackSegments) {
+    return SessionGraphError::InvalidParameter;
+  }
+  for (uint32_t index = 0; index < metadata.segmentCount; ++index) {
+    const auto& segment = metadata.segments[index];
+    if (segment.startSample < metadata.trimInSamples || segment.endSample <= segment.startSample ||
+        segment.endSample > trimOut || segment.repeatCount == 0 ||
+        segment.repeatCount > kMaxClipSegmentRepeatCount) {
+      return SessionGraphError::InvalidParameter;
+    }
+  }
+
   // Validate fade durations
   int64_t clipDuration = trimOut - metadata.trimInSamples;
   double clipDurationSeconds =
@@ -2293,6 +2402,8 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
   cmd.data.metadata.playbackRate = metadata.playbackRate;
   cmd.data.metadata.playDelayFrames = playDelayFrames;
   cmd.data.metadata.routingGroup = metadata.routingGroup;
+  cmd.data.metadata.segmentCount = metadata.segmentCount;
+  cmd.data.metadata.segments = metadata.segments;
 
   // Queue admission precedes the persistent commit. A full ring therefore
   // cannot publish metadata that active voices did not receive, which is
@@ -2328,6 +2439,8 @@ SessionGraphError TransportController::updateClipMetadata(ClipHandle handle,
     it->second.sourceLayout = metadata.sourceLayout;
     it->second.speakerPatchSize = metadata.speakerPatchSize;
     it->second.speakerPatch = metadata.speakerPatch;
+    it->second.segmentCount = metadata.segmentCount;
+    it->second.segments = metadata.segments;
   }
 
   return SessionGraphError::OK;
@@ -2355,6 +2468,8 @@ std::optional<ClipMetadata> TransportController::getClipMetadata(ClipHandle hand
   metadata.stopFadeOutSeconds = it->second.stopFadeOutSeconds;
   metadata.stopFadeOutCurve = it->second.stopFadeOutCurve;
   metadata.loopEnabled = it->second.loopEnabled;
+  metadata.segmentCount = it->second.segmentCount;
+  metadata.segments = it->second.segments;
   metadata.stopOthersOnPlay = it->second.stopOthersOnPlay;
   metadata.voiceMode = it->second.voiceMode; // ORP127 G5
   metadata.gainDb = it->second.gainDb;

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -529,6 +529,10 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
     const float clipGainTarget = muted ? 0.0f : clip.gainLinear.load(std::memory_order_acquire);
     const size_t numFileChannels = clip.numChannels;
     const size_t laneBase = voiceIndex * m_config.maxSourceChannels;
+    const bool panMonoToStereo =
+        numFileChannels == 1 && m_config.maxSourceChannels > 1 &&
+        clip.routingGroup < m_config.numGroups &&
+        m_groupOutputWidths[clip.routingGroup].load(std::memory_order_relaxed) >= 2;
     float* const clipReadBuffer = m_clipReadBuffers[voiceIndex].data();
     const size_t clipReadBufferSize = m_clipReadBuffers[voiceIndex].size();
 
@@ -725,12 +729,13 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
 
         const size_t destinationFrame = outputFrame + frame;
         if (m_config.sourceChannelPolicy == SourceChannelPolicy::Discrete) {
-          if (numFileChannels == 1 && m_config.maxSourceChannels > 1) {
+          if (panMonoToStereo) {
             m_clipChannelBuffers[laneBase][destinationFrame] = sourceFrame[0] * gain * panLeft;
             m_clipChannelBuffers[laneBase + 1][destinationFrame] = sourceFrame[0] * gain * panRight;
           } else {
             for (size_t channel = 0; channel < numFileChannels; ++channel) {
-              const float panGain = channel == 0 ? panLeft : (channel == 1 ? panRight : 1.0f);
+              const float panGain =
+                  channel == 0 && numFileChannels > 1 ? panLeft : (channel == 1 ? panRight : 1.0f);
               m_clipChannelBuffers[laneBase + channel][destinationFrame] =
                   sourceFrame[channel] * gain * panGain;
             }
@@ -2087,6 +2092,9 @@ SessionGraphError TransportController::updateClipFades(ClipHandle handle, double
       return SessionGraphError::ClipNotRegistered;
     }
     fileDurationSamples = it->second.metadata.duration_samples;
+    currentTrimIn = it->second.trimInSamples;
+    currentTrimOut =
+        it->second.trimOutSamples == 0 ? fileDurationSamples : it->second.trimOutSamples;
   }
 
   // Get current trim points (or use defaults). ORP127 G1: read from the
@@ -2103,8 +2111,10 @@ SessionGraphError TransportController::updateClipFades(ClipHandle handle, double
   }
 
   if (!foundActiveClip) {
-    currentTrimIn = 0;
-    currentTrimOut = fileDurationSamples;
+    // Preserve the registered trim window for stopped clips. This legacy
+    // convenience method also configures the operator-stop fade, so accepting
+    // a full-file fade here would violate that window at the next start.
+    currentTrimOut = currentTrimOut == 0 ? fileDurationSamples : currentTrimOut;
   }
 
   // Validate fade durations

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -115,6 +115,18 @@ std::pair<float, float> panGains(float pan, uint16_t numChannels) noexcept {
       static_cast<double>(std::max(-normalized, 0.0f)) * static_cast<double>(M_PI_2);
   return {static_cast<float>(std::cos(leftAngle)), static_cast<float>(std::cos(rightAngle))};
 }
+void beginOperatorStop(ActiveClip& clip) noexcept {
+  const bool wasWaitingForDelay = clip.playDelayFramesRemaining > 0;
+  clip.isStopping = true;
+  clip.isNaturalEnding = false;
+  clip.fadeOutGain = 1.0f;
+  clip.fadeOutStartPos = clip.currentSample;
+  clip.playDelayFramesRemaining = 0;
+  clip.stopFadeFramesElapsed =
+      wasWaitingForDelay
+          ? std::max<int64_t>(clip.stopFadeOutSamples.load(std::memory_order_relaxed), 0)
+          : 0;
+}
 
 } // namespace
 
@@ -576,6 +588,17 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
         clip.source->setDemand(readStart);
         framesRead = 0;
       }
+      std::array<float, 8> loopStartFrame{};
+      bool hasLoopStartFrame = false;
+      if (loopEnabled && readStart + static_cast<int64_t>(requestedInputFrames) > trimOut) {
+        size_t loopStartFramesRead = 0;
+        hasLoopStartFrame =
+            clip.source->read(trimIn, loopStartFrame.data(), 1, loopStartFramesRead) &&
+            loopStartFramesRead == 1;
+        if (!hasLoopStartFrame) {
+          clip.source->setDemand(trimIn);
+        }
+      }
 
       for (size_t frame = 0; frame < segmentFrames; ++frame) {
         if (clip.gainCurrent < clipGainTarget) {
@@ -637,7 +660,11 @@ void TransportController::processAudio(float* const* outputBuffers, size_t numCh
         std::array<float, 8> sourceFrame{};
         for (size_t channel = 0; channel < numFileChannels; ++channel) {
           const float first = clipReadBuffer[firstInputFrame * numFileChannels + channel];
-          const float second = clipReadBuffer[secondInputFrame * numFileChannels + channel];
+          const bool secondFrameWraps =
+              loopEnabled && readStart + static_cast<int64_t>(secondInputFrame) >= trimOut;
+          const float second = secondFrameWraps
+                                   ? (hasLoopStartFrame ? loopStartFrame[channel] : first)
+                                   : clipReadBuffer[secondInputFrame * numFileChannels + channel];
           sourceFrame[channel] = first + (second - first) * fraction;
         }
 
@@ -836,11 +863,7 @@ void TransportController::processCommands() {
         for (size_t i = 0; i < m_activeClipCount; ++i) {
           ActiveClip& peer = m_activeClips[i];
           if (peer.handle != cmd.handle && peer.routingGroup == group && !peer.isStopping) {
-            peer.isStopping = true;
-            peer.fadeOutGain = 1.0f;
-            peer.fadeOutStartPos = peer.currentSample;
-            peer.stopFadeFramesElapsed = 0;
-            peer.isNaturalEnding = false;
+            beginOperatorStop(peer);
           }
         }
       }
@@ -850,24 +873,14 @@ void TransportController::processCommands() {
       // Multi-voice: Stop ALL voice instances for this handle
       for (size_t i = 0; i < m_activeClipCount; ++i) {
         if (m_activeClips[i].handle == cmd.handle && !m_activeClips[i].isStopping) {
-          m_activeClips[i].isStopping = true;
-          m_activeClips[i].fadeOutGain = 1.0f;
-          m_activeClips[i].fadeOutStartPos =
-              m_activeClips[i].currentSample; // Record position when fade-out started
-          m_activeClips[i].stopFadeFramesElapsed = 0;
-          m_activeClips[i].isNaturalEnding = false;
+          beginOperatorStop(m_activeClips[i]);
         }
       }
     } break;
 
     case TransportCommand::Type::StopAll:
       for (size_t i = 0; i < m_activeClipCount; ++i) {
-        m_activeClips[i].isStopping = true;
-        m_activeClips[i].fadeOutGain = 1.0f;
-        m_activeClips[i].fadeOutStartPos =
-            m_activeClips[i].currentSample; // Record position when fade-out started
-        m_activeClips[i].stopFadeFramesElapsed = 0;
-        m_activeClips[i].isNaturalEnding = false;
+        beginOperatorStop(m_activeClips[i]);
       }
       break;
 
@@ -899,11 +912,7 @@ void TransportController::processCommands() {
       // ORP127 G7: choke primitive — stop every voice except cmd.handle.
       for (size_t i = 0; i < m_activeClipCount; ++i) {
         if (m_activeClips[i].handle != cmd.handle && !m_activeClips[i].isStopping) {
-          m_activeClips[i].isStopping = true;
-          m_activeClips[i].fadeOutGain = 1.0f;
-          m_activeClips[i].fadeOutStartPos = m_activeClips[i].currentSample;
-          m_activeClips[i].stopFadeFramesElapsed = 0;
-          m_activeClips[i].isNaturalEnding = false;
+          beginOperatorStop(m_activeClips[i]);
         }
       }
       break;

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -49,6 +49,8 @@ struct ClipPlaybackContext {
   double playbackRate;
   int64_t playDelayFrames;
   bool loopEnabled;
+  uint32_t segmentCount{0};
+  std::array<ClipPlaybackSegment, kMaxClipPlaybackSegments> segments{};
   uint16_t numChannels;
   RoutingGroupIndex routingGroup{0};
   VoiceMode voiceMode; // ORP127 G5: voice policy captured at fire time
@@ -130,9 +132,14 @@ struct TransportCommand {
       double playbackRate;
       int64_t playDelayFrames;
       RoutingGroupIndex routingGroup;
+      uint32_t segmentCount;
+      std::array<ClipPlaybackSegment, kMaxClipPlaybackSegments> segments;
     } metadata;
   } data;
+
+  TransportCommand() noexcept : type(Type::Start), handle(0), data{} {}
 };
+static_assert(std::is_trivially_copyable_v<TransportCommand>);
 
 /// Active clip state (in audio thread)
 struct ActiveClip {
@@ -185,6 +192,10 @@ struct ActiveClip {
 
   // Loop mode (atomic for thread safety)
   std::atomic<bool> loopEnabled{false}; // true = loop indefinitely
+  uint32_t segmentCount{0};
+  uint32_t segmentIndex{0};
+  uint32_t segmentRepeatsRemaining{0};
+  std::array<ClipPlaybackSegment, kMaxClipPlaybackSegments> segments{};
 
   float fadeOutGain;       // 1.0 = normal, 0.0 = fully faded (for stop fade-out)
   bool isStopping;         // true if fade-out in progress
@@ -610,6 +621,8 @@ private:
     std::array<Speaker, MAX_FILE_CHANNELS> speakerPatch = {
         Speaker::None, Speaker::None, Speaker::None, Speaker::None,
         Speaker::None, Speaker::None, Speaker::None, Speaker::None};
+    uint32_t segmentCount = 0;
+    std::array<ClipPlaybackSegment, kMaxClipPlaybackSegments> segments{};
 
     // ORP134 G1: the realtime playback source built by prepareClipAudio()
     // (or lazily by startClip). The reader above remains the background

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -38,8 +38,16 @@ struct ClipPlaybackContext {
   double fadeOutSeconds;
   FadeCurve fadeInCurve;
   FadeCurve fadeOutCurve;
+  double stopFadeOutSeconds;
+  FadeCurve stopFadeOutCurve;
   float gainDb;
   float gainLinear;
+  bool muted;
+  float pan;
+  float panLeftGain;
+  float panRightGain;
+  double playbackRate;
+  int64_t playDelayFrames;
   bool loopEnabled;
   uint16_t numChannels;
   RoutingGroupIndex routingGroup{0};
@@ -109,9 +117,18 @@ struct TransportCommand {
       double fadeOutSeconds;
       FadeCurve fadeInCurve;
       FadeCurve fadeOutCurve;
+      int64_t stopFadeOutSamples;
+      double stopFadeOutSeconds;
+      FadeCurve stopFadeOutCurve;
       bool loopEnabled;
       float gainDb;
       float gainLinear;
+      bool muted;
+      float pan;
+      float panLeftGain;
+      float panRightGain;
+      double playbackRate;
+      int64_t playDelayFrames;
       RoutingGroupIndex routingGroup;
     } metadata;
   } data;
@@ -124,6 +141,7 @@ struct ActiveClip {
   uint64_t startOrdinal; // Chronological start generation (wrap-aware)
   int64_t startSample;   // When clip started playing (transport time)
   int64_t currentSample; // Current position within clip audio
+  double sourcePosition; // Fractional source cursor for varispeed interpolation
 
   // Trim points (atomic for thread safety)
   std::atomic<int64_t> trimInSamples{0};  // Trim IN point (from metadata)
@@ -143,10 +161,21 @@ struct ActiveClip {
   // Cached fade sample counts (computed when fades are updated)
   std::atomic<int64_t> fadeInSamples{0};
   std::atomic<int64_t> fadeOutSamples{0};
+  std::atomic<double> stopFadeOutSeconds{0.01};
+  std::atomic<FadeCurve> stopFadeOutCurve{FadeCurve::Linear};
+  std::atomic<int64_t> stopFadeOutSamples{0};
+  int64_t stopFadeFramesElapsed{0};
 
   // Gain control (atomic for thread safety)
   std::atomic<float> gainDb{0.0f};     // Gain in decibels (0.0 = unity)
   std::atomic<float> gainLinear{1.0f}; // Cached linear gain target (precomputed from gainDb)
+  std::atomic<bool> muted{false};
+  std::atomic<float> pan{0.0f};
+  std::atomic<float> panLeftGain{1.0f};
+  std::atomic<float> panRightGain{1.0f};
+  std::atomic<double> playbackRate{1.0};
+  std::atomic<int64_t> playDelayFrames{0};
+  int64_t playDelayFramesRemaining{0};
 
   // ORP127 G4: per-voice gain smoothing state (audio-thread only). gainCurrent
   // ramps toward gainLinear by gainRampIncrement per sample so Set-Gain changes
@@ -160,6 +189,7 @@ struct ActiveClip {
   float fadeOutGain;       // 1.0 = normal, 0.0 = fully faded (for stop fade-out)
   bool isStopping;         // true if fade-out in progress
   int64_t fadeOutStartPos; // Sample position when fade-out started (for additive time)
+  bool isNaturalEnding;    // true when OUT, false for operator/choke stop
 
   // Restart crossfade state (broadcast-safe restart mechanism)
   bool isRestarting; // true if restart crossfade in progress
@@ -561,9 +591,15 @@ private:
     double fadeOutSeconds = 0.0;
     FadeCurve fadeInCurve = FadeCurve::Linear;
     FadeCurve fadeOutCurve = FadeCurve::Linear;
+    double stopFadeOutSeconds = 0.01;
+    FadeCurve stopFadeOutCurve = FadeCurve::Linear;
     float gainDb = 0.0f;           // Gain in decibels (0.0 = unity)
     bool loopEnabled = false;      // true = loop indefinitely
     bool stopOthersOnPlay = false; // true = stop all other clips when this one starts
+    bool muted = false;
+    float pan = 0.0f;
+    double playbackRate = 1.0;
+    double playDelaySeconds = 0.0;
 
     // ORP127 G5: voice allocation policy for this clip (default preserves the
     // SDK's historical polyphonic behavior).

--- a/src/core/transport/transport_controller.h
+++ b/src/core/transport/transport_controller.h
@@ -139,7 +139,6 @@ struct TransportCommand {
 
   TransportCommand() noexcept : type(Type::Start), handle(0), data{} {}
 };
-static_assert(std::is_trivially_copyable_v<TransportCommand>);
 
 /// Active clip state (in audio thread)
 struct ActiveClip {

--- a/tests/transport/CMakeLists.txt
+++ b/tests/transport/CMakeLists.txt
@@ -244,6 +244,38 @@ if(TARGET orpheus_audio_io)
         COMMAND clip_gain_test
     )
 
+    # Per-clip audio-control contract tests (ORP152)
+    add_executable(clip_controls_test
+        clip_controls_test.cpp
+    )
+
+    target_link_libraries(clip_controls_test
+        PRIVATE
+            orpheus_transport
+            orpheus_audio_io
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+    )
+
+    if(SNDFILE_FOUND)
+        target_link_libraries(clip_controls_test PRIVATE ${SNDFILE_LIBRARIES})
+        if(SNDFILE_LIBRARY_DIRS)
+            target_link_directories(clip_controls_test PRIVATE ${SNDFILE_LIBRARY_DIRS})
+        endif()
+    endif()
+
+    target_include_directories(clip_controls_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src/core
+    )
+
+    add_test(
+        NAME clip_controls_test
+        COMMAND clip_controls_test
+    )
+
     # Clip loop tests (ORP099 Task 1.2)
     add_executable(clip_loop_test
         clip_loop_test.cpp
@@ -800,4 +832,5 @@ if(TARGET orpheus_audio_io)
         NAME sample_rate_conversion_test
         COMMAND sample_rate_conversion_test
     )
+
 endif()

--- a/tests/transport/clip_controls_test.cpp
+++ b/tests/transport/clip_controls_test.cpp
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+
+#include "../../src/core/transport/transport_controller.h"
+
+#include <orpheus/audio_file_writer.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <string>
+
+using namespace orpheus;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr int kFileFrames = 4096;
+
+void writeStereoFixture(const std::string& path) {
+  auto writer = createAudioFileWriter();
+  ASSERT_NE(writer, nullptr);
+
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::WAV;
+  config.sample_rate = kSampleRate;
+  config.num_channels = 2;
+  config.sample_format = AudioSampleFormat::Float32;
+  ASSERT_EQ(writer->open(path, config), SessionGraphError::OK);
+
+  std::array<float, kFileFrames * 2> samples{};
+  for (size_t frame = 0; frame < kFileFrames; ++frame) {
+    samples[frame * 2] = 0.25f;
+    samples[frame * 2 + 1] = 0.5f;
+  }
+  const Result<size_t> written = writer->writeSamples(samples.data(), kFileFrames);
+  ASSERT_TRUE(written.isOk()) << written.errorMessage;
+  ASSERT_EQ(written.value, kFileFrames);
+  ASSERT_EQ(writer->close(), SessionGraphError::OK);
+}
+
+class ClipAudioControlsTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    path = (std::filesystem::temp_directory_path() / "orpheus_clip_audio_controls.wav").string();
+    writeStereoFixture(path);
+    transport =
+        std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = kSampleRate});
+    ASSERT_EQ(transport->registerClipAudio(handle, path.c_str()), SessionGraphError::OK);
+  }
+
+  void TearDown() override {
+    transport.reset();
+    std::error_code error;
+    std::filesystem::remove(path, error);
+  }
+
+  ClipMetadata metadata() const {
+    const auto value = transport->getClipMetadata(handle);
+    EXPECT_TRUE(value.has_value());
+    return value.value_or(ClipMetadata{});
+  }
+
+  template <size_t Frames>
+  void render(std::array<float, Frames>& left, std::array<float, Frames>& right) {
+    left.fill(0.0f);
+    right.fill(0.0f);
+    float* outputs[] = {left.data(), right.data()};
+    transport->processAudio(outputs, 2, Frames);
+  }
+
+  std::unique_ptr<TransportController> transport;
+  std::string path;
+  const ClipHandle handle = 1;
+};
+
+TEST_F(ClipAudioControlsTest, MetadataRoundTripsAndRejectsUnsafeBounds) {
+  auto value = metadata();
+  value.stopFadeOutSeconds = 0.02;
+  value.stopFadeOutCurve = FadeCurve::Exponential;
+  value.muted = true;
+  value.pan = -0.4f;
+  value.playbackRate = 1.25;
+  value.playDelaySeconds = 0.05;
+
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  const auto restored = metadata();
+  EXPECT_DOUBLE_EQ(restored.stopFadeOutSeconds, 0.02);
+  EXPECT_EQ(restored.stopFadeOutCurve, FadeCurve::Exponential);
+  EXPECT_TRUE(restored.muted);
+  EXPECT_FLOAT_EQ(restored.pan, -0.4f);
+  EXPECT_DOUBLE_EQ(restored.playbackRate, 1.25);
+  EXPECT_DOUBLE_EQ(restored.playDelaySeconds, 0.05);
+
+  value.pan = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::InvalidParameter);
+  value.pan = 0.0f;
+  value.playbackRate = 4.01;
+  EXPECT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::InvalidParameter);
+  value.playbackRate = 1.0;
+  value.playDelaySeconds = 100.0;
+  EXPECT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::InvalidParameter);
+  value.playDelaySeconds = 0.0;
+  value.stopFadeOutSeconds = 1.0;
+  EXPECT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::InvalidFadeDuration);
+}
+
+TEST_F(ClipAudioControlsTest, DelayDefersAudioWithoutAdvancingSource) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.playDelaySeconds = 0.001;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 64> left{};
+  std::array<float, 64> right{};
+  render(left, right);
+
+  for (size_t frame = 0; frame < 48; ++frame) {
+    EXPECT_FLOAT_EQ(left[frame], 0.0f);
+    EXPECT_FLOAT_EQ(right[frame], 0.0f);
+  }
+  EXPECT_GT(std::abs(left[48]), 0.1f);
+  EXPECT_GT(std::abs(right[48]), 0.2f);
+  EXPECT_EQ(transport->getClipPosition(handle), 16);
+}
+
+TEST_F(ClipAudioControlsTest, LiveMuteRampsToSilenceWhileTransportAdvances) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.muted = false;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 32> left{};
+  std::array<float, 32> right{};
+  render(left, right);
+  ASSERT_GT(std::abs(left.front()), 0.1f);
+
+  value.muted = true;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  render(left, right);
+  EXPECT_GT(std::abs(left.front()), std::abs(left.back()));
+
+  for (int block = 0; block < 8; ++block) {
+    render(left, right);
+  }
+  for (float sample : left) {
+    EXPECT_NEAR(sample, 0.0f, 1.0e-6f);
+  }
+  for (float sample : right) {
+    EXPECT_NEAR(sample, 0.0f, 1.0e-6f);
+  }
+  EXPECT_EQ(transport->getClipPosition(handle), 320);
+  EXPECT_FLOAT_EQ(metadata().gainDb, value.gainDb);
+}
+
+TEST_F(ClipAudioControlsTest, HardLeftPanSuppressesOnlyRightOutput) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.pan = -1.0f;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 16> left{};
+  std::array<float, 16> right{};
+  render(left, right);
+
+  EXPECT_GT(std::abs(left[0]), 0.1f);
+  for (float sample : right) {
+    EXPECT_NEAR(sample, 0.0f, 1.0e-6f);
+  }
+}
+
+TEST_F(ClipAudioControlsTest, PlaybackRateControlsSourcePosition) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.playbackRate = 2.0;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 32> left{};
+  std::array<float, 32> right{};
+  render(left, right);
+  EXPECT_EQ(transport->getClipPosition(handle), 64);
+
+  value.playbackRate = 0.5;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->seekClip(handle, 0), SessionGraphError::OK);
+  render(left, right);
+  EXPECT_EQ(transport->getClipPosition(handle), 16);
+}
+
+TEST_F(ClipAudioControlsTest, OperatorStopFadeIsIndependentFromTailFade) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.05;
+  value.stopFadeOutSeconds = 0.0;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 16> left{};
+  std::array<float, 16> right{};
+  render(left, right);
+  ASSERT_EQ(transport->stopClip(handle), SessionGraphError::OK);
+  render(left, right);
+  EXPECT_EQ(transport->getClipState(handle), PlaybackState::Stopped);
+}
+
+TEST_F(ClipAudioControlsTest, OperatorStopFadeUsesOutputFrameDuration) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.stopFadeOutSeconds = 0.001;
+  value.playbackRate = 4.0;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 16> left{};
+  std::array<float, 16> right{};
+  render(left, right);
+  ASSERT_EQ(transport->stopClip(handle), SessionGraphError::OK);
+  render(left, right);
+  EXPECT_EQ(transport->getClipState(handle), PlaybackState::Stopping);
+  render(left, right);
+  EXPECT_EQ(transport->getClipState(handle), PlaybackState::Stopping);
+  render(left, right);
+  EXPECT_EQ(transport->getClipState(handle), PlaybackState::Stopped);
+}
+
+TEST_F(ClipAudioControlsTest, SessionDefaultsNormalizeClipControlBounds) {
+  SessionDefaults defaults;
+  defaults.stopFadeOutSeconds = -1.0;
+  defaults.pan = 2.0f;
+  defaults.playbackRate = 0.1;
+  defaults.playDelaySeconds = 100.0;
+  transport->setSessionDefaults(defaults);
+
+  const SessionDefaults normalized = transport->getSessionDefaults();
+  EXPECT_DOUBLE_EQ(normalized.stopFadeOutSeconds, 0.01);
+  EXPECT_FLOAT_EQ(normalized.pan, 1.0f);
+  EXPECT_DOUBLE_EQ(normalized.playbackRate, 0.25);
+  EXPECT_DOUBLE_EQ(normalized.playDelaySeconds, 99.9);
+
+  constexpr ClipHandle secondHandle = 2;
+  ASSERT_EQ(transport->registerClipAudio(secondHandle, path), SessionGraphError::OK);
+  const auto secondMetadata = transport->getClipMetadata(secondHandle);
+  ASSERT_TRUE(secondMetadata.has_value());
+  EXPECT_DOUBLE_EQ(secondMetadata->stopFadeOutSeconds, 0.01);
+  EXPECT_FLOAT_EQ(secondMetadata->pan, 1.0f);
+  EXPECT_DOUBLE_EQ(secondMetadata->playbackRate, 0.25);
+  EXPECT_DOUBLE_EQ(secondMetadata->playDelaySeconds, 99.9);
+}
+
+} // namespace

--- a/tests/transport/clip_controls_test.cpp
+++ b/tests/transport/clip_controls_test.cpp
@@ -131,6 +131,19 @@ TEST_F(ClipAudioControlsTest, MetadataRoundTripsAndRejectsUnsafeBounds) {
   EXPECT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::InvalidFadeDuration);
 }
 
+TEST_F(ClipAudioControlsTest, LegacyFadeUpdateRespectsStoppedClipTrimWindow) {
+  auto value = metadata();
+  value.trimInSamples = 0;
+  value.trimOutSamples = 100;
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.stopFadeOutSeconds = 0.0;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+
+  EXPECT_EQ(transport->updateClipFades(handle, 0.0, 0.01, FadeCurve::Linear, FadeCurve::Linear),
+            SessionGraphError::InvalidFadeDuration);
+}
+
 TEST_F(ClipAudioControlsTest, DelayDefersAudioWithoutAdvancingSource) {
   auto value = metadata();
   value.fadeInSeconds = 0.0;
@@ -240,6 +253,28 @@ TEST_F(ClipAudioControlsTest, MonoCenterPanDuplicatesWithConstantPowerGain) {
   constexpr float expected = 0.3535533906f;
   EXPECT_NEAR(left.front(), expected, 1.0e-5f);
   EXPECT_NEAR(right.front(), expected, 1.0e-5f);
+}
+
+TEST_F(ClipAudioControlsTest, MonoRoutePreservesLevelRegardlessOfPan) {
+  TransportConfig config;
+  config.sampleRate = kSampleRate;
+  config.outputChannels = 1;
+  auto monoTransport = std::make_unique<TransportController>(nullptr, config);
+  constexpr ClipHandle monoHandle = 3;
+  ASSERT_EQ(monoTransport->registerClipAudio(monoHandle, monoPath.c_str()), SessionGraphError::OK);
+
+  auto value = monoTransport->getClipMetadata(monoHandle);
+  ASSERT_TRUE(value.has_value());
+  value->fadeInSeconds = 0.0;
+  value->fadeOutSeconds = 0.0;
+  value->pan = 1.0f;
+  ASSERT_EQ(monoTransport->updateClipMetadata(monoHandle, *value), SessionGraphError::OK);
+  ASSERT_EQ(monoTransport->startClip(monoHandle), SessionGraphError::OK);
+
+  std::array<float, 16> output{};
+  float* outputs[] = {output.data()};
+  monoTransport->processAudio(outputs, 1, output.size());
+  EXPECT_NEAR(output.front(), 0.5f, 1.0e-5f);
 }
 
 TEST_F(ClipAudioControlsTest, PlaybackRateControlsSourcePosition) {

--- a/tests/transport/clip_controls_test.cpp
+++ b/tests/transport/clip_controls_test.cpp
@@ -41,12 +41,33 @@ void writeStereoFixture(const std::string& path) {
   ASSERT_EQ(written.value, kFileFrames);
   ASSERT_EQ(writer->close(), SessionGraphError::OK);
 }
+void writeMonoFixture(const std::string& path) {
+  auto writer = createAudioFileWriter();
+  ASSERT_NE(writer, nullptr);
+
+  AudioFileWriterConfig config;
+  config.format = AudioFileFormat::WAV;
+  config.sample_rate = kSampleRate;
+  config.num_channels = 1;
+  config.sample_format = AudioSampleFormat::Float32;
+  ASSERT_EQ(writer->open(path, config), SessionGraphError::OK);
+
+  std::array<float, kFileFrames> samples{};
+  samples.fill(0.5f);
+  const Result<size_t> written = writer->writeSamples(samples.data(), kFileFrames);
+  ASSERT_TRUE(written.isOk()) << written.errorMessage;
+  ASSERT_EQ(written.value, kFileFrames);
+  ASSERT_EQ(writer->close(), SessionGraphError::OK);
+}
 
 class ClipAudioControlsTest : public ::testing::Test {
 protected:
   void SetUp() override {
     path = (std::filesystem::temp_directory_path() / "orpheus_clip_audio_controls.wav").string();
     writeStereoFixture(path);
+    monoPath =
+        (std::filesystem::temp_directory_path() / "orpheus_clip_audio_controls_mono.wav").string();
+    writeMonoFixture(monoPath);
     transport =
         std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = kSampleRate});
     ASSERT_EQ(transport->registerClipAudio(handle, path.c_str()), SessionGraphError::OK);
@@ -56,6 +77,7 @@ protected:
     transport.reset();
     std::error_code error;
     std::filesystem::remove(path, error);
+    std::filesystem::remove(monoPath, error);
   }
 
   ClipMetadata metadata() const {
@@ -74,6 +96,7 @@ protected:
 
   std::unique_ptr<TransportController> transport;
   std::string path;
+  std::string monoPath;
   const ClipHandle handle = 1;
 };
 
@@ -128,6 +151,28 @@ TEST_F(ClipAudioControlsTest, DelayDefersAudioWithoutAdvancingSource) {
   EXPECT_GT(std::abs(right[48]), 0.2f);
   EXPECT_EQ(transport->getClipPosition(handle), 16);
 }
+TEST_F(ClipAudioControlsTest, StopCancelsVoiceWaitingForDelay) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.stopFadeOutSeconds = 0.02;
+  value.playDelaySeconds = 0.05;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+  ASSERT_EQ(transport->stopClip(handle), SessionGraphError::OK);
+
+  std::array<float, 32> left{};
+  std::array<float, 32> right{};
+  render(left, right);
+
+  EXPECT_EQ(transport->getClipState(handle), PlaybackState::Stopped);
+  for (float sample : left) {
+    EXPECT_FLOAT_EQ(sample, 0.0f);
+  }
+  for (float sample : right) {
+    EXPECT_FLOAT_EQ(sample, 0.0f);
+  }
+}
 
 TEST_F(ClipAudioControlsTest, LiveMuteRampsToSilenceWhileTransportAdvances) {
   auto value = metadata();
@@ -176,6 +221,25 @@ TEST_F(ClipAudioControlsTest, HardLeftPanSuppressesOnlyRightOutput) {
   for (float sample : right) {
     EXPECT_NEAR(sample, 0.0f, 1.0e-6f);
   }
+}
+TEST_F(ClipAudioControlsTest, MonoCenterPanDuplicatesWithConstantPowerGain) {
+  constexpr ClipHandle monoHandle = 2;
+  ASSERT_EQ(transport->registerClipAudio(monoHandle, monoPath.c_str()), SessionGraphError::OK);
+  auto value = transport->getClipMetadata(monoHandle);
+  ASSERT_TRUE(value.has_value());
+  value->fadeInSeconds = 0.0;
+  value->fadeOutSeconds = 0.0;
+  value->pan = 0.0f;
+  ASSERT_EQ(transport->updateClipMetadata(monoHandle, *value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(monoHandle), SessionGraphError::OK);
+
+  std::array<float, 16> left{};
+  std::array<float, 16> right{};
+  render(left, right);
+
+  constexpr float expected = 0.3535533906f;
+  EXPECT_NEAR(left.front(), expected, 1.0e-5f);
+  EXPECT_NEAR(right.front(), expected, 1.0e-5f);
 }
 
 TEST_F(ClipAudioControlsTest, PlaybackRateControlsSourcePosition) {

--- a/tests/transport/clip_controls_test.cpp
+++ b/tests/transport/clip_controls_test.cpp
@@ -262,6 +262,56 @@ TEST_F(ClipAudioControlsTest, PlaybackRateControlsSourcePosition) {
   EXPECT_EQ(transport->getClipPosition(handle), 16);
 }
 
+TEST_F(ClipAudioControlsTest, SegmentProgramRepeatsAndAdvancesWithinOneRenderBlock) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.segmentCount = 2;
+  value.segments[0] = {100, 116, 2};
+  value.segments[1] = {200, 216, 1};
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 40> left{};
+  std::array<float, 40> right{};
+  render(left, right);
+
+  EXPECT_EQ(transport->getClipPosition(handle), 208);
+  for (float sample : left)
+    EXPECT_GT(std::abs(sample), 0.1f);
+}
+
+TEST_F(ClipAudioControlsTest, SegmentProgramValidationIsAtomicAndUnrelatedUpdatesDoNotRestart) {
+  auto value = metadata();
+  value.fadeInSeconds = 0.0;
+  value.fadeOutSeconds = 0.0;
+  value.segmentCount = 1;
+  value.segments[0] = {100, 200, 3};
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  ASSERT_EQ(transport->startClip(handle), SessionGraphError::OK);
+
+  std::array<float, 16> left{};
+  std::array<float, 16> right{};
+  render(left, right);
+  EXPECT_EQ(transport->getClipPosition(handle), 116);
+
+  value.gainDb = -3.0f;
+  ASSERT_EQ(transport->updateClipMetadata(handle, value), SessionGraphError::OK);
+  render(left, right);
+  EXPECT_EQ(transport->getClipPosition(handle), 132);
+
+  auto invalid = value;
+  invalid.segments[0].repeatCount = 0;
+  EXPECT_EQ(transport->updateClipMetadata(handle, invalid), SessionGraphError::InvalidParameter);
+  invalid = value;
+  invalid.segments[0].endSample = kFileFrames + 1;
+  EXPECT_EQ(transport->updateClipMetadata(handle, invalid), SessionGraphError::InvalidParameter);
+
+  const auto restored = metadata();
+  EXPECT_EQ(restored.segmentCount, 1u);
+  EXPECT_EQ(restored.segments[0], value.segments[0]);
+}
+
 TEST_F(ClipAudioControlsTest, OperatorStopFadeIsIndependentFromTailFade) {
   auto value = metadata();
   value.fadeInSeconds = 0.0;

--- a/tests/transport/clip_metadata_test.cpp
+++ b/tests/transport/clip_metadata_test.cpp
@@ -12,7 +12,8 @@ using namespace orpheus;
 class ClipMetadataTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
+    m_transport = std::make_unique<TransportController>(
+        nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
     m_testFilePath = (std::filesystem::temp_directory_path() / "test_clip_metadata.wav").string();
     createTestAudioFile();
   }
@@ -201,14 +202,14 @@ TEST_F(ClipMetadataTest, BatchUpdateMetadata) {
   m_transport->updateClipGain(handle, 0.9f);
   m_transport->updateClipTrimPoints(handle, 500, 2000);
   m_transport->setClipLoopMode(handle, true);
-  m_transport->updateClipFades(handle, 0.1, 0.1, FadeCurve::Linear, FadeCurve::Linear);
+  m_transport->updateClipFades(handle, 0.01, 0.01, FadeCurve::Linear, FadeCurve::Linear);
 
   auto meta = m_transport->getClipMetadata(handle);
   EXPECT_FLOAT_EQ(meta->gainDb, 0.9f);
   EXPECT_EQ(meta->trimInSamples, 500);
   EXPECT_EQ(meta->trimOutSamples, 2000);
   EXPECT_TRUE(meta->loopEnabled);
-  EXPECT_DOUBLE_EQ(meta->fadeInSeconds, 0.1);
+  EXPECT_DOUBLE_EQ(meta->fadeInSeconds, 0.01);
 }
 
 // Test 8: Defaults applied correctly on registration


### PR DESCRIPTION
## Summary
- add independent operator-stop fades, mute, stereo balance, forward varispeed, and trigger delay to clip metadata and session defaults
- apply controls through the bounded transport command path without callback allocation or blocking I/O
- add rendered contract coverage and ORP152 implementation record

## Verification
- `cmake --build build-ci --clean-first --parallel 8 && ctest --test-dir build-ci --output-on-failure` (150/150 passed)
- `clip_controls_test` (8/8 passed)