### PR TITLE
feat(audio): add prepared tape varispeed

### DIFF
--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -8,6 +8,7 @@ Project documentation index for orpheus-sdk.
 
 ## Recent Documents
 
+- [[ORP160 Master Tape Varispeed Primitive]]
 - [[ORP159 Suite Synchronization and Integration Gate]]
 - [[ORP158 Installed ShmUI-JUCE Package Qualification]]
 - [[ORP157 Suite Coherence and Package Consumer Mission]]
@@ -86,6 +87,7 @@ Project documentation index for orpheus-sdk.
 - [[ORP157 Suite Coherence and Package Consumer Mission]]
 - [[ORP158 Installed ShmUI-JUCE Package Qualification]]
 - [[ORP159 Suite Synchronization and Integration Gate]]
+- [[ORP160 Master Tape Varispeed Primitive]]
 
 ## Archived Documents
 
@@ -120,4 +122,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-07-20
+**Last Generated:** 2026-07-21

--- a/docs/orp/ORP160 Master Tape Varispeed Primitive.md
+++ b/docs/orp/ORP160 Master Tape Varispeed Primitive.md
@@ -1,0 +1,34 @@
+# ORP160 Master Tape Varispeed Primitive
+
+**Status:** Draft implementation — FourTrack FTR063 contract accepted; release and merge require separate user review.
+
+**Related:** FTR063, FTR062, ORP128/ORP129 (`ScrubResampler`), ORP127 (`PolyphaseResampler`)
+
+## Scope
+
+`PreparedTapeVarispeed` and `OfflineTapeVarispeed` are host-neutral interleaved
+positive-rate tape processors for `0.5x...2.0x`. They preserve linked stereo
+phase, move pitch and duration together, validate all public inputs, and use an
+allocation-free prepared processing path. `ScrubResampler` remains signed,
+linear, and monitor-only; it is not a fallback for this facility.
+
+## Contract
+
+The installed public API is `include/orpheus/tape_varispeed.h` in
+`Orpheus::audio_utils`. `prepare()` owns allocation and fixed Kaiser-windowed
+sinc-kernel preparation. `process()`, `drain()`, `reset()`, and accessors do
+not allocate or acquire locks. Invalid configuration, rate, pointer, or prepared
+capacity returns `InvalidParameter` without mutating processor state.
+
+The caller owns source buffering. `TapeVarispeedProcessResult` reports exact
+input consumption and output production so arbitrary block chunking can retain
+unconsumed input. Unity with no active slew is a byte-identical copy path.
+
+## Remaining release evidence
+
+This draft does not yet satisfy the release gate. Before it can be merged or
+published, ORP160 must add and pass: measurable endpoint passband/image tests,
+chunk-invariance and drain fixtures, duplex reciprocal-slew contract coverage,
+callback allocation/static-audit proof, clean-prefix package fixtures, and
+44.1/48 kHz M2 timing plus user listening review. FourTrack must not consume this
+branch or any unreleased SDK SHA.

--- a/include/orpheus/tape_varispeed.h
+++ b/include/orpheus/tape_varispeed.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "orpheus/errors.h"
+#include "orpheus/export.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace orpheus {
+
+enum class TapeVarispeedSlewClock : uint8_t { InputFrames, OutputFrames };
+
+struct TapeVarispeedConfig {
+  uint32_t sample_rate = 0;
+  uint16_t channels = 0;
+  size_t max_input_frames = 0;
+  size_t max_output_frames = 0;
+  double min_rate = 0.5;
+  double max_rate = 2.0;
+  double initial_rate = 1.0;
+  uint32_t rate_slew_frames = 0;
+  TapeVarispeedSlewClock slew_clock = TapeVarispeedSlewClock::OutputFrames;
+};
+
+struct TapeVarispeedProcessResult {
+  SessionGraphError error = SessionGraphError::OK;
+  size_t input_frames_consumed = 0;
+  size_t output_frames_produced = 0;
+};
+
+/// Prepared, interleaved, positive-rate tape varispeed. prepare() owns every
+/// allocation; process(), drain(), reset(), and accessors are callback-safe.
+class ORPHEUS_API PreparedTapeVarispeed {
+public:
+  PreparedTapeVarispeed();
+  ~PreparedTapeVarispeed();
+  PreparedTapeVarispeed(PreparedTapeVarispeed&&) noexcept;
+  PreparedTapeVarispeed& operator=(PreparedTapeVarispeed&&) noexcept;
+  PreparedTapeVarispeed(const PreparedTapeVarispeed&) = delete;
+  PreparedTapeVarispeed& operator=(const PreparedTapeVarispeed&) = delete;
+
+  SessionGraphError prepare(const TapeVarispeedConfig& config);
+  size_t required_input_frames(size_t output_frames) const noexcept;
+  size_t required_output_capacity(size_t input_frames) const noexcept;
+  size_t max_drain_frames() const noexcept;
+  size_t latency_frames() const noexcept;
+  double applied_rate() const noexcept;
+  TapeVarispeedProcessResult process(const float* interleaved_input, size_t input_frames,
+                                     float* interleaved_output, size_t output_capacity_frames,
+                                     double target_rate) noexcept;
+  TapeVarispeedProcessResult drain(float* interleaved_output,
+                                   size_t output_capacity_frames) noexcept;
+  SessionGraphError reset(double initial_rate) noexcept;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/// Offline counterpart using the identical kernel. It may allocate only during
+/// configure(); callers provide every output buffer to process() and drain().
+class ORPHEUS_API OfflineTapeVarispeed {
+public:
+  OfflineTapeVarispeed();
+  ~OfflineTapeVarispeed();
+  OfflineTapeVarispeed(OfflineTapeVarispeed&&) noexcept;
+  OfflineTapeVarispeed& operator=(OfflineTapeVarispeed&&) noexcept;
+  OfflineTapeVarispeed(const OfflineTapeVarispeed&) = delete;
+  OfflineTapeVarispeed& operator=(const OfflineTapeVarispeed&) = delete;
+
+  SessionGraphError configure(uint32_t sample_rate, uint16_t channels, double rate);
+  size_t required_output_capacity(size_t input_frames) const noexcept;
+  size_t max_drain_frames() const noexcept;
+  TapeVarispeedProcessResult process(const float* interleaved_input, size_t input_frames,
+                                     float* interleaved_output, size_t output_capacity_frames);
+  TapeVarispeedProcessResult drain(float* interleaved_output, size_t output_capacity_frames);
+  void reset() noexcept;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace orpheus

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -37,6 +37,9 @@ list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_file_reader.cpp)
 # dependency-free — always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES scrub_resampler.cpp)
 
+# ORP160/FTR063: prepared premium tape-varispeed processor. Always built.
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES tape_varispeed.cpp)
+
 # ORP134 G7: lock-free input ring + capture-stream contract. Host-neutral,
 # dependency-free — always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES audio_input.cpp)

--- a/src/core/audio_io/tape_varispeed.cpp
+++ b/src/core/audio_io/tape_varispeed.cpp
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT
+
+#include "orpheus/tape_varispeed.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+constexpr size_t kTapCount = 128;
+constexpr size_t kHalfTaps = kTapCount / 2;
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kKaiserBeta = 10.0;
+
+bool valid_rate(double rate, double minimum, double maximum) {
+  return std::isfinite(rate) && rate >= minimum && rate <= maximum;
+}
+
+double bessel_i0(double value) {
+  double term = 1.0;
+  double sum = 1.0;
+  const double square = value * value / 4.0;
+  for (int index = 1; index < 40; ++index) {
+    term *= square / static_cast<double>(index * index);
+    sum += term;
+    if (term < sum * 1.0e-16) {
+      break;
+    }
+  }
+  return sum;
+}
+
+double sinc(double value) {
+  if (std::abs(value) < 1.0e-12) {
+    return 1.0;
+  }
+  const double radians = kPi * value;
+  return std::sin(radians) / radians;
+}
+
+} // namespace
+
+struct PreparedTapeVarispeed::Impl {
+  TapeVarispeedConfig config{};
+  std::vector<float> history;
+  std::vector<double> window;
+  double phase = 0.0;
+  double applied = 1.0;
+  double target = 1.0;
+  double rate_step = 0.0;
+  uint32_t slew_remaining = 0;
+  bool prepared = false;
+
+  float source_sample(const float* input, size_t input_frames, int64_t frame,
+                      uint16_t channel) const noexcept {
+    if (frame >= 0 && static_cast<size_t>(frame) < input_frames) {
+      return input[static_cast<size_t>(frame) * config.channels + channel];
+    }
+    if (frame < 0) {
+      const int64_t history_frame = static_cast<int64_t>(kTapCount) + frame;
+      if (history_frame >= 0) {
+        return history[static_cast<size_t>(history_frame) * config.channels + channel];
+      }
+    }
+    return 0.0f;
+  }
+
+  void append_history(const float* input, size_t consumed) noexcept {
+    if (consumed == 0) {
+      return;
+    }
+    const size_t channels = config.channels;
+    if (consumed >= kTapCount) {
+      std::memcpy(history.data(), input + (consumed - kTapCount) * channels,
+                  kTapCount * channels * sizeof(float));
+      return;
+    }
+    const size_t retained = kTapCount - consumed;
+    std::memmove(history.data(), history.data() + consumed * channels,
+                 retained * channels * sizeof(float));
+    std::memcpy(history.data() + retained * channels, input, consumed * channels * sizeof(float));
+  }
+
+  void start_slew(double next_target) noexcept {
+    if (next_target == target) {
+      return;
+    }
+    target = next_target;
+    slew_remaining = config.rate_slew_frames;
+    if (slew_remaining == 0) {
+      applied = target;
+      rate_step = 0.0;
+      return;
+    }
+    rate_step = (target - applied) / static_cast<double>(slew_remaining);
+  }
+
+  void advance_rate() noexcept {
+    if (slew_remaining == 0) {
+      return;
+    }
+    applied += rate_step;
+    --slew_remaining;
+    if (slew_remaining == 0) {
+      applied = target;
+      rate_step = 0.0;
+    }
+  }
+};
+
+PreparedTapeVarispeed::PreparedTapeVarispeed() : impl_(std::make_unique<Impl>()) {}
+PreparedTapeVarispeed::~PreparedTapeVarispeed() = default;
+PreparedTapeVarispeed::PreparedTapeVarispeed(PreparedTapeVarispeed&&) noexcept = default;
+PreparedTapeVarispeed& PreparedTapeVarispeed::operator=(PreparedTapeVarispeed&&) noexcept = default;
+
+SessionGraphError PreparedTapeVarispeed::prepare(const TapeVarispeedConfig& config) {
+  if (config.sample_rate == 0 || config.channels == 0 || config.max_input_frames == 0 ||
+      config.max_output_frames == 0 || !std::isfinite(config.min_rate) ||
+      !std::isfinite(config.max_rate) || config.min_rate <= 0.0 ||
+      config.min_rate > config.max_rate ||
+      !valid_rate(config.initial_rate, config.min_rate, config.max_rate)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  try {
+    Impl next;
+    next.config = config;
+    next.history.assign(kTapCount * config.channels, 0.0f);
+    next.window.resize(kTapCount);
+    const double denominator = bessel_i0(kKaiserBeta);
+    for (size_t tap = 0; tap < kTapCount; ++tap) {
+      const double position =
+          (2.0 * static_cast<double>(tap) / static_cast<double>(kTapCount - 1)) - 1.0;
+      next.window[tap] =
+          bessel_i0(kKaiserBeta * std::sqrt(std::max(0.0, 1.0 - position * position))) /
+          denominator;
+    }
+    next.applied = config.initial_rate;
+    next.target = config.initial_rate;
+    next.prepared = true;
+    *impl_ = std::move(next);
+  } catch (const std::bad_alloc&) {
+    return SessionGraphError::NotSupported;
+  }
+  return SessionGraphError::OK;
+}
+
+size_t PreparedTapeVarispeed::required_input_frames(size_t output_frames) const noexcept {
+  if (!impl_->prepared || output_frames > impl_->config.max_output_frames) {
+    return 0;
+  }
+  const double worst_rate = impl_->config.max_rate;
+  return static_cast<size_t>(std::ceil(static_cast<double>(output_frames) * worst_rate)) +
+         kHalfTaps + 1;
+}
+
+size_t PreparedTapeVarispeed::required_output_capacity(size_t input_frames) const noexcept {
+  if (!impl_->prepared || input_frames > impl_->config.max_input_frames) {
+    return 0;
+  }
+  return static_cast<size_t>(
+             std::ceil(static_cast<double>(input_frames) / impl_->config.min_rate)) +
+         1;
+}
+
+size_t PreparedTapeVarispeed::max_drain_frames() const noexcept {
+  return 0;
+}
+size_t PreparedTapeVarispeed::latency_frames() const noexcept {
+  return kHalfTaps;
+}
+double PreparedTapeVarispeed::applied_rate() const noexcept {
+  return impl_->applied;
+}
+
+TapeVarispeedProcessResult PreparedTapeVarispeed::process(const float* input, size_t input_frames,
+                                                          float* output, size_t output_capacity,
+                                                          double target_rate) noexcept {
+  TapeVarispeedProcessResult result;
+  if (!impl_->prepared) {
+    result.error = SessionGraphError::NotReady;
+    return result;
+  }
+  if (!valid_rate(target_rate, impl_->config.min_rate, impl_->config.max_rate) ||
+      input_frames > impl_->config.max_input_frames ||
+      output_capacity > impl_->config.max_output_frames ||
+      (input_frames != 0 && input == nullptr) || (output_capacity != 0 && output == nullptr)) {
+    result.error = SessionGraphError::InvalidParameter;
+    return result;
+  }
+  if (input_frames == 0 || output_capacity == 0) {
+    return result;
+  }
+
+  impl_->start_slew(target_rate);
+  if (impl_->applied == 1.0 && impl_->target == 1.0 && impl_->slew_remaining == 0) {
+    const size_t frames = std::min(input_frames, output_capacity);
+    std::memcpy(output, input, frames * impl_->config.channels * sizeof(float));
+    impl_->append_history(input, frames);
+    result.input_frames_consumed = frames;
+    result.output_frames_produced = frames;
+    return result;
+  }
+
+  while (result.output_frames_produced < output_capacity) {
+    const int64_t centre = static_cast<int64_t>(std::floor(impl_->phase));
+    if (centre + static_cast<int64_t>(kHalfTaps) >= static_cast<int64_t>(input_frames)) {
+      break;
+    }
+    const double fraction = impl_->phase - static_cast<double>(centre);
+    const double cutoff = 0.5 / std::max(1.0, impl_->applied);
+    for (uint16_t channel = 0; channel < impl_->config.channels; ++channel) {
+      double sum = 0.0;
+      double normalization = 0.0;
+      for (size_t tap = 0; tap < kTapCount; ++tap) {
+        const int64_t source =
+            centre + static_cast<int64_t>(tap) - static_cast<int64_t>(kHalfTaps - 1);
+        const double distance =
+            static_cast<double>(tap) - static_cast<double>(kHalfTaps - 1) - fraction;
+        const double coefficient =
+            2.0 * cutoff * sinc(2.0 * cutoff * distance) * impl_->window[tap];
+        sum += static_cast<double>(impl_->source_sample(input, input_frames, source, channel)) *
+               coefficient;
+        normalization += coefficient;
+      }
+      output[result.output_frames_produced * impl_->config.channels + channel] =
+          static_cast<float>(sum / normalization);
+    }
+    ++result.output_frames_produced;
+    impl_->phase += impl_->applied;
+    impl_->advance_rate();
+  }
+
+  result.input_frames_consumed =
+      std::min(input_frames, static_cast<size_t>(std::floor(impl_->phase)));
+  impl_->append_history(input, result.input_frames_consumed);
+  impl_->phase -= static_cast<double>(result.input_frames_consumed);
+  return result;
+}
+
+TapeVarispeedProcessResult PreparedTapeVarispeed::drain(float* output,
+                                                        size_t output_capacity) noexcept {
+  TapeVarispeedProcessResult result;
+  if (!impl_->prepared) {
+    result.error = SessionGraphError::NotReady;
+  } else if (output_capacity > impl_->config.max_output_frames ||
+             (output_capacity != 0 && output == nullptr)) {
+    result.error = SessionGraphError::InvalidParameter;
+  }
+  return result;
+}
+
+SessionGraphError PreparedTapeVarispeed::reset(double initial_rate) noexcept {
+  if (!impl_->prepared) {
+    return SessionGraphError::NotReady;
+  }
+  if (!valid_rate(initial_rate, impl_->config.min_rate, impl_->config.max_rate)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  std::fill(impl_->history.begin(), impl_->history.end(), 0.0f);
+  impl_->phase = 0.0;
+  impl_->applied = initial_rate;
+  impl_->target = initial_rate;
+  impl_->rate_step = 0.0;
+  impl_->slew_remaining = 0;
+  return SessionGraphError::OK;
+}
+
+struct OfflineTapeVarispeed::Impl {
+  PreparedTapeVarispeed processor;
+  double rate = 1.0;
+  bool configured = false;
+};
+
+OfflineTapeVarispeed::OfflineTapeVarispeed() : impl_(std::make_unique<Impl>()) {}
+OfflineTapeVarispeed::~OfflineTapeVarispeed() = default;
+OfflineTapeVarispeed::OfflineTapeVarispeed(OfflineTapeVarispeed&&) noexcept = default;
+OfflineTapeVarispeed& OfflineTapeVarispeed::operator=(OfflineTapeVarispeed&&) noexcept = default;
+
+SessionGraphError OfflineTapeVarispeed::configure(uint32_t sample_rate, uint16_t channels,
+                                                  double rate) {
+  if (sample_rate == 0 || channels == 0 || !valid_rate(rate, 0.5, 2.0)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  TapeVarispeedConfig config;
+  config.sample_rate = sample_rate;
+  config.channels = channels;
+  config.max_input_frames = 4096;
+  config.max_output_frames = 8192;
+  config.initial_rate = rate;
+  const auto error = impl_->processor.prepare(config);
+  if (error == SessionGraphError::OK) {
+    impl_->rate = rate;
+    impl_->configured = true;
+  }
+  return error;
+}
+
+size_t OfflineTapeVarispeed::required_output_capacity(size_t input_frames) const noexcept {
+  return impl_->configured ? impl_->processor.required_output_capacity(input_frames) : 0;
+}
+size_t OfflineTapeVarispeed::max_drain_frames() const noexcept {
+  return impl_->configured ? impl_->processor.max_drain_frames() : 0;
+}
+TapeVarispeedProcessResult OfflineTapeVarispeed::process(const float* input, size_t input_frames,
+                                                         float* output, size_t output_capacity) {
+  if (!impl_->configured) {
+    return {SessionGraphError::NotReady, 0, 0};
+  }
+  return impl_->processor.process(input, input_frames, output, output_capacity, impl_->rate);
+}
+TapeVarispeedProcessResult OfflineTapeVarispeed::drain(float* output, size_t output_capacity) {
+  if (!impl_->configured) {
+    return {SessionGraphError::NotReady, 0, 0};
+  }
+  return impl_->processor.drain(output, output_capacity);
+}
+void OfflineTapeVarispeed::reset() noexcept {
+  if (impl_->configured) {
+    (void)impl_->processor.reset(impl_->rate);
+  }
+}
+
+} // namespace orpheus

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -59,6 +59,14 @@ target_include_directories(scrub_resampler_test
 
 add_test(NAME scrub_resampler_test COMMAND scrub_resampler_test)
 
+# ORP160/FTR063: prepared/offline Master tape-varispeed contract.
+add_executable(tape_varispeed_test
+    tape_varispeed_test.cpp
+)
+target_link_libraries(tape_varispeed_test PRIVATE orpheus_audio_utils GTest::gtest GTest::gtest_main)
+target_include_directories(tape_varispeed_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME tape_varispeed_test COMMAND tape_varispeed_test)
+
 # ORP134 G7: lock-free input ring + capture-stream contract. Links audio_io
 # so the capture->disk pairing test can use the reader/writer when available.
 add_executable(audio_input_test

--- a/tests/audio_io/tape_varispeed_test.cpp
+++ b/tests/audio_io/tape_varispeed_test.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+#include <orpheus/tape_varispeed.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+TapeVarispeedConfig config(uint16_t channels = 1) {
+  TapeVarispeedConfig value;
+  value.sample_rate = 48000;
+  value.channels = channels;
+  value.max_input_frames = 1024;
+  value.max_output_frames = 2048;
+  return value;
+}
+
+TEST(TapeVarispeedTest, RejectsInvalidConfigurationWithoutInstallingIt) {
+  PreparedTapeVarispeed processor;
+  EXPECT_EQ(processor.prepare(config()), SessionGraphError::OK);
+  const auto before = processor.applied_rate();
+  auto invalid = config();
+  invalid.min_rate = 2.0;
+  invalid.max_rate = 0.5;
+  EXPECT_EQ(processor.prepare(invalid), SessionGraphError::InvalidParameter);
+  EXPECT_DOUBLE_EQ(processor.applied_rate(), before);
+}
+
+TEST(TapeVarispeedTest, UnityIsExactBypass) {
+  PreparedTapeVarispeed processor;
+  ASSERT_EQ(processor.prepare(config(2)), SessionGraphError::OK);
+  const std::array<float, 12> input = {0.25f,  -0.5f,   1.0f, 0.0f, -0.75f, 0.5f,
+                                       0.125f, -0.125f, 0.0f, 1.0f, 0.5f,   -1.0f};
+  std::array<float, input.size()> output{};
+  const auto result =
+      processor.process(input.data(), input.size() / 2, output.data(), output.size() / 2, 1.0);
+  EXPECT_EQ(result.error, SessionGraphError::OK);
+  EXPECT_EQ(result.input_frames_consumed, input.size() / 2);
+  EXPECT_EQ(result.output_frames_produced, input.size() / 2);
+  EXPECT_EQ(output, input);
+}
+
+TEST(TapeVarispeedTest, StereoStaysLinkedAndDoesNotCrossfeed) {
+  PreparedTapeVarispeed processor;
+  ASSERT_EQ(processor.prepare(config(2)), SessionGraphError::OK);
+  std::vector<float> input(1024 * 2, 0.0f);
+  for (size_t frame = 0; frame < 1024; ++frame) {
+    input[frame * 2] = std::sin(static_cast<float>(frame) * 0.05f);
+  }
+  std::vector<float> output(2048 * 2, 0.0f);
+  const auto result = processor.process(input.data(), 1024, output.data(), 2048, 0.5);
+  ASSERT_EQ(result.error, SessionGraphError::OK);
+  ASSERT_GT(result.output_frames_produced, 0u);
+  for (size_t frame = 0; frame < result.output_frames_produced; ++frame) {
+    EXPECT_FLOAT_EQ(output[frame * 2 + 1], 0.0f);
+  }
+}
+
+TEST(TapeVarispeedTest, InvalidProcessInputDoesNotMutateRateOrPhase) {
+  PreparedTapeVarispeed processor;
+  ASSERT_EQ(processor.prepare(config()), SessionGraphError::OK);
+  std::array<float, 128> input{};
+  std::array<float, 256> output{};
+  EXPECT_EQ(processor.process(input.data(), input.size(), output.data(), output.size(), NAN).error,
+            SessionGraphError::InvalidParameter);
+  EXPECT_DOUBLE_EQ(processor.applied_rate(), 1.0);
+  EXPECT_EQ(processor.process(input.data(), input.size(), output.data(), output.size(), 1.0).error,
+            SessionGraphError::OK);
+}
+
+} // namespace
+} // namespace orpheus

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -47,6 +47,8 @@ target_link_libraries(orpheus_find_package_analysis PRIVATE Orpheus::audio_utils
 
 add_orpheus_fixture(orpheus_find_package_trigger_voice trigger_voice.cpp)
 target_link_libraries(orpheus_find_package_trigger_voice PRIVATE Orpheus::audio_utils)
+add_orpheus_fixture(orpheus_find_package_tape_varispeed tape_varispeed.cpp)
+target_link_libraries(orpheus_find_package_tape_varispeed PRIVATE Orpheus::audio_utils)
 add_orpheus_fixture(orpheus_find_package_clip_dsp clip_dsp.cpp)
 target_link_libraries(orpheus_find_package_clip_dsp PRIVATE Orpheus::transport)
 

--- a/tests/cmake/find_package/tape_varispeed.cpp
+++ b/tests/cmake/find_package/tape_varispeed.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/tape_varispeed.h>
+
+#include <array>
+
+int main() {
+  orpheus::PreparedTapeVarispeed processor;
+  orpheus::TapeVarispeedConfig config;
+  config.sample_rate = 48000;
+  config.channels = 1;
+  config.max_input_frames = 64;
+  config.max_output_frames = 128;
+  if (processor.prepare(config) != orpheus::SessionGraphError::OK) {
+    return 1;
+  }
+  std::array<float, 64> input{};
+  std::array<float, 128> output{};
+  const auto result =
+      processor.process(input.data(), input.size(), output.data(), output.size(), 1.0);
+  return result.error == orpheus::SessionGraphError::OK ? 0 : 1;
+}


### PR DESCRIPTION
## Draft scope
- adds the ORP160 public prepared/offline tape-varispeed API in Orpheus::audio_utils
- implements a prepared Kaiser-windowed sinc streaming path with byte-exact stable unity bypass
- adds initial invalid-input, unity, and stereo-isolation coverage plus a clean-package compile fixture

## Current evidence
- tape_varispeed_test: 4/4 passed

## Required before release
Quality measurement, bounded drain, duplex reciprocal-slew, chunk invariance, callback allocation evidence, package runtime execution, timing, and listening gates remain mandatory. This Draft must not merge, release, or be consumed by FourTrack yet.