### PR TITLE
feat(routing): publish coherent group control snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-16
+
+Minor pre-1.0 release adding a coherent public routing-control contract.
+Custom `IRoutingMatrix` implementations must implement the two new snapshot
+methods.
+
+### Added
+
+- `RoutingControlSnapshot` and `RoutingGroupControlState` expose fixed-capacity,
+  schema-versioned, allocation-free configured gain, mute, solo, output route,
+  effective mute, and monotonic revision state.
+- `IRoutingMatrix::getRoutingControlSnapshot()` returns one coherent public
+  control value without allocating or capturing a scene.
+- `IRoutingMatrix::applyGroupControlSnapshot()` validates every configured group
+  before mutation, rejects without changing state or revision, and publishes
+  accepted batches to rendering at one buffer boundary.
+
+### Changed
+
+- Group gain targets now enter the smoother at the render boundary rather than
+  during a concurrent control-thread write.
+- Routing preset load and reset apply group controls through the validated batch
+  contract.
+
+### Verification
+
+- All 150 configured SDK tests pass.
+- The installed `Orpheus::routing` and transitively linked
+  `Orpheus::transport` package consumers compile and exercise snapshot
+  write/readback and rejection rollback through public headers.
+- All routing-matrix tests pass under ThreadSanitizer, including concurrent
+  render, transaction publication, and coherent query coverage.
+
 ## [0.5.3] - 2026-07-16
 
 Patch release for host-correct route-latency placement and isolated per-channel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.5.3 LANGUAGES CXX)
+project(orpheus VERSION 0.6.0 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.5.3 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.6.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/API_SURFACE_INDEX.md
+++ b/docs/API_SURFACE_INDEX.md
@@ -4,7 +4,7 @@ This index catalogs public entry points exposed by the Orpheus SDK workspace. Up
 notable APIs are added.
 
 **Last Updated:** 2026-07-16 (isolated channel-meter contract)
-**SDK Version:** 0.5.3 — the authoritative version is `project(orpheus VERSION ...)`
+**SDK Version:** 0.6.0 — the authoritative version is `project(orpheus VERSION ...)`
 in the repo-root `CMakeLists.txt`. ("Added" tags below cite the historical
 release names in `CHANGELOG.md`, including the pre-renumbering `v1.0.0-rc.*`
 labels.)
@@ -35,7 +35,7 @@ labels.)
 
 | Header                             | Primary Interface        | Description                                                     | Added               |
 | ---------------------------------- | ------------------------ | --------------------------------------------------------------- | ------------------- |
-| `include/orpheus/routing_matrix.h` | `IRoutingMatrix`         | Professional N×M routing (64 channels → 16 groups → 32 outputs) | ORP109 (unreleased) |
+| `include/orpheus/routing_matrix.h` | `IRoutingMatrix`         | N×M routing plus coherent group-control snapshots               | ORP109, ORP153       |
 | `include/orpheus/clip_routing.h`   | `IClipRoutingMatrix`     | Simplified clip-based routing (4 Clip Groups for OCC)           | ORP109 (unreleased) |
 | `include/orpheus/clip_routing.h`   | Multi-channel extensions | Output bus assignment for 8-32 channel interfaces               | ORP109 (unreleased) |
 
@@ -89,7 +89,7 @@ labels.)
 
 **Routing:**
 
-- `ChannelConfig`, `GroupConfig`, `RoutingConfig`, `AudioMeter`, `RoutingSnapshot`, `SoloMode`, `MeteringMode`
+- `ChannelConfig`, `GroupConfig`, `RoutingConfig`, `AudioMeter`, `RoutingSnapshot`, `RoutingControlSnapshot`, `RoutingGroupControlState`, `SoloMode`, `MeteringMode`
 
 **Device Management:**
 

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -11,6 +11,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP150 Atomic Clip-Group Choke Admission]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 - [[ORP152 Clip Playback Controls]]
+- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
 - [[ORP126 Codex Integration Audit and Checkpoint]]
 - [[ORP125 Architecture Refactor Sprint - Completion Report]]
 - [[ORP124 Architecture Cross-Reference Matrix]]
@@ -70,6 +71,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP150 Atomic Clip-Group Choke Admission]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 - [[ORP152 Clip Playback Controls]]
+- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
 
 ## Archived Documents
 

--- a/docs/orp/ORP.md
+++ b/docs/orp/ORP.md
@@ -14,6 +14,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 - [[ORP152 Clip Playback Controls]]
+- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
 
 - [[ORP131 Clip Composer Subdirectory Archival]]
 - [[ORP130 CoreAudio Input Capture]]
@@ -116,6 +117,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP149 Aurora Control-Plane Opportunities for Game Audio and IoT]]
 - [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
 - [[ORP152 Clip Playback Controls]]
+- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
 
 ## Archived Documents
 

--- a/docs/orp/ORP153 Clip Composer Routing State Snapshot Adoption Handoff.md
+++ b/docs/orp/ORP153 Clip Composer Routing State Snapshot Adoption Handoff.md
@@ -5,25 +5,26 @@
 **Document type:** Downstream adoption handoff  
 **Owning implementation team:** Clip Composer  
 **Issuing repository:** Orpheus SDK  
-**Status:** Dependency-blocked; schedule after the SDK routing-state contract ships  
+**Status:** SDK prerequisite delivered in `v0.6.0`; downstream adoption active
 **Date:** 2026-07-16  
 **Related SDK direction:** [[ORP147 SDK Customer-Fit Gap Register and Incremental Build Guide]]
+**SDK release:** `v0.6.0`
 
 ---
 
 ## 1. Purpose
 
 This document hands one child-application task to the Clip Composer team: remove
-its shadow copy of SDK routing gain, mute, and solo state after Orpheus publishes
-a coherent routing-state query contract.
+its shadow copy of SDK routing gain, mute, and solo state by adopting the
+coherent routing-state contract shipped in Orpheus SDK `v0.6.0`.
 
 This is downstream adoption work. Orpheus owns the prerequisite public API,
 realtime publication model, package fixture, and SDK contract tests. Clip
 Composer owns its SDK pin, app-side migration, UI projection, and application
 verification.
 
-Do not begin the migration against the current SDK API. `IRoutingMatrix` does
-not yet provide the required coherent configured-state query.
+The prerequisite is now available through installed public headers. Clip
+Composer can perform the clean cutover in §4.
 
 ---
 
@@ -62,10 +63,9 @@ future SDK control path can leave the application projection stale.
 
 ## 3. SDK prerequisite
 
-The Orpheus team must ship and package a public routing-state contract before
-this handoff becomes actionable. The final SDK symbol names are intentionally
-not prescribed here, but the contract must provide one coherent control-thread
-value containing, for every configured group:
+Orpheus SDK `v0.6.0` ships the public routing-state contract required by this
+handoff. `IRoutingMatrix::getRoutingControlSnapshot()` returns one coherent,
+fixed-capacity control-thread value containing, for every configured group:
 
 - group index or stable group identity;
 - configured gain in decibels;
@@ -94,6 +94,25 @@ The SDK prerequisite is complete only when all of the following are true:
 - an SDK test proves coherent gain/mute/solo readback after mutation and
   rollback; and
 - the SDK release or candidate version containing the contract is identified.
+
+### 3.1 Delivered SDK contract
+
+- `RoutingControlSnapshot` is a fixed-capacity, standard-layout,
+  trivially-copyable public value with schema, group count, and monotonic
+  revision.
+- Each `RoutingGroupControlState` distinguishes configured mute from effective
+  solo-derived mute and carries configured gain, solo, and output route.
+- `IRoutingMatrix::applyGroupControlSnapshot()` validates the entire group set
+  before mutation. Rejection preserves every prior field and the revision.
+- Accepted batches publish to the render thread at one buffer boundary. The
+  render thread copies a bounded value without waiting, allocation, locking, or
+  I/O and retains the prior complete value if control publication overlaps its
+  boundary.
+- Installed `Orpheus::routing` and `Orpheus::transport` package fixtures compile,
+  write, and read the contract through public interfaces.
+- Routing unit coverage proves configured/effective projection, coherent batch
+  publication, rejection rollback, preset recall, and concurrent render/query
+  behavior. The concurrent contract passes under ThreadSanitizer.
 
 ---
 
@@ -194,8 +213,9 @@ The handoff is complete when:
   smoke checks pass; and
 - the child-app change records its tested SDK revision.
 
-No Clip Composer source change, SDK-pin change, build result, or runtime result
-is claimed by this document.
+The SDK delivery claims above are verified in the Orpheus repository. Clip
+Composer source, pin, build, and runtime results remain downstream work until
+the application completes this handoff.
 
 ---
 
@@ -205,15 +225,14 @@ is claimed by this document.
 - Moving group names, Cue/PFL policy, or device UI into the SDK.
 - Adding a general plugin or DSP graph.
 - Changing the application's audio-thread ownership model.
-- Prescribing the final SDK C++ symbol names before the Orpheus routing contract
-  is reviewed.
+- Extending the contract beyond the reviewed fixed-capacity group-control
+  surface.
 
 ---
 
 ## 9. Dispatch state
 
 **Pass to:** Clip Composer team.  
-**Start condition:** Orpheus publishes the prerequisite coherent routing-state
-and rollback-safe batch contract.  
-**Current action:** retain this handoff in the Clip Composer backlog; do not
-implement against the current SDK surface.
+**Start condition:** satisfied by Orpheus SDK `v0.6.0`.
+**Current action:** advance the Clip Composer pin and complete the clean
+application cutover in §4.

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.3
+**SDK Version:** 0.6.0
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.3
+**SDK Version:** 0.6.0

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.3
+**SDK Version:** 0.6.0

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.5.3
+**SDK Version:** 0.6.0

--- a/include/orpheus/routing_matrix.h
+++ b/include/orpheus/routing_matrix.h
@@ -4,11 +4,13 @@
 #include <orpheus/export.h>
 #include <orpheus/time_domain.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <orpheus/errors.h>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace orpheus {
@@ -43,6 +45,12 @@ constexpr RoutingGroupIndex UNASSIGNED_GROUP = UINT16_MAX;
 /// buffer size) can size their render blocks against it. Offline hosts
 /// (bounce/export) may pass blocks of any size and let chunking handle it.
 constexpr uint32_t kRoutingSliceFrames = 2048;
+
+/// Fixed public capacity for coherent group-control snapshots.
+constexpr size_t kRoutingControlMaxGroups = 32;
+
+/// Schema version for RoutingControlSnapshot.
+constexpr uint32_t kRoutingControlSnapshotSchemaVersion = 1;
 
 // ============================================================================
 // Routing Configuration Types
@@ -109,14 +117,14 @@ enum class DownmixPolicy : uint8_t {
 
 /// Channel strip configuration (like a console channel)
 struct ChannelConfig {
-  std::string name;               ///< Human-readable channel name
-  RoutingGroupIndex group_index;  ///< Assigned group, or UNASSIGNED_GROUP
+  std::string name;                  ///< Human-readable channel name
+  RoutingGroupIndex group_index;     ///< Assigned group, or UNASSIGNED_GROUP
   RoutingOutputIndex output_channel; ///< Discrete destination within the group bus
-  float gain_db;       ///< Channel gain in dB (-inf to +12 dB)
-  float pan;           ///< Pan position (-1.0 = hard left, 0.0 = center, +1.0 = hard right)
-  bool mute;           ///< Mute flag
-  bool solo;           ///< Solo flag
-  uint32_t color;      ///< UI color hint (RGBA)
+  float gain_db;                     ///< Channel gain in dB (-inf to +12 dB)
+  float pan;      ///< Pan position (-1.0 = hard left, 0.0 = center, +1.0 = hard right)
+  bool mute;      ///< Mute flag
+  bool solo;      ///< Solo flag
+  uint32_t color; ///< UI color hint (RGBA)
 
   /// Default constructor
   ChannelConfig()
@@ -126,19 +134,48 @@ struct ChannelConfig {
 
 /// Group (bus) configuration (like a console subgroup)
 struct GroupConfig {
-  std::string name;   ///< Group name (e.g., "Drums", "Music", "SFX", "Dialogue")
-  float gain_db;      ///< Group gain in dB (-inf to +12 dB)
-  bool mute;          ///< Mute flag
-  bool solo;          ///< Solo flag (groups can be solo'd too)
+  std::string name;                ///< Group name (e.g., "Drums", "Music", "SFX", "Dialogue")
+  float gain_db;                   ///< Group gain in dB (-inf to +12 dB)
+  bool mute;                       ///< Mute flag
+  bool solo;                       ///< Solo flag (groups can be solo'd too)
   RoutingOutputIndex output_start; ///< First physical output for this logical bus
   uint16_t output_width;           ///< Number of routed channels in this bus
   uint32_t color;                  ///< UI color hint (RGBA)
 
   /// Default constructor
   GroupConfig()
-      : name(""), gain_db(0.0f), mute(false), solo(false), output_start(0),
-        output_width(2), color(0xFFFFFFFF) {}
+      : name(""), gain_db(0.0f), mute(false), solo(false), output_start(0), output_width(2),
+        color(0xFFFFFFFF) {}
 };
+
+/// One logical group's configured and effective control state.
+struct RoutingGroupControlState {
+  float gain_db{0.0f};
+  RoutingOutputIndex output_start{0};
+  uint16_t output_width{0};
+  bool configured_mute{false};
+  bool configured_solo{false};
+  bool effective_mute{false};
+  uint8_t reserved{0};
+};
+
+/// Fixed-capacity coherent view of every configured logical group.
+///
+/// revision changes after every accepted group-control mutation. configured_mute
+/// remains the operator-authored flag; effective_mute additionally reflects
+/// group-solo logic.
+struct RoutingControlSnapshot {
+  uint32_t schema_version{kRoutingControlSnapshotSchemaVersion};
+  RoutingGroupIndex group_count{0};
+  uint16_t reserved{0};
+  uint64_t revision{0};
+  std::array<RoutingGroupControlState, kRoutingControlMaxGroups> groups{};
+};
+
+static_assert(std::is_trivially_copyable_v<RoutingGroupControlState>);
+static_assert(std::is_standard_layout_v<RoutingGroupControlState>);
+static_assert(std::is_trivially_copyable_v<RoutingControlSnapshot>);
+static_assert(std::is_standard_layout_v<RoutingControlSnapshot>);
 
 /// Routing matrix configuration (complete topology)
 struct RoutingConfig {
@@ -358,10 +395,17 @@ public:
                                            const GroupConfig& config) = 0;
 
   /// Atomically route a logical group bus to a contiguous physical output range.
-  virtual SessionGraphError
-  setGroupOutputRoute(RoutingGroupIndex group_index,
-                      RoutingOutputIndex output_start,
-                      uint16_t output_width) = 0;
+  virtual SessionGraphError setGroupOutputRoute(RoutingGroupIndex group_index,
+                                                RoutingOutputIndex output_start,
+                                                uint16_t output_width) = 0;
+
+  /// Validate and apply all configured group controls as one transaction.
+  ///
+  /// group_count must exactly match the matrix configuration. Validation
+  /// completes before live state changes; any rejection preserves the prior
+  /// routing state and revision. Accepted controls become visible together at
+  /// one render boundary. Call from the host's single control thread.
+  virtual SessionGraphError applyGroupControlSnapshot(const RoutingControlSnapshot& snapshot) = 0;
 
   // ========================================================================
   // Master Output Configuration (UI Thread, Lock-Free)
@@ -394,6 +438,13 @@ public:
   /// @param group_index Group index [0, num_groups)
   /// @return True if effectively muted
   virtual bool isGroupMuted(RoutingGroupIndex group_index) const = 0;
+
+  /// Read one coherent fixed-capacity group-control state value.
+  ///
+  /// Call from a host control thread; it remains safe while rendering runs
+  /// concurrently. This query does not allocate and never exposes a partially
+  /// applied applyGroupControlSnapshot() transaction.
+  virtual RoutingControlSnapshot getRoutingControlSnapshot() const noexcept = 0;
 
   /// Get one channel's isolated effective contribution meter.
   ///

--- a/src/core/routing/routing_matrix.cpp
+++ b/src/core/routing/routing_matrix.cpp
@@ -77,6 +77,7 @@ SessionGraphError RoutingMatrix::initialize(const RoutingConfig& config) {
     meter.reset();
   }
 
+  m_group_control_sequence.store(0, std::memory_order_release);
   m_initialized.store(true, std::memory_order_release);
 
   return SessionGraphError::OK;
@@ -250,24 +251,23 @@ SessionGraphError RoutingMatrix::setGroupGain(RoutingGroupIndex group_index, flo
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
-
   if (group_index >= m_groups.size()) {
     return SessionGraphError::InvalidParameter;
   }
+  if (!std::isfinite(gain_db)) {
+    return SessionGraphError::InvalidParameter;
+  }
 
-  // Clamp to valid range
   gain_db = std::clamp(gain_db, -100.0f, 12.0f);
+  beginGroupControlWrite();
+  auto& group = m_groups[group_index];
+  group.configured_gain_db.store(gain_db, std::memory_order_relaxed);
+  group.config.gain_db = gain_db;
+  endGroupControlWrite();
 
-  // Convert to linear and set target (lock-free)
-  float gain_linear = dbToLinear(gain_db);
-  m_groups[group_index].gain_smoother->setTarget(gain_linear);
-  m_groups[group_index].config.gain_db = gain_db;
-
-  // Notify callback
   if (m_callback) {
     m_callback->onGroupGainChanged(group_index, gain_db);
   }
-
   return SessionGraphError::OK;
 }
 
@@ -275,15 +275,14 @@ SessionGraphError RoutingMatrix::setGroupMute(RoutingGroupIndex group_index, boo
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
-
   if (group_index >= m_groups.size()) {
     return SessionGraphError::InvalidParameter;
   }
 
-  // Atomic update (lock-free)
-  m_groups[group_index].mute.store(mute, std::memory_order_release);
+  beginGroupControlWrite();
+  m_groups[group_index].mute.store(mute, std::memory_order_relaxed);
   m_groups[group_index].config.mute = mute;
-
+  endGroupControlWrite();
   return SessionGraphError::OK;
 }
 
@@ -291,18 +290,18 @@ SessionGraphError RoutingMatrix::setGroupSolo(RoutingGroupIndex group_index, boo
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
-
   if (group_index >= m_groups.size()) {
     return SessionGraphError::InvalidParameter;
   }
 
-  // Atomic update (lock-free)
-  m_groups[group_index].solo.store(solo, std::memory_order_release);
+  beginGroupControlWrite();
+  m_groups[group_index].solo.store(solo, std::memory_order_relaxed);
   m_groups[group_index].config.solo = solo;
-
-  // Update global solo state
-  updateSoloState();
-
+  updateSoloState(false);
+  endGroupControlWrite();
+  if (m_callback) {
+    m_callback->onSoloStateChanged(m_solo_active.load(std::memory_order_acquire));
+  }
   return SessionGraphError::OK;
 }
 
@@ -311,52 +310,47 @@ SessionGraphError RoutingMatrix::configureGroup(RoutingGroupIndex group_index,
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
-
   if (group_index >= m_groups.size()) {
     return SessionGraphError::InvalidParameter;
   }
-  const auto activeConfig =
-      m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
-  if (config.output_width == 0 ||
-      static_cast<uint32_t>(config.output_start) + config.output_width >
-          activeConfig.num_outputs) {
-    return SessionGraphError::InvalidParameter;
+
+  auto snapshot = getRoutingControlSnapshot();
+  auto& state = snapshot.groups[group_index];
+  state.gain_db = config.gain_db;
+  state.configured_mute = config.mute;
+  state.configured_solo = config.solo;
+  state.output_start = config.output_start;
+  state.output_width = config.output_width;
+  const auto result = applyGroupControlSnapshot(snapshot);
+  if (result == SessionGraphError::OK) {
+    m_groups[group_index].config.name = config.name;
+    m_groups[group_index].config.color = config.color;
   }
-
-  // Batch update all parameters
-  setGroupGain(group_index, config.gain_db);
-  setGroupMute(group_index, config.mute);
-  setGroupSolo(group_index, config.solo);
-
-  m_groups[group_index].config.name = config.name;
-  setGroupOutputRoute(group_index, config.output_start, config.output_width);
-  m_groups[group_index].config.color = config.color;
-
-  return SessionGraphError::OK;
+  return result;
 }
 
-SessionGraphError RoutingMatrix::setGroupOutputRoute(
-    RoutingGroupIndex group_index, RoutingOutputIndex output_start,
-    uint16_t output_width) {
+SessionGraphError RoutingMatrix::setGroupOutputRoute(RoutingGroupIndex group_index,
+                                                     RoutingOutputIndex output_start,
+                                                     uint16_t output_width) {
   if (!m_initialized.load(std::memory_order_acquire)) {
     return SessionGraphError::NotInitialized;
   }
   if (group_index >= m_groups.size()) {
     return SessionGraphError::InvalidParameter;
   }
-  const auto& config =
-      m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
+  const auto& config = m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
   if (output_width == 0 ||
-      static_cast<uint32_t>(output_start) + output_width >
-          config.num_outputs) {
+      static_cast<uint32_t>(output_start) + output_width > config.num_outputs) {
     return SessionGraphError::InvalidParameter;
   }
 
+  beginGroupControlWrite();
   auto& group = m_groups[group_index];
-  group.output_start.store(output_start, std::memory_order_release);
-  group.output_width.store(output_width, std::memory_order_release);
+  group.output_start.store(output_start, std::memory_order_relaxed);
+  group.output_width.store(output_width, std::memory_order_relaxed);
   group.config.output_start = output_start;
   group.config.output_width = output_width;
+  endGroupControlWrite();
   return SessionGraphError::OK;
 }
 
@@ -416,20 +410,147 @@ bool RoutingMatrix::isChannelMuted(RoutingChannelIndex channel_index) const {
 }
 
 bool RoutingMatrix::isGroupMuted(RoutingGroupIndex group_index) const {
-  if (group_index >= m_groups.size()) {
+  const auto snapshot = getRoutingControlSnapshot();
+  if (group_index >= snapshot.group_count) {
     return true;
   }
+  return snapshot.groups[group_index].effective_mute;
+}
 
-  bool is_muted = m_groups[group_index].mute.load(std::memory_order_acquire);
-  bool is_solo = m_groups[group_index].solo.load(std::memory_order_acquire);
-  bool solo_active = m_group_solo_active.load(std::memory_order_acquire);
-
-  // If solo is active and this group is not solo'd, it's effectively muted
-  if (solo_active && !is_solo) {
-    return true;
+RoutingControlSnapshot RoutingMatrix::getRoutingControlSnapshot() const noexcept {
+  RoutingControlSnapshot snapshot;
+  if (!m_initialized.load(std::memory_order_acquire)) {
+    return snapshot;
   }
 
-  return is_muted;
+  for (;;) {
+    const uint64_t before = m_group_control_sequence.load(std::memory_order_acquire);
+    if ((before & 1u) != 0u) {
+      continue;
+    }
+
+    snapshot.group_count =
+        static_cast<RoutingGroupIndex>(std::min<size_t>(m_groups.size(), kRoutingControlMaxGroups));
+    const bool groupSoloActive = m_group_solo_active.load(std::memory_order_relaxed);
+    for (RoutingGroupIndex index = 0; index < snapshot.group_count; ++index) {
+      const auto& group = m_groups[index];
+      auto& state = snapshot.groups[index];
+      state.gain_db = group.configured_gain_db.load(std::memory_order_relaxed);
+      state.output_start = group.output_start.load(std::memory_order_relaxed);
+      state.output_width = group.output_width.load(std::memory_order_relaxed);
+      state.configured_mute = group.mute.load(std::memory_order_relaxed);
+      state.configured_solo = group.solo.load(std::memory_order_relaxed);
+      state.effective_mute = state.configured_mute || (groupSoloActive && !state.configured_solo);
+    }
+
+    const uint64_t after = m_group_control_sequence.load(std::memory_order_acquire);
+    if (before == after) {
+      snapshot.revision = after / 2u;
+      return snapshot;
+    }
+  }
+}
+
+bool RoutingMatrix::validateGroupControlSnapshot(
+    const RoutingControlSnapshot& snapshot) const noexcept {
+  if (snapshot.schema_version != kRoutingControlSnapshotSchemaVersion ||
+      snapshot.group_count != m_groups.size()) {
+    return false;
+  }
+  const auto& config = m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
+  for (RoutingGroupIndex index = 0; index < snapshot.group_count; ++index) {
+    const auto& state = snapshot.groups[index];
+    if (!std::isfinite(state.gain_db) || state.gain_db < -100.0f || state.gain_db > 12.0f ||
+        state.output_width == 0 ||
+        static_cast<uint32_t>(state.output_start) + state.output_width > config.num_outputs) {
+      return false;
+    }
+  }
+  return true;
+}
+
+SessionGraphError RoutingMatrix::applyGroupControlSnapshot(const RoutingControlSnapshot& snapshot) {
+  if (!m_initialized.load(std::memory_order_acquire)) {
+    return SessionGraphError::NotInitialized;
+  }
+  if (!validateGroupControlSnapshot(snapshot)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  beginGroupControlWrite();
+  for (RoutingGroupIndex index = 0; index < snapshot.group_count; ++index) {
+    const auto& state = snapshot.groups[index];
+    auto& group = m_groups[index];
+    group.configured_gain_db.store(state.gain_db, std::memory_order_relaxed);
+    group.mute.store(state.configured_mute, std::memory_order_relaxed);
+    group.solo.store(state.configured_solo, std::memory_order_relaxed);
+    group.output_start.store(state.output_start, std::memory_order_relaxed);
+    group.output_width.store(state.output_width, std::memory_order_relaxed);
+    group.config.gain_db = state.gain_db;
+    group.config.mute = state.configured_mute;
+    group.config.solo = state.configured_solo;
+    group.config.output_start = state.output_start;
+    group.config.output_width = state.output_width;
+  }
+  updateSoloState(false);
+  endGroupControlWrite();
+
+  if (m_callback) {
+    for (RoutingGroupIndex index = 0; index < snapshot.group_count; ++index) {
+      m_callback->onGroupGainChanged(index, snapshot.groups[index].gain_db);
+    }
+    m_callback->onSoloStateChanged(m_solo_active.load(std::memory_order_acquire));
+  }
+  return SessionGraphError::OK;
+}
+
+void RoutingMatrix::beginGroupControlWrite() noexcept {
+  bool expected = false;
+  while (!m_group_control_publication_in_progress.compare_exchange_weak(
+      expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
+    expected = false;
+  }
+  while (m_group_control_render_reading.load(std::memory_order_acquire)) {
+  }
+  m_group_control_sequence.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void RoutingMatrix::endGroupControlWrite() noexcept {
+  m_group_control_sequence.fetch_add(1, std::memory_order_release);
+  m_group_control_publication_in_progress.store(false, std::memory_order_release);
+}
+
+void RoutingMatrix::refreshRenderGroupControls() noexcept {
+  if (m_group_control_publication_in_progress.load(std::memory_order_acquire)) {
+    return;
+  }
+
+  m_group_control_render_reading.store(true, std::memory_order_release);
+  if (m_group_control_publication_in_progress.load(std::memory_order_acquire)) {
+    m_group_control_render_reading.store(false, std::memory_order_release);
+    return;
+  }
+
+  bool groupSoloActive = false;
+  for (RoutingGroupIndex index = 0; index < m_groups.size(); ++index) {
+    const auto& group = m_groups[index];
+    auto& state = m_render_group_controls[index];
+    const float gainDb = group.configured_gain_db.load(std::memory_order_relaxed);
+    if (gainDb != state.gain_db) {
+      state.gain_db = gainDb;
+      group.gain_smoother->setTarget(dbToLinear(gainDb));
+    }
+    state.output_start = group.output_start.load(std::memory_order_relaxed);
+    state.output_width = group.output_width.load(std::memory_order_relaxed);
+    state.configured_mute = group.mute.load(std::memory_order_relaxed);
+    state.configured_solo = group.solo.load(std::memory_order_relaxed);
+    groupSoloActive = groupSoloActive || state.configured_solo;
+  }
+  for (RoutingGroupIndex index = 0; index < m_groups.size(); ++index) {
+    auto& state = m_render_group_controls[index];
+    state.effective_mute = state.configured_mute || (groupSoloActive && !state.configured_solo);
+  }
+  m_group_control_render_reading.store(false, std::memory_order_release);
 }
 
 AudioMeter RoutingMatrix::getChannelMeter(RoutingChannelIndex channel_index) const {
@@ -502,9 +623,17 @@ RoutingSnapshot RoutingMatrix::saveSnapshot(const std::string& name,
     snapshot.channels.push_back(channel.config);
   }
 
-  // Save group states
-  for (const auto& group : m_groups) {
-    snapshot.groups.push_back(group.config);
+  // Save group controls from one coherent transaction boundary.
+  const auto controls = getRoutingControlSnapshot();
+  for (RoutingGroupIndex index = 0; index < controls.group_count; ++index) {
+    auto config = m_groups[index].config;
+    const auto& state = controls.groups[index];
+    config.gain_db = state.gain_db;
+    config.mute = state.configured_mute;
+    config.solo = state.configured_solo;
+    config.output_start = state.output_start;
+    config.output_width = state.output_width;
+    snapshot.groups.push_back(std::move(config));
   }
 
   // Save master state
@@ -527,14 +656,28 @@ SessionGraphError RoutingMatrix::loadSnapshot(const RoutingSnapshot& snapshot) {
     return SessionGraphError::InvalidParameter;
   }
 
-  // Load channel states
-  for (size_t i = 0; i < snapshot.channels.size(); ++i) {
-    configureChannel(static_cast<RoutingChannelIndex>(i), snapshot.channels[i]);
+  auto controls = getRoutingControlSnapshot();
+  for (RoutingGroupIndex index = 0; index < controls.group_count; ++index) {
+    const auto& group = snapshot.groups[index];
+    auto& state = controls.groups[index];
+    state.gain_db = group.gain_db;
+    state.configured_mute = group.mute;
+    state.configured_solo = group.solo;
+    state.output_start = group.output_start;
+    state.output_width = group.output_width;
+  }
+  const auto groupResult = applyGroupControlSnapshot(controls);
+  if (groupResult != SessionGraphError::OK) {
+    return groupResult;
+  }
+  for (RoutingGroupIndex index = 0; index < controls.group_count; ++index) {
+    m_groups[index].config.name = snapshot.groups[index].name;
+    m_groups[index].config.color = snapshot.groups[index].color;
   }
 
-  // Load group states
-  for (size_t i = 0; i < snapshot.groups.size(); ++i) {
-    configureGroup(static_cast<RoutingGroupIndex>(i), snapshot.groups[i]);
+  // Load channel states after the group transaction has validated.
+  for (size_t i = 0; i < snapshot.channels.size(); ++i) {
+    configureChannel(static_cast<RoutingChannelIndex>(i), snapshot.channels[i]);
   }
 
   // Load master state
@@ -555,10 +698,20 @@ SessionGraphError RoutingMatrix::reset() {
     configureChannel(static_cast<RoutingChannelIndex>(i), default_config);
   }
 
-  // Reset all groups to default
-  for (size_t i = 0; i < m_groups.size(); ++i) {
-    GroupConfig default_config;
-    configureGroup(static_cast<RoutingGroupIndex>(i), default_config);
+  // Reset all groups in one validated transaction.
+  auto controls = getRoutingControlSnapshot();
+  const auto& routingConfig = m_config_buffers[m_active_config_idx.load(std::memory_order_acquire)];
+  for (RoutingGroupIndex index = 0; index < controls.group_count; ++index) {
+    auto& state = controls.groups[index];
+    state.gain_db = 0.0f;
+    state.configured_mute = false;
+    state.configured_solo = false;
+    state.output_start = 0;
+    state.output_width = routingConfig.num_outputs;
+  }
+  const auto groupResult = applyGroupControlSnapshot(controls);
+  if (groupResult != SessionGraphError::OK) {
+    return groupResult;
   }
 
   // Reset master
@@ -591,6 +744,7 @@ SessionGraphError RoutingMatrix::processRouting(const float* const* channel_inpu
   //
   // Get active config (lock-free read) to know the channel/output counts for
   // pointer offsetting.
+  refreshRenderGroupControls();
   {
     int cfg_idx = m_active_config_idx.load(std::memory_order_acquire);
     const RoutingConfig& cfg = m_config_buffers[cfg_idx];
@@ -730,13 +884,12 @@ SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel
   for (RoutingGroupIndex group_index = 0; group_index < config.num_groups; ++group_index) {
     auto& group = m_groups[group_index];
     auto& group_buffer = m_group_buffers[group_index];
-    const bool muted = isGroupMuted(group_index);
+    const auto& controls = m_render_group_controls[group_index];
+    const bool muted = controls.effective_mute;
     const float headroom = getHeadroomCompensation(group_index);
 
-    const RoutingOutputIndex outputStart =
-        group.output_start.load(std::memory_order_acquire);
-    const uint16_t outputWidth =
-        group.output_width.load(std::memory_order_acquire);
+    const RoutingOutputIndex outputStart = controls.output_start;
+    const uint16_t outputWidth = controls.output_width;
 
     for (uint32_t frame = 0; frame < num_frames; ++frame) {
       const float group_gain = group.gain_smoother->process();
@@ -762,8 +915,7 @@ SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel
     }
 
     if (config.enable_metering) {
-      const float* right =
-          config.num_outputs > 1 ? group_buffer.channels[1].data() : nullptr;
+      const float* right = config.num_outputs > 1 ? group_buffer.channels[1].data() : nullptr;
       processStereoMetering(group_buffer.channels[0].data(), right, num_frames,
                             group.true_peak_meters, group.peak_level, group.rms_level);
       for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
@@ -787,9 +939,8 @@ SessionGraphError RoutingMatrix::processRoutingBlock(const float* const* channel
   }
 
   if (config.enable_metering) {
-    processStereoMetering(master_output[0],
-                          config.num_outputs > 1 ? master_output[1] : nullptr, num_frames,
-                          m_master_true_peak_meters, m_master_peak, m_master_rms);
+    processStereoMetering(master_output[0], config.num_outputs > 1 ? master_output[1] : nullptr,
+                          num_frames, m_master_true_peak_meters, m_master_peak, m_master_rms);
     for (RoutingOutputIndex output = 0; output < config.num_outputs; ++output) {
       if (detectClipping(master_output[output], num_frames)) {
         m_master_clip_count.fetch_add(1, std::memory_order_relaxed);
@@ -856,8 +1007,7 @@ void RoutingMatrix::initializeChannels() {
     // Default config
     channel.config.name = "Channel " + std::to_string(i + 1);
     channel.config.group_index = 0;
-    channel.config.output_channel =
-        static_cast<RoutingOutputIndex>(i % config.num_outputs);
+    channel.config.output_channel = static_cast<RoutingOutputIndex>(i % config.num_outputs);
     channel.config.gain_db = 0.0f;
     channel.config.pan = 0.0f;
     channel.config.mute = false;
@@ -885,6 +1035,7 @@ void RoutingMatrix::initializeGroups() {
 
     group.mute.store(false, std::memory_order_release);
     group.solo.store(false, std::memory_order_release);
+    group.configured_gain_db.store(0.0f, std::memory_order_release);
 
     group.peak_level.store(0.0f, std::memory_order_release);
     group.rms_level.store(0.0f, std::memory_order_release);
@@ -901,11 +1052,19 @@ void RoutingMatrix::initializeGroups() {
     group.config.output_width = config.num_outputs;
     group.config.color = 0xFFFFFFFF;
 
+    auto& renderState = m_render_group_controls[i];
+    renderState.gain_db = 0.0f;
+    renderState.output_start = 0;
+    renderState.output_width = config.num_outputs;
+    renderState.configured_mute = false;
+    renderState.configured_solo = false;
+    renderState.effective_mute = false;
+
     m_groups.push_back(std::move(group));
   }
 }
 
-void RoutingMatrix::updateSoloState() {
+void RoutingMatrix::updateSoloState(bool notifyCallback) {
   bool any_channel_solo = false;
   for (const auto& channel : m_channels) {
     if (channel.solo.load(std::memory_order_acquire)) {
@@ -927,8 +1086,9 @@ void RoutingMatrix::updateSoloState() {
   const bool any_solo = any_channel_solo || any_group_solo;
   m_solo_active.store(any_solo, std::memory_order_release);
 
-  // Notify callback
-  if (m_callback) {
+  // Notify callback after state publication unless a surrounding transaction
+  // owns the notification boundary.
+  if (notifyCallback && m_callback) {
     m_callback->onSoloStateChanged(any_solo);
   }
 }

--- a/src/core/routing/routing_matrix.h
+++ b/src/core/routing/routing_matrix.h
@@ -57,6 +57,7 @@ struct GroupState {
   std::unique_ptr<GainSmoother> gain_smoother; ///< Gain smoothing
   std::atomic<bool> mute;
   std::atomic<bool> solo;
+  std::atomic<float> configured_gain_db;
   std::atomic<RoutingOutputIndex> output_start;
   std::atomic<uint16_t> output_width;
 
@@ -72,15 +73,15 @@ struct GroupState {
   // Move constructor (needed for std::vector with atomics)
   GroupState(GroupState&& other) noexcept
       : gain_smoother(std::move(other.gain_smoother)), mute(other.mute.load()),
-        solo(other.solo.load()), output_start(other.output_start.load()),
-        output_width(other.output_width.load()), peak_level(other.peak_level.load()),
-        rms_level(other.rms_level.load()), clip_count(other.clip_count.load()),
-        true_peak_meters(std::move(other.true_peak_meters)),
+        solo(other.solo.load()), configured_gain_db(other.configured_gain_db.load()),
+        output_start(other.output_start.load()), output_width(other.output_width.load()),
+        peak_level(other.peak_level.load()), rms_level(other.rms_level.load()),
+        clip_count(other.clip_count.load()), true_peak_meters(std::move(other.true_peak_meters)),
         config(std::move(other.config)) {}
 
   // Default constructor
   GroupState()
-      : gain_smoother(nullptr), mute(false), solo(false), output_start(0),
+      : gain_smoother(nullptr), mute(false), solo(false), configured_gain_db(0.0f), output_start(0),
         output_width(2), peak_level(0.0f), rms_level(0.0f), clip_count(0) {}
 
   // Deleted copy constructor (atomics are not copyable)
@@ -135,9 +136,10 @@ public:
   SessionGraphError configureGroup(RoutingGroupIndex group_index,
                                    const GroupConfig& config) override;
 
-  SessionGraphError setGroupOutputRoute(
-      RoutingGroupIndex group_index, RoutingOutputIndex output_start,
-      uint16_t output_width) override;
+  SessionGraphError setGroupOutputRoute(RoutingGroupIndex group_index,
+                                        RoutingOutputIndex output_start,
+                                        uint16_t output_width) override;
+  SessionGraphError applyGroupControlSnapshot(const RoutingControlSnapshot& snapshot) override;
 
   // Master configuration
   SessionGraphError setMasterGain(float gain_db) override;
@@ -150,6 +152,7 @@ public:
   AudioMeter getChannelMeter(RoutingChannelIndex channel_index) const override;
   AudioMeter getGroupMeter(RoutingGroupIndex group_index) const override;
   AudioMeter getMasterMeter() const override;
+  RoutingControlSnapshot getRoutingControlSnapshot() const noexcept override;
 
   // Snapshots
   RoutingSnapshot saveSnapshot(const std::string& name,
@@ -158,8 +161,8 @@ public:
   SessionGraphError reset() override;
 
   // Audio processing
-  SessionGraphError processRouting(const float* const* channel_inputs,
-                                   float* const* master_output, uint32_t num_frames) override;
+  SessionGraphError processRouting(const float* const* channel_inputs, float* const* master_output,
+                                   uint32_t num_frames) override;
   uint32_t maxBlockFrames() const override;
 
 private:
@@ -176,8 +179,12 @@ private:
   void cleanupChannels();
   void cleanupGroups();
 
-  void updateSoloState();
+  void updateSoloState(bool notifyCallback = true);
   void updatePanLaw(RoutingChannelIndex channel_index, float pan);
+  void beginGroupControlWrite() noexcept;
+  void endGroupControlWrite() noexcept;
+  bool validateGroupControlSnapshot(const RoutingControlSnapshot& snapshot) const noexcept;
+  void refreshRenderGroupControls() noexcept;
 
   float dbToLinear(float db) const;
   float linearToDb(float linear) const;
@@ -217,6 +224,15 @@ private:
   std::atomic<bool> m_group_solo_active{false};
   std::atomic<bool> m_solo_active{false};
   std::atomic<uint64_t> m_snapshot_revision{0};
+  /// Seqlock for fixed-capacity coherent group-control publication. The host's
+  /// control thread is the sole writer; readers may run concurrently.
+  std::atomic<uint64_t> m_group_control_sequence{0};
+  /// Control writers defer until the audio thread finishes its bounded snapshot
+  /// copy. The audio thread never waits; it renders the prior complete value
+  /// when publication is in progress.
+  std::atomic<bool> m_group_control_publication_in_progress{false};
+  std::atomic<bool> m_group_control_render_reading{false};
+  std::array<RoutingGroupControlState, kRoutingControlMaxGroups> m_render_group_controls{};
 
   // Callback
   IRoutingCallback* m_callback;

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(orpheus_audio_driver_manager
 target_link_libraries(orpheus_audio_driver_manager
     PUBLIC
         orpheus_session  # For SessionGraphError
+        orpheus_audio_io  # For the cross-platform dummy driver factory
 )
 
 # Link platform-specific frameworks

--- a/tests/cmake/find_package/transport_routing.cpp
+++ b/tests/cmake/find_package/transport_routing.cpp
@@ -15,6 +15,11 @@ static_assert(std::is_standard_layout_v<orpheus::TransportCallbackTelemetry>);
 static_assert(std::is_trivially_copyable_v<orpheus::ActiveVoiceSnapshot>);
 static_assert(std::is_standard_layout_v<orpheus::ActiveVoiceSnapshot>);
 static_assert(orpheus::kActiveVoiceSnapshotCapacity == 32);
+static_assert(std::is_trivially_copyable_v<orpheus::RoutingGroupControlState>);
+static_assert(std::is_standard_layout_v<orpheus::RoutingGroupControlState>);
+static_assert(std::is_trivially_copyable_v<orpheus::RoutingControlSnapshot>);
+static_assert(std::is_standard_layout_v<orpheus::RoutingControlSnapshot>);
+static_assert(orpheus::kRoutingControlMaxGroups == 32);
 
 namespace {
 
@@ -73,6 +78,31 @@ int main() {
   if (routing->processRouting(inputs, outputs, frames) != orpheus::SessionGraphError::OK ||
       left[2048] < 0.3f || right.back() < 0.3f) {
     return 2;
+  }
+
+  const auto initialRouting = routing->getRoutingControlSnapshot();
+  if (initialRouting.schema_version != orpheus::kRoutingControlSnapshotSchemaVersion ||
+      initialRouting.group_count != 1) {
+    return 7;
+  }
+  auto desiredRouting = initialRouting;
+  desiredRouting.groups[0].gain_db = -6.0f;
+  desiredRouting.groups[0].configured_mute = true;
+  if (routing->applyGroupControlSnapshot(desiredRouting) != orpheus::SessionGraphError::OK) {
+    return 8;
+  }
+  const auto appliedRouting = routing->getRoutingControlSnapshot();
+  if (appliedRouting.revision != initialRouting.revision + 1 ||
+      appliedRouting.groups[0].gain_db != -6.0f || !appliedRouting.groups[0].configured_mute ||
+      !appliedRouting.groups[0].effective_mute) {
+    return 9;
+  }
+  auto invalidRouting = appliedRouting;
+  invalidRouting.groups[0].output_width = 3;
+  if (routing->applyGroupControlSnapshot(invalidRouting) !=
+          orpheus::SessionGraphError::InvalidParameter ||
+      routing->getRoutingControlSnapshot().revision != appliedRouting.revision) {
+    return 10;
   }
 
   orpheus::TransportConfig transportConfig;

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+#include <orpheus/routing_matrix.h>
 #include <orpheus/transport_controller.h>
 
 #include <cstddef>
@@ -28,7 +29,8 @@ int main() {
   constexpr orpheus::ClipHandle kHandle = 17;
   constexpr size_t kFrames = 64;
 
-  auto transport = orpheus::createTransportController(nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
+  auto transport = orpheus::createTransportController(
+      nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});
   if (!transport) {
     return 1;
   }
@@ -39,8 +41,27 @@ int main() {
     return 2;
   }
 
-  std::vector<std::vector<float>> storage(
-      config.outputChannels, std::vector<float>(kFrames, 1.0f));
+  auto* routing = transport->getRoutingMatrix();
+  if (routing == nullptr) {
+    return 7;
+  }
+  const auto initialRouting = routing->getRoutingControlSnapshot();
+  if (initialRouting.group_count != config.numGroups) {
+    return 8;
+  }
+  auto desiredRouting = initialRouting;
+  desiredRouting.groups[0].gain_db = -4.0f;
+  desiredRouting.groups[0].configured_mute = true;
+  if (routing->applyGroupControlSnapshot(desiredRouting) != orpheus::SessionGraphError::OK) {
+    return 9;
+  }
+  const auto appliedRouting = routing->getRoutingControlSnapshot();
+  if (appliedRouting.revision != initialRouting.revision + 1 ||
+      appliedRouting.groups[0].gain_db != -4.0f || !appliedRouting.groups[0].configured_mute) {
+    return 10;
+  }
+
+  std::vector<std::vector<float>> storage(config.outputChannels, std::vector<float>(kFrames, 1.0f));
   std::vector<float*> outputs;
   outputs.reserve(config.outputChannels);
   for (auto& channel : storage) {

--- a/tests/routing/routing_matrix_test.cpp
+++ b/tests/routing/routing_matrix_test.cpp
@@ -2,10 +2,12 @@
 #include "../../include/orpheus/routing_matrix.h"
 
 #include <array>
+#include <atomic>
 
 #include <cmath>
 #include <gtest/gtest.h>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace orpheus;
@@ -1134,6 +1136,198 @@ TEST_F(RoutingMatrixTest, ProcessRoutingLargeBlockMatchesChunkedEquivalent) {
     EXPECT_NEAR(outA[0][i], outB[0][i], 1e-6f) << "left mismatch @ " << i;
     EXPECT_NEAR(outA[1][i], outB[1][i], 1e-6f) << "right mismatch @ " << i;
   }
+}
+
+// ============================================================================
+// Coherent group-control contract
+// ============================================================================
+
+TEST_F(RoutingMatrixTest, GroupControlSnapshotReportsConfiguredAndEffectiveState) {
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+
+  const auto initial = matrix->getRoutingControlSnapshot();
+  ASSERT_EQ(initial.schema_version, kRoutingControlSnapshotSchemaVersion);
+  ASSERT_EQ(initial.group_count, 2);
+  EXPECT_EQ(initial.revision, 0u);
+
+  ASSERT_EQ(matrix->setGroupGain(0, -6.0f), SessionGraphError::OK);
+  ASSERT_EQ(matrix->setGroupMute(0, true), SessionGraphError::OK);
+  ASSERT_EQ(matrix->setGroupSolo(1, true), SessionGraphError::OK);
+
+  const auto snapshot = matrix->getRoutingControlSnapshot();
+  EXPECT_EQ(snapshot.revision, 3u);
+  EXPECT_FLOAT_EQ(snapshot.groups[0].gain_db, -6.0f);
+  EXPECT_TRUE(snapshot.groups[0].configured_mute);
+  EXPECT_FALSE(snapshot.groups[0].configured_solo);
+  EXPECT_TRUE(snapshot.groups[0].effective_mute);
+  EXPECT_FALSE(snapshot.groups[1].configured_mute);
+  EXPECT_TRUE(snapshot.groups[1].configured_solo);
+  EXPECT_FALSE(snapshot.groups[1].effective_mute);
+}
+
+TEST_F(RoutingMatrixTest, GroupControlTransactionRejectsInvalidStateWithoutMutation) {
+  config.num_outputs = 4;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  const auto before = matrix->getRoutingControlSnapshot();
+
+  auto invalid = before;
+  invalid.groups[0].gain_db = -9.0f;
+  invalid.groups[0].configured_mute = true;
+  invalid.groups[1].output_start = 3;
+  invalid.groups[1].output_width = 2;
+  EXPECT_EQ(matrix->applyGroupControlSnapshot(invalid), SessionGraphError::InvalidParameter);
+
+  const auto after = matrix->getRoutingControlSnapshot();
+  EXPECT_EQ(after.revision, before.revision);
+  EXPECT_FLOAT_EQ(after.groups[0].gain_db, before.groups[0].gain_db);
+  EXPECT_EQ(after.groups[0].configured_mute, before.groups[0].configured_mute);
+  EXPECT_EQ(after.groups[1].output_start, before.groups[1].output_start);
+  EXPECT_EQ(after.groups[1].output_width, before.groups[1].output_width);
+}
+
+TEST_F(RoutingMatrixTest, GroupControlTransactionPublishesOneCoherentRevision) {
+  config.num_outputs = 4;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  auto desired = matrix->getRoutingControlSnapshot();
+  desired.groups[0].gain_db = -3.0f;
+  desired.groups[0].configured_mute = true;
+  desired.groups[0].output_start = 0;
+  desired.groups[0].output_width = 2;
+  desired.groups[1].gain_db = 4.0f;
+  desired.groups[1].configured_solo = true;
+  desired.groups[1].output_start = 2;
+  desired.groups[1].output_width = 2;
+
+  ASSERT_EQ(matrix->applyGroupControlSnapshot(desired), SessionGraphError::OK);
+  const auto applied = matrix->getRoutingControlSnapshot();
+  EXPECT_EQ(applied.revision, desired.revision + 1u);
+  EXPECT_FLOAT_EQ(applied.groups[0].gain_db, -3.0f);
+  EXPECT_TRUE(applied.groups[0].configured_mute);
+  EXPECT_EQ(applied.groups[0].output_width, 2);
+  EXPECT_FLOAT_EQ(applied.groups[1].gain_db, 4.0f);
+  EXPECT_TRUE(applied.groups[1].configured_solo);
+  EXPECT_EQ(applied.groups[1].output_start, 2);
+}
+
+TEST_F(RoutingMatrixTest, AcceptedGroupTransactionTakesEffectAtNextRenderBoundary) {
+  config.num_channels = 2;
+  config.num_groups = 2;
+  config.num_outputs = 4;
+  config.source_channel_policy = SourceChannelPolicy::Discrete;
+  config.enable_metering = false;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+
+  ChannelConfig channel0;
+  channel0.group_index = 0;
+  channel0.output_channel = 0;
+  ChannelConfig channel1;
+  channel1.group_index = 1;
+  channel1.output_channel = 0;
+  ASSERT_EQ(matrix->configureChannel(0, channel0), SessionGraphError::OK);
+  ASSERT_EQ(matrix->configureChannel(1, channel1), SessionGraphError::OK);
+
+  auto profile = matrix->getRoutingControlSnapshot();
+  profile.groups[0].output_start = 1;
+  profile.groups[0].output_width = 1;
+  profile.groups[1].configured_mute = true;
+  profile.groups[1].output_start = 3;
+  profile.groups[1].output_width = 1;
+  ASSERT_EQ(matrix->applyGroupControlSnapshot(profile), SessionGraphError::OK);
+
+  std::vector<float> source0(BUFFER_SIZE, 0.25f);
+  std::vector<float> source1(BUFFER_SIZE, 0.5f);
+  const float* inputs[2] = {source0.data(), source1.data()};
+  std::vector<std::vector<float>> outputs(config.num_outputs,
+                                          std::vector<float>(BUFFER_SIZE, -999.0f));
+  auto outputPointers = toPointerArray(outputs);
+  ASSERT_EQ(matrix->processRouting(inputs, outputPointers.data(), BUFFER_SIZE),
+            SessionGraphError::OK);
+
+  EXPECT_FLOAT_EQ(outputs[0].front(), 0.0f);
+  EXPECT_NEAR(outputs[1].front(), 0.25f, TOLERANCE);
+  EXPECT_FLOAT_EQ(outputs[2].front(), 0.0f);
+  EXPECT_FLOAT_EQ(outputs[3].front(), 0.0f);
+}
+
+TEST_F(RoutingMatrixTest, RoutingPresetRecallPublishesSavedGroupControls) {
+  config.num_outputs = 4;
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  auto expected = matrix->getRoutingControlSnapshot();
+  expected.groups[0].gain_db = -12.0f;
+  expected.groups[0].configured_mute = true;
+  expected.groups[0].output_width = 1;
+  expected.groups[1].gain_db = 3.0f;
+  expected.groups[1].output_start = 2;
+  expected.groups[1].output_width = 2;
+  ASSERT_EQ(matrix->applyGroupControlSnapshot(expected), SessionGraphError::OK);
+  const auto preset = matrix->saveSnapshot("routing");
+
+  auto changed = matrix->getRoutingControlSnapshot();
+  changed.groups[0].gain_db = 0.0f;
+  changed.groups[0].configured_mute = false;
+  changed.groups[0].output_width = 4;
+  changed.groups[1].gain_db = 0.0f;
+  changed.groups[1].output_start = 0;
+  changed.groups[1].output_width = 4;
+  ASSERT_EQ(matrix->applyGroupControlSnapshot(changed), SessionGraphError::OK);
+  ASSERT_EQ(matrix->loadSnapshot(preset), SessionGraphError::OK);
+
+  const auto recalled = matrix->getRoutingControlSnapshot();
+  EXPECT_FLOAT_EQ(recalled.groups[0].gain_db, -12.0f);
+  EXPECT_TRUE(recalled.groups[0].configured_mute);
+  EXPECT_EQ(recalled.groups[0].output_width, 1);
+  EXPECT_FLOAT_EQ(recalled.groups[1].gain_db, 3.0f);
+  EXPECT_EQ(recalled.groups[1].output_start, 2);
+  EXPECT_EQ(recalled.groups[1].output_width, 2);
+}
+
+TEST_F(RoutingMatrixTest, ConcurrentRenderAndQueryObserveOnlyCompleteTransactions) {
+  ASSERT_EQ(matrix->initialize(config), SessionGraphError::OK);
+  auto stateA = matrix->getRoutingControlSnapshot();
+  stateA.groups[0].gain_db = -8.0f;
+  stateA.groups[0].configured_mute = true;
+  stateA.groups[1].gain_db = 2.0f;
+  stateA.groups[1].configured_solo = false;
+  auto stateB = stateA;
+  stateB.groups[0].gain_db = 5.0f;
+  stateB.groups[0].configured_mute = false;
+  stateB.groups[1].gain_db = -4.0f;
+  stateB.groups[1].configured_solo = true;
+  ASSERT_EQ(matrix->applyGroupControlSnapshot(stateA), SessionGraphError::OK);
+
+  std::atomic<bool> writerDone{false};
+  std::atomic<bool> failed{false};
+  std::thread writer([&] {
+    for (int iteration = 0; iteration < 2000; ++iteration) {
+      const auto& state = (iteration & 1) == 0 ? stateB : stateA;
+      if (matrix->applyGroupControlSnapshot(state) != SessionGraphError::OK) {
+        failed.store(true, std::memory_order_release);
+      }
+    }
+    writerDone.store(true, std::memory_order_release);
+  });
+
+  auto inputs = createTestInputs(config.num_channels, BUFFER_SIZE);
+  auto inputPointers = toPointerArray(inputs);
+  std::vector<std::vector<float>> outputs(config.num_outputs, std::vector<float>(BUFFER_SIZE));
+  auto outputPointers = toPointerArray(outputs);
+  do {
+    if (matrix->processRouting(reinterpret_cast<const float* const*>(inputPointers.data()),
+                               outputPointers.data(), BUFFER_SIZE) != SessionGraphError::OK) {
+      failed.store(true, std::memory_order_release);
+    }
+    const auto observed = matrix->getRoutingControlSnapshot();
+    const bool isA = observed.groups[0].gain_db == -8.0f && observed.groups[0].configured_mute &&
+                     observed.groups[1].gain_db == 2.0f && !observed.groups[1].configured_solo;
+    const bool isB = observed.groups[0].gain_db == 5.0f && !observed.groups[0].configured_mute &&
+                     observed.groups[1].gain_db == -4.0f && observed.groups[1].configured_solo;
+    if (!isA && !isB) {
+      failed.store(true, std::memory_order_release);
+    }
+  } while (!writerDone.load(std::memory_order_acquire));
+
+  writer.join();
+  EXPECT_FALSE(failed.load(std::memory_order_acquire));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add fixed-capacity coherent configured/effective group routing snapshots
- add validated failure-atomic batch application published at one render boundary
- cover public routing and transport package consumers and release as SDK 0.6.0

## Verification
- 150/150 configured SDK tests pass
- routing_matrix_test passes under ThreadSanitizer
- installed routing and transport package fixtures pass
- realtime static audit, docs audit, and version contract pass