### PR TITLE
fix(transport): prime streaming refires at trim in

### DIFF
--- a/docs/orp/ORP152 Clip Playback Controls.md
+++ b/docs/orp/ORP152 Clip Playback Controls.md
@@ -75,6 +75,14 @@ A mono source is duplicated to the first two discrete lanes when available, so
 pan can create a real left/right placement. Wider sources retain their existing
 source-to-output mapping; only their first stereo pair receives a balance gain.
 
+Long-file streaming keeps a four-page playback window plus one bounded restart
+page. Each control-thread start primes the clip's trim-in page before posting
+the realtime command. A `MonoWithFadeOverlap` restart or atomic group-choke
+refire therefore cannot emit an initial silent buffer merely because a prior
+playback advanced the streaming cache beyond trim-in. Worker and control-thread
+page claims are serialized; the audio thread still performs only resident-page
+reads and atomic ownership handoffs.
+
 ## Verification
 
 `clip_controls_test` covers:
@@ -93,3 +101,7 @@ source-to-output mapping; only their first stereo pair receives a balance gain.
 The pre-existing stop-fade and transport tests remain the regression coverage
 for trim boundaries, restart, loop behavior, routing, voice ownership, and
 callback delivery.
+
+`realtime_harness_test` additionally advances a streaming clip beyond its first
+page and verifies that an atomic group-choke refire restarts at trim-in with
+audible output, zero underrun callbacks, and no realtime allocation.

--- a/include/orpheus/clip_source.h
+++ b/include/orpheus/clip_source.h
@@ -112,7 +112,8 @@ private:
 class StreamingClipSource : public IClipSource {
 public:
   static constexpr size_t kPageFrames = 65536; ///< frames per page (~1.4s @ 48k)
-  static constexpr size_t kNumPages = 4;       ///< 1 behind + demand page + 2 ahead (≈5.5s @ 48k)
+  static constexpr size_t kWindowPages = 4;    ///< 1 behind + demand + 2 ahead (≈5.5s @ 48k)
+  static constexpr size_t kNumPages = kWindowPages + 1; ///< reserved restart/refire page
 
   /// BACKGROUND/CONTROL THREAD. The reader is retained and used exclusively
   /// from worker/control threads (guarded by an internal mutex).
@@ -135,11 +136,12 @@ public:
 
   /// Fill up to `max_pages` non-resident pages of the window around `pos`
   /// synchronously — the demand page first, then the forward pages, then the
-  /// behind page. CONTROL/WORKER THREAD. Called by prepareClipAudio so
-  /// playback from the trim-in point starts without an initial underrun.
+  /// behind page. CONTROL/WORKER THREAD. One page is reserved outside the
+  /// steady-state worker window so a control-thread start/refire can prime its
+  /// first audible page before the realtime command resets the voice cursor.
   /// Hosts with latency-bounded transitions can pass max_pages = 1 to prime
   /// only the audible page and leave the rest to the worker.
-  void prefill(int64_t pos, size_t max_pages = kNumPages);
+  void prefill(int64_t pos, size_t max_pages = kWindowPages);
 
   /// One worker pass: refill FREE pages inside the current demand window.
   /// WORKER THREAD ONLY.

--- a/src/core/transport/clip_source.cpp
+++ b/src/core/transport/clip_source.cpp
@@ -105,7 +105,7 @@ bool StreamingClipSource::read(int64_t pos, float* dest, size_t frames, size_t& 
   m_demand.store(pos, std::memory_order_relaxed);
   const int64_t windowBase = alignDown(pos) - static_cast<int64_t>(kPageFrames);
   const int64_t windowEnd =
-      alignDown(pos) + static_cast<int64_t>(kNumPages - 1) * static_cast<int64_t>(kPageFrames);
+      alignDown(pos) + static_cast<int64_t>(kWindowPages - 1) * static_cast<int64_t>(kPageFrames);
   for (auto& page : m_pages) {
     const int64_t start = page.start.load(std::memory_order_acquire);
     if (start >= 0 && (start < windowBase || start >= windowEnd)) {
@@ -131,7 +131,16 @@ bool StreamingClipSource::read(int64_t pos, float* dest, size_t frames, size_t& 
 }
 
 bool StreamingClipSource::fillPage(int64_t alignedStart) {
-  // Find a FREE page (worker-owned).
+  // Worker service and control-thread refire priming may run concurrently.
+  // Serialize both page ownership selection and reader access so they cannot
+  // claim the same FREE page or publish duplicate copies of one page.
+  std::lock_guard<std::mutex> lock(m_readerMutex);
+  for (auto& page : m_pages) {
+    if (page.start.load(std::memory_order_acquire) == alignedStart) {
+      return true;
+    }
+  }
+
   Page* target = nullptr;
   for (auto& page : m_pages) {
     if (page.start.load(std::memory_order_acquire) == -1) {
@@ -140,7 +149,7 @@ bool StreamingClipSource::fillPage(int64_t alignedStart) {
     }
   }
   if (target == nullptr) {
-    return false; // nothing FREE yet — audio thread will retire on its next read
+    return false;
   }
 
   const int64_t framesLeft = m_lengthFrames - alignedStart;
@@ -150,21 +159,17 @@ bool StreamingClipSource::fillPage(int64_t alignedStart) {
     return false;
   }
 
-  {
-    std::lock_guard<std::mutex> lock(m_readerMutex);
-    if (!m_reader || m_reader->seek(alignedStart) != SessionGraphError::OK) {
-      return false;
-    }
-    auto result = m_reader->readSamples(target->data.data(), want);
-    if (!result.isOk()) {
-      return false;
-    }
-    // Zero-pad a short tail (EOF) so the whole page is defined.
-    const size_t got = result.value;
-    if (got < kPageFrames) {
-      std::fill(target->data.begin() + static_cast<ptrdiff_t>(got * m_numChannels),
-                target->data.end(), 0.0f);
-    }
+  if (!m_reader || m_reader->seek(alignedStart) != SessionGraphError::OK) {
+    return false;
+  }
+  auto result = m_reader->readSamples(target->data.data(), want);
+  if (!result.isOk()) {
+    return false;
+  }
+  const size_t got = result.value;
+  if (got < kPageFrames) {
+    std::fill(target->data.begin() + static_cast<ptrdiff_t>(got * m_numChannels),
+              target->data.end(), 0.0f);
   }
 
   target->start.store(alignedStart, std::memory_order_release);
@@ -178,9 +183,9 @@ void StreamingClipSource::prefill(int64_t pos, size_t max_pages) {
   // the behind page — so a max_pages-capped prime always makes the position
   // under the cursor playable, and reverse runway comes after lookahead. The
   // candidate set matches the retirement window in read() exactly.
-  int64_t wanted[kNumPages];
+  int64_t wanted[kWindowPages];
   size_t num_wanted = 0;
-  for (size_t i = 0; i + 1 < kNumPages; ++i) {
+  for (size_t i = 0; i + 1 < kWindowPages; ++i) {
     wanted[num_wanted++] = base + static_cast<int64_t>(i) * static_cast<int64_t>(kPageFrames);
   }
   wanted[num_wanted++] = base - static_cast<int64_t>(kPageFrames);

--- a/src/core/transport/transport_controller.cpp
+++ b/src/core/transport/transport_controller.cpp
@@ -1983,6 +1983,13 @@ SessionGraphError TransportController::ensurePreparedSourceLocked(AudioFileEntry
   // decode/resample/file I/O happens here (or on the stream worker) - the
   // audio thread only ever memcpy-reads the published source.
   if (entry.source) {
+    if (auto streaming = std::dynamic_pointer_cast<StreamingClipSource>(entry.source)) {
+      // Keep refires and starts after a prior stop gap-free. The streaming
+      // ring reserves one page outside its steady-state worker window so this
+      // bounded control-thread prime cannot displace pages an active voice is
+      // still reading.
+      streaming->prefill(entry.trimInSamples, 1);
+    }
     return SessionGraphError::OK;
   }
 

--- a/tests/transport/realtime_harness_test.cpp
+++ b/tests/transport/realtime_harness_test.cpp
@@ -103,7 +103,8 @@ protected:
   void SetUp() override {
     m_tempDir = std::filesystem::temp_directory_path() / "orp136_rt_harness";
     std::filesystem::create_directories(m_tempDir);
-    m_transport = std::make_unique<TransportController>(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
+    m_transport = std::make_unique<TransportController>(
+        nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
     m_left.assign(kBufferFrames, 0.0f);
     m_right.assign(kBufferFrames, 0.0f);
     m_buffers[0] = m_left.data();
@@ -326,6 +327,38 @@ TEST_F(RealtimeHarnessTest, StreamingSourcePlaysPrefilledWindowWithoutUnderrun) 
   EXPECT_EQ(buffersWithSignal, kBuffers) << "silent buffers inside the prefilled window";
   EXPECT_EQ(RtGuardState::allocViolations(), 0u) << "streaming read path allocated";
 
+  m_transport->setCallback(nullptr);
+}
+
+TEST_F(RealtimeHarnessTest, StreamingGroupChokeRefirePrimesTrimInWithoutUnderrun) {
+  m_transport->setPreparedSourceMaxFrames(48000);
+
+  UnderrunCountingCallback callback;
+  m_transport->setCallback(&callback);
+
+  const std::string path = writeSineWav(m_tempDir, "stream_group_refire.wav", 220.0f, 10.0f);
+  ASSERT_EQ(m_transport->registerClipAudio(1, path), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->setClipVoiceMode(1, VoiceMode::MonoWithFadeOverlap),
+            SessionGraphError::OK);
+  ASSERT_EQ(m_transport->prepareClipAudio(1), SessionGraphError::OK);
+  ASSERT_EQ(m_transport->startClip(1), SessionGraphError::OK);
+  guardedCallback();
+
+  // Move beyond the first page while staying inside the initial resident
+  // window. The audio thread retires page zero, reproducing a long clip whose
+  // streaming cache has advanced away from its trim-in point.
+  constexpr int64_t advancedPosition = 2 * static_cast<int64_t>(StreamingClipSource::kPageFrames);
+  ASSERT_EQ(m_transport->seekClip(1, advancedPosition), SessionGraphError::OK);
+  guardedCallback();
+  m_transport->processCallbacks();
+  ASSERT_EQ(callback.underruns.load(), 0);
+
+  ASSERT_EQ(m_transport->startClipWithGroupChoke(1), SessionGraphError::OK);
+  guardedCallback();
+  m_transport->processCallbacks();
+
+  EXPECT_EQ(callback.underruns.load(), 0) << "group-choke refire missed the trim-in streaming page";
+  EXPECT_TRUE(bufferHasSignal(m_left));
   m_transport->setCallback(nullptr);
 }
 


### PR DESCRIPTION
## Summary
- reserve a bounded restart page outside the steady streaming window
- prime trim-in before start/group-choke refire and serialize page claims
- add deterministic realtime regression coverage and update ORP152

## Verification
- `ctest --test-dir build-sdk-fix --output-on-failure -R '^realtime_harness_test$'`
- live Clip Composer sequence: long clip start -> advance -> stop -> group-choke refire; no underrun and subsequent peer start accepted