### PR TITLE
fix(coreaudio): harden runtime sample-rate changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CoreAudio now monitors active aggregate and physical route sample rates after
+  start. It gates rendering during verification, reasserts the configured rate
+  off the render thread, and stops with a factory-visible terminal outcome when
+  recovery or querying fails.
+
 ## [0.6.7] - 2026-07-24
 
 Patch release correcting capture-channel selection for distinct CoreAudio input

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,47 @@
+# Progress
+
+## ORP128 — CoreAudio runtime sample-rate resilience
+
+**Date:** 2026-07-28  
+**Branch:** `feat/orp128-coreaudio-rate-resilience`  
+**Status:** Sprint 1 implementation and focused verification complete; commit and remote delivery pending.
+
+### Delivered
+
+- Active CoreAudio routes now register nominal-sample-rate listeners for the AU
+  route and every physical input/output endpoint.
+- Listener notifications only close an atomic render gate and signal a control
+  worker. The worker reasserts the configured rate outside the render callback.
+- A refused reassertion or rate-query failure stops rendering and is exposed as
+  `AudioIoTelemetry::runtime_outcome`; hosts must explicitly reinitialize.
+- Explicit directional endpoint IDs remain immutable. The driver does not
+  select a fallback device, rebuild an AudioUnit, resample, or invoke a host
+  callback while a rate mismatch is pending.
+
+### Evidence
+
+- ASan/UBSan Debug focused CoreAudio suite passed 12 contracts, covering all
+  deterministic monitor outcomes plus live playback-route startup,
+  initialization, admitted-callback teardown, directional routes, aggregate
+  capture, duplex capture, and capture-failure telemetry.
+- Deterministic fake-property coverage proves listener registration/removal,
+  no post-teardown callback, successful recovery, refused recovery, query
+  failure, and rendering gate behavior.
+- `tools/realtime_audit.py --root . --fail-known-debt` passed with zero hard
+  failures and zero tracked-debt findings.
+
+### Configured-suite observation
+
+- The three failing commands were `docs_path_audit` (eight missing document
+  links), `cmake_shmui_package_consumer` (unexported JUCE dependencies), and
+  `coreaudio_driver_test`.
+- On this host, 12 legacy CoreAudio cases that rely on the default
+  two-input-channel configuration return `InvalidParameter`; the same run
+  passed the focused output, directional, aggregate, and capture contracts
+  listed above. This record does not treat the complete suite as green.
+
+### Limitation
+
+No controllable macOS device was available locally to record a live nominal
+48 kHz → 44.1 kHz transition or rejected reassertion. The deterministic fake
+covers both paths; no hardware recovery/refusal support claim is made.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 
 **Date:** 2026-07-28  
 **Branch:** `feat/orp128-coreaudio-rate-resilience`  
-**Status:** Sprint 1 implementation and focused verification complete; commit and remote delivery pending.
+**Status:** Sprint 1 implementation and focused verification complete. Committed as `3b0df2e8` and pushed to `origin/feat/orp128-coreaudio-rate-resilience`.
 
 ### Delivered
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ auto driver = orpheus::createCoreAudioDriver();
 if (driver->initialize(audio) == orpheus::SessionGraphError::OK) {
   const auto io = driver->getTelemetry();
   // io.input_render_failures distinguishes capture failure from real silence.
+  // A runtime nominal-rate change is never rendered silently. CoreAudio first
+  // reasserts audio.sample_rate; a terminal outcome has stopped the driver and
+  // requires an explicit initialize() with the host's chosen configuration.
+  if (io.runtime_outcome ==
+      orpheus::AudioDriverRuntimeOutcome::SampleRateReinitializationRequired) {
+    // Reconfigure the host deliberately; endpoint IDs remain unchanged.
+  }
 }
 ```
 
@@ -117,6 +124,13 @@ Distinct CoreAudio endpoints use a driver-owned private aggregate. Unknown or
 direction-incompatible UIDs fail with `InvalidParameter`; they never fall back
 to another device. `getTelemetry()` is available through `IAudioDriver`, so
 factory consumers do not downcast to platform implementations.
+
+During an active CoreAudio route, the driver listens to the aggregate wrapper
+and each physical input/output endpoint's nominal sample rate. A notification
+closes the render gate, then a control worker reasserts the configured rate. If
+the device refuses or cannot be queried, rendering stops and
+`runtime_outcome` reports the exact terminal condition; the driver never
+silently substitutes another endpoint or rate.
 
 Child-app teams should use
 [`ORP143 §5`](docs/orp/ORP143%20Reliability%20and%20Adoption%20Sprint%20Completion%20and%20Child-App%20Handoff.md#5-child-app-handoff-matrix)
@@ -262,7 +276,7 @@ The Orpheus SDK provides deterministic session/transport control for professiona
 - **Platform drivers** – CoreAudio (supported), Dummy (supported); WASAPI and Linux device backends are not yet release-supported
 - **Dummy driver** – Testing and offline rendering
 - **Device selection** – Direction-specific stable input/output IDs; persistent CoreAudio DeviceUIDs and owned duplex aggregates (ORP155)
-- **Capture diagnostics** – Factory-visible saturating input-render failure telemetry (ORP155)
+- **Capture and rate diagnostics** – Factory-visible saturating input-render failure telemetry plus runtime nominal-rate recovery/reinitialization outcomes (ORP155, ORP128)
 - **Waveform processing** – Fast downsampling for UI rendering (ORP109)
 
 ### Routing & Mixing

--- a/docs/orp/ORP128 CoreAudio Runtime Sample-Rate Resilience.md
+++ b/docs/orp/ORP128 CoreAudio Runtime Sample-Rate Resilience.md
@@ -1,0 +1,51 @@
+# ORP128 CoreAudio Runtime Sample-Rate Resilience
+
+**Date:** 2026-07-29  
+**Status:** Delivered in SDK PR #225
+
+## Problem
+
+A CoreAudio route can change its nominal sample rate after an audio unit starts.
+Continuing to render against the stale configured format risks invalid host audio
+I/O and makes the failure invisible to the control thread.
+
+## Contract
+
+`CoreAudioDriver` now monitors the nominal sample-rate property of every active
+aggregate, output, and input route. Listener callbacks only publish an atomic
+notification and close the render gate. A control worker reads and, when
+possible, reasserts the configured rate before reopening that gate.
+
+If the property cannot be queried or reasserted, the driver stops rendering and
+reports `AudioDriverRuntimeOutcome::SampleRateQueryFailure` or
+`AudioDriverRuntimeOutcome::SampleRateReinitializationRequired` through
+`IAudioDriver::getTelemetry()`. Listener registration failure is reported as
+`AudioDriverRuntimeOutcome::SampleRateListenerFailure`. A recovered route is
+reported as `AudioDriverRuntimeOutcome::SampleRateRestored`.
+
+The render gate uses a listener-generation compare-exchange. A notification that
+arrives while the worker polls cannot be consumed by that poll; rendering remains
+closed until a later poll validates the newly notified route.
+
+## Package coverage
+
+The clean-prefix `cmake_find_package` fixture compiles, links, and runs a
+consumer of `AudioIoTelemetry`, `AudioDriverRuntimeOutcome`, and the default
+`IAudioDriver::getTelemetry()` behavior through `Orpheus::audio_io`.
+
+## Verification
+
+- `coreaudio_sample_rate_monitor_test` covers listener registration, rate
+  restoration, terminal refusal/query failures, and a notification delivered
+  during the final property read.
+- `coreaudio_driver_test` covers the CoreAudio driver integration and
+  playback-only monitor startup smoke path.
+- The specialized realtime audit remains the gate for ensuring listener
+  notifications and render callbacks stay allocation- and lock-free.
+
+## Hardware limitation
+
+No controllable local physical route was available to record a 48 kHz-to-44.1
+kHz transition during this delivery. Deterministic listener/property tests cover
+the recovery and terminal paths; a physical-device acceptance remains useful
+release evidence when such hardware is available.

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -30,9 +30,22 @@ struct AudioDriverConfig {
   std::string device_name;      ///< Optional host-visible display name
 };
 
-/// Factory-visible backend I/O diagnostics.
+/// Outcome of a backend runtime condition that can invalidate active audio I/O.
+/// A terminal outcome means the driver has stopped rendering and requires an
+/// explicit initialize() call with a host-selected configuration.
+enum class AudioDriverRuntimeOutcome : uint8_t {
+  Healthy,
+  SampleRateRestored,
+  SampleRateReinitializationRequired,
+  SampleRateListenerFailure,
+  SampleRateQueryFailure,
+};
+
+/// Factory-visible backend I/O diagnostics. Runtime outcomes are safe to poll
+/// from a control thread and never invoke the host's realtime callback.
 struct AudioIoTelemetry {
   uint64_t input_render_failures = 0; ///< Cumulative failed capture renders
+  AudioDriverRuntimeOutcome runtime_outcome = AudioDriverRuntimeOutcome::Healthy;
 };
 
 /// Audio backend family.

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -58,6 +58,7 @@ message(STATUS "Orpheus: Audio Driver Manager enabled")
 if(ORPHEUS_ENABLE_COREAUDIO)
     add_library(orpheus_audio_driver_coreaudio STATIC
         coreaudio/coreaudio_driver.cpp
+        coreaudio/coreaudio_sample_rate_monitor.cpp
     )
 
     target_include_directories(orpheus_audio_driver_coreaudio

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -15,15 +15,23 @@ namespace orpheus {
 CoreAudioDriver::CoreAudioDriver() = default;
 
 CoreAudioDriver::~CoreAudioDriver() {
-  if (is_running_.load(std::memory_order_acquire)) {
-    stop();
-  }
+  stop();
   cleanupAudioUnit();
 }
 
 SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_running_.load(std::memory_order_acquire)) {
+      return SessionGraphError::NotReady;
+    }
+  }
 
+  // A previous terminal runtime outcome leaves a joined-but-still-owned
+  // monitor. Tear it down before replacing the route.
+  stopSampleRateMonitor();
+
+  std::lock_guard<std::mutex> lock(mutex_);
   if (is_running_.load(std::memory_order_acquire)) {
     return SessionGraphError::NotReady;
   }
@@ -55,6 +63,7 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     cleanupAudioUnit();
     return result;
   }
+  createSampleRateMonitor();
 
   // Pre-allocate audio buffers (no allocations in audio callback)
   uint32_t num_outputs = config_.num_outputs;
@@ -84,6 +93,7 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   }
 
   input_render_failures_.store(0, std::memory_order_release);
+  runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
   return SessionGraphError::OK;
 }
 
@@ -102,16 +112,36 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
     return SessionGraphError::InvalidParameter;
   }
 
+  // Listener registration and the initial rate verification happen before the
+  // AU is started. A device that already rejects the requested rate therefore
+  // never reaches processAudio() with a mismatched stream format.
+  if (!startSampleRateMonitorLocked()) {
+    return SessionGraphError::InternalError;
+  }
+
   callback_ = callback;
   callback_admission_.store(kCallbackAccepting, std::memory_order_release);
   is_running_.store(true, std::memory_order_release);
 
-  // Start AudioUnit
   OSStatus status = AudioOutputUnitStart(audio_unit_);
   if (status != noErr) {
     is_running_.store(false, std::memory_order_release);
     closeCallbackAdmission();
     callback_ = nullptr;
+    sample_rate_monitor_->stop();
+    return SessionGraphError::InternalError;
+  }
+
+  sample_rate_monitor_active_.store(true, std::memory_order_release);
+  try {
+    sample_rate_monitor_thread_ = std::thread(&CoreAudioDriver::sampleRateMonitorLoop, this);
+  } catch (...) {
+    sample_rate_monitor_active_.store(false, std::memory_order_release);
+    AudioOutputUnitStop(audio_unit_);
+    closeCallbackAdmission();
+    callback_ = nullptr;
+    is_running_.store(false, std::memory_order_release);
+    sample_rate_monitor_->stop();
     return SessionGraphError::InternalError;
   }
 
@@ -119,26 +149,11 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
 }
 
 SessionGraphError CoreAudioDriver::stop() {
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  if (!is_running_.load(std::memory_order_acquire)) {
-    return SessionGraphError::OK; // Already stopped
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stopRenderingLocked();
   }
-
-  is_running_.store(false, std::memory_order_release);
-  uint64_t admission = closeCallbackAdmission();
-
-  if (audio_unit_) {
-    AudioOutputUnitStop(audio_unit_);
-  }
-
-  while ((admission & kCallbackCountMask) != 0) {
-    callback_admission_.wait(admission, std::memory_order_acquire);
-    admission = callback_admission_.load(std::memory_order_acquire);
-  }
-
-  callback_ = nullptr;
-
+  stopSampleRateMonitor();
   return SessionGraphError::OK;
 }
 
@@ -163,7 +178,8 @@ uint32_t CoreAudioDriver::getLatencySamples() const {
 }
 
 AudioIoTelemetry CoreAudioDriver::getTelemetry() const noexcept {
-  return {input_render_failures_.load(std::memory_order_acquire)};
+  return {input_render_failures_.load(std::memory_order_acquire),
+          runtime_outcome_.load(std::memory_order_acquire)};
 }
 
 void CoreAudioDriver::setInputRenderFailuresForTesting(uint64_t count) noexcept {
@@ -286,6 +302,13 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   // This prevents use-after-free if callback is invoked during/after stop()
   if (!driver->is_running_.load(std::memory_order_acquire)) {
     return noErr; // Driver is stopping, output silence
+  }
+
+  // A nominal-rate notification closes this gate before the control worker
+  // touches CoreAudio. Never hand a host processAudio() a block whose AU
+  // format may no longer match the hardware clock.
+  if (!driver->sample_rate_monitor_ || !driver->sample_rate_monitor_->permitsRendering()) {
+    return noErr;
   }
 
   IAudioCallback* callback = driver->callback_;
@@ -863,7 +886,133 @@ SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
   return SessionGraphError::OK;
 }
 
+void CoreAudioDriver::createSampleRateMonitor() {
+  std::vector<AudioDeviceID> monitored_devices;
+  monitored_devices.reserve(3);
+  monitored_devices.push_back(device_id_);
+  monitored_devices.push_back(output_device_id_);
+  if (config_.num_inputs > 0) {
+    monitored_devices.push_back(input_device_id_);
+  }
+  sample_rate_monitor_ = std::make_unique<CoreAudioSampleRateMonitor>(
+      sample_rate_property_api_, config_.sample_rate, std::move(monitored_devices));
+}
+
+bool CoreAudioDriver::startSampleRateMonitorLocked() {
+  std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
+  if (!sample_rate_monitor_ || !sample_rate_monitor_->start()) {
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateListenerFailure,
+                           std::memory_order_release);
+    return false;
+  }
+
+  sample_rate_monitor_->requestCheck();
+  const CoreAudioSampleRatePollResult result = sample_rate_monitor_->poll();
+  switch (result) {
+  case CoreAudioSampleRatePollResult::NoChange:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+    return true;
+  case CoreAudioSampleRatePollResult::RateRestored:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateRestored,
+                           std::memory_order_release);
+    return true;
+  case CoreAudioSampleRatePollResult::ReinitializationRequired:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateReinitializationRequired,
+                           std::memory_order_release);
+    break;
+  case CoreAudioSampleRatePollResult::QueryFailed:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateQueryFailure,
+                           std::memory_order_release);
+    break;
+  }
+
+  sample_rate_monitor_->stop();
+  return false;
+}
+
+void CoreAudioDriver::stopSampleRateMonitor() {
+  sample_rate_monitor_active_.store(false, std::memory_order_release);
+  {
+    std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
+    if (sample_rate_monitor_) {
+      sample_rate_monitor_->stop();
+      sample_rate_monitor_->requestCheck();
+    }
+  }
+  if (sample_rate_monitor_thread_.joinable()) {
+    sample_rate_monitor_thread_.join();
+  }
+}
+
+void CoreAudioDriver::sampleRateMonitorLoop() {
+  while (sample_rate_monitor_active_.load(std::memory_order_acquire)) {
+    sample_rate_monitor_->waitForChange();
+    if (!sample_rate_monitor_active_.load(std::memory_order_acquire)) {
+      break;
+    }
+
+    CoreAudioSampleRatePollResult result;
+    {
+      std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
+      if (!sample_rate_monitor_active_.load(std::memory_order_acquire)) {
+        break;
+      }
+      result = sample_rate_monitor_->poll();
+      if (result == CoreAudioSampleRatePollResult::ReinitializationRequired ||
+          result == CoreAudioSampleRatePollResult::QueryFailed) {
+        sample_rate_monitor_->stop();
+      }
+    }
+
+    switch (result) {
+    case CoreAudioSampleRatePollResult::NoChange:
+      runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+      continue;
+    case CoreAudioSampleRatePollResult::RateRestored:
+      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateRestored,
+                             std::memory_order_release);
+      continue;
+    case CoreAudioSampleRatePollResult::ReinitializationRequired:
+      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateReinitializationRequired,
+                             std::memory_order_release);
+      break;
+    case CoreAudioSampleRatePollResult::QueryFailed:
+      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateQueryFailure,
+                             std::memory_order_release);
+      break;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      stopRenderingLocked();
+    }
+    sample_rate_monitor_active_.store(false, std::memory_order_release);
+  }
+}
+
+void CoreAudioDriver::stopRenderingLocked() {
+  if (!is_running_.load(std::memory_order_acquire)) {
+    return;
+  }
+
+  is_running_.store(false, std::memory_order_release);
+  uint64_t admission = closeCallbackAdmission();
+
+  if (audio_unit_) {
+    AudioOutputUnitStop(audio_unit_);
+  }
+
+  while ((admission & kCallbackCountMask) != 0) {
+    callback_admission_.wait(admission, std::memory_order_acquire);
+    admission = callback_admission_.load(std::memory_order_acquire);
+  }
+
+  callback_ = nullptr;
+}
+
 void CoreAudioDriver::cleanupAudioUnit() {
+  // Callers stop and join the control worker before destroying the route.
+  sample_rate_monitor_.reset();
   if (audio_unit_) {
     AudioUnitUninitialize(audio_unit_);
     AudioComponentInstanceDispose(audio_unit_);

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -112,6 +112,12 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
     return SessionGraphError::InvalidParameter;
   }
 
+  // A terminal monitor outcome stops the worker without joining it. Reap that
+  // completed worker before replacing std::thread on a later start().
+  if (sample_rate_monitor_thread_.joinable()) {
+    sample_rate_monitor_thread_.join();
+  }
+
   // Listener registration and the initial rate verification happen before the
   // AU is started. A device that already rejects the requested rate therefore
   // never reaches processAudio() with a mismatched stream format.

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "coreaudio_sample_rate_monitor.h"
+
 #include <orpheus/audio_driver.h>
 
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudio.h>
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace orpheus {
@@ -110,6 +114,18 @@ private:
   /// Cleanup AudioUnit resources
   void cleanupAudioUnit();
 
+  /// Creates the runtime monitor after route resolution has identified the
+  /// aggregate wrapper and each physical endpoint.
+  void createSampleRateMonitor();
+  /// Starts listeners and the control worker. mutex_ must be held.
+  bool startSampleRateMonitorLocked();
+  /// Removes listeners, wakes the control worker, and joins it.
+  void stopSampleRateMonitor();
+  /// Services listener notifications outside the audio callback.
+  void sampleRateMonitorLoop();
+  /// Stops the AudioUnit and drains admitted callbacks. mutex_ must be held.
+  void stopRenderingLocked();
+
   // Configuration
   AudioDriverConfig config_;
 
@@ -129,6 +145,18 @@ private:
   uint32_t input_channel_offset_{0};
   std::atomic<bool> is_running_{false};
   std::atomic<uint64_t> input_render_failures_{0};
+  std::atomic<AudioDriverRuntimeOutcome> runtime_outcome_{AudioDriverRuntimeOutcome::Healthy};
+
+  // Listener registration belongs to the active route. The property callback
+  // only signals this monitor; a control worker performs all HAL queries and
+  // rate changes outside the audio callback.
+  CoreAudioSampleRatePropertyApi sample_rate_property_api_;
+  std::unique_ptr<CoreAudioSampleRateMonitor> sample_rate_monitor_;
+  std::atomic<bool> sample_rate_monitor_active_{false};
+  // Serializes listener registration/removal and control-thread polling; never
+  // acquired by the CoreAudio render callback or property-listener callback.
+  std::mutex sample_rate_monitor_mutex_;
+  std::thread sample_rate_monitor_thread_;
 
   // Non-owning host callback. It is only read while callback_admission_ holds
   // an admitted callback, which stop() drains before clearing this pointer.

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
@@ -49,6 +49,7 @@ bool CoreAudioSampleRateMonitor::start() noexcept {
   if (registered_count_ != 0 || device_ids_.empty()) {
     return registered_count_ != 0;
   }
+  state_.store(0, std::memory_order_release);
 
   const AudioObjectPropertyAddress address = nominalSampleRateAddress();
   for (const AudioDeviceID device_id : device_ids_) {
@@ -68,24 +69,37 @@ void CoreAudioSampleRateMonitor::stop() noexcept {
     property_api_.removePropertyListener(device_ids_[registered_count_], &address, &propertyChanged,
                                          this);
   }
-  pending_.store(false, std::memory_order_release);
-  permits_rendering_.store(false, std::memory_order_release);
+  state_.fetch_or(kStoppedBit | kPendingBit, std::memory_order_release);
   pending_changed_.notify_all();
 }
 
 void CoreAudioSampleRateMonitor::requestCheck() noexcept {
-  permits_rendering_.store(false, std::memory_order_release);
-  pending_.store(true, std::memory_order_release);
+  // Publish the next generation and close the gate in one atomic transition.
+  // poll() only opens the gate by clearing the pending bit with a
+  // compare-exchange on this same word, so it cannot acknowledge a notification
+  // that arrived during its queries.
+  uint64_t state = state_.load(std::memory_order_acquire);
+  uint64_t requested_state = 0;
+  do {
+    requested_state = (state + kGenerationIncrement) | kPendingBit;
+  } while (!state_.compare_exchange_weak(state, requested_state, std::memory_order_acq_rel,
+                                         std::memory_order_acquire));
   pending_changed_.notify_one();
 }
 
 void CoreAudioSampleRateMonitor::waitForChange() noexcept {
   std::unique_lock<std::mutex> lock(pending_mutex_);
-  pending_changed_.wait(lock, [this] { return pending_.load(std::memory_order_acquire); });
+  pending_changed_.wait(lock, [this] {
+    return (state_.load(std::memory_order_acquire) & kPendingBit) != 0;
+  });
 }
 
 CoreAudioSampleRatePollResult CoreAudioSampleRateMonitor::poll() noexcept {
-  if (!pending_.load(std::memory_order_acquire)) {
+  uint64_t serviced_state = state_.load(std::memory_order_acquire);
+  if ((serviced_state & kPendingBit) == 0) {
+    return CoreAudioSampleRatePollResult::NoChange;
+  }
+  if ((serviced_state & kStoppedBit) != 0) {
     return CoreAudioSampleRatePollResult::NoChange;
   }
 
@@ -120,18 +134,25 @@ CoreAudioSampleRatePollResult CoreAudioSampleRateMonitor::poll() noexcept {
     restored = true;
   }
 
-  pending_.store(false, std::memory_order_release);
-  permits_rendering_.store(true, std::memory_order_release);
+  // A listener notification mutates the generation before setting pending.
+  // Failing this CAS leaves the gate closed for the next control-thread poll.
+  if (!state_.compare_exchange_strong(serviced_state, serviced_state & ~kPendingBit,
+                                      std::memory_order_acq_rel, std::memory_order_acquire)) {
+    return CoreAudioSampleRatePollResult::NoChange;
+  }
   return restored ? CoreAudioSampleRatePollResult::RateRestored
                   : CoreAudioSampleRatePollResult::NoChange;
 }
 
+
 bool CoreAudioSampleRateMonitor::permitsRendering() const noexcept {
-  return permits_rendering_.load(std::memory_order_acquire);
+  const uint64_t state = state_.load(std::memory_order_acquire);
+  return (state & (kPendingBit | kStoppedBit)) == 0;
 }
 
 bool CoreAudioSampleRateMonitor::isPending() const noexcept {
-  return pending_.load(std::memory_order_acquire);
+  const uint64_t state = state_.load(std::memory_order_acquire);
+  return (state & (kPendingBit | kStoppedBit)) == kPendingBit;
 }
 
 OSStatus CoreAudioSampleRateMonitor::propertyChanged(AudioObjectID, UInt32,

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio_sample_rate_monitor.h"
+
+#include <algorithm>
+
+namespace orpheus {
+
+OSStatus CoreAudioSampleRatePropertyApi::addPropertyListener(
+    AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+    AudioObjectPropertyListenerProc listener, void* context) noexcept {
+  return AudioObjectAddPropertyListener(device_id, address, listener, context);
+}
+
+OSStatus CoreAudioSampleRatePropertyApi::removePropertyListener(
+    AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+    AudioObjectPropertyListenerProc listener, void* context) noexcept {
+  return AudioObjectRemovePropertyListener(device_id, address, listener, context);
+}
+
+OSStatus CoreAudioSampleRatePropertyApi::getPropertyData(AudioObjectID device_id,
+                                                         const AudioObjectPropertyAddress* address,
+                                                         UInt32* size, void* data) noexcept {
+  return AudioObjectGetPropertyData(device_id, address, 0, nullptr, size, data);
+}
+
+OSStatus CoreAudioSampleRatePropertyApi::setPropertyData(AudioObjectID device_id,
+                                                         const AudioObjectPropertyAddress* address,
+                                                         UInt32 size, const void* data) noexcept {
+  return AudioObjectSetPropertyData(device_id, address, 0, nullptr, size, data);
+}
+
+CoreAudioSampleRateMonitor::CoreAudioSampleRateMonitor(
+    ICoreAudioSampleRatePropertyApi& property_api, uint32_t expected_sample_rate,
+    std::vector<AudioDeviceID> device_ids)
+    : property_api_(property_api),
+      expected_sample_rate_(static_cast<Float64>(expected_sample_rate)),
+      device_ids_(std::move(device_ids)) {
+  std::sort(device_ids_.begin(), device_ids_.end());
+  device_ids_.erase(std::unique(device_ids_.begin(), device_ids_.end()), device_ids_.end());
+  device_ids_.erase(std::remove(device_ids_.begin(), device_ids_.end(), AudioDeviceID{0}),
+                    device_ids_.end());
+}
+
+CoreAudioSampleRateMonitor::~CoreAudioSampleRateMonitor() {
+  stop();
+}
+
+bool CoreAudioSampleRateMonitor::start() noexcept {
+  if (registered_count_ != 0 || device_ids_.empty()) {
+    return registered_count_ != 0;
+  }
+
+  const AudioObjectPropertyAddress address = nominalSampleRateAddress();
+  for (const AudioDeviceID device_id : device_ids_) {
+    if (property_api_.addPropertyListener(device_id, &address, &propertyChanged, this) != noErr) {
+      stop();
+      return false;
+    }
+    ++registered_count_;
+  }
+  return true;
+}
+
+void CoreAudioSampleRateMonitor::stop() noexcept {
+  const AudioObjectPropertyAddress address = nominalSampleRateAddress();
+  while (registered_count_ != 0) {
+    --registered_count_;
+    property_api_.removePropertyListener(device_ids_[registered_count_], &address, &propertyChanged,
+                                         this);
+  }
+  pending_.store(false, std::memory_order_release);
+  permits_rendering_.store(false, std::memory_order_release);
+  pending_changed_.notify_all();
+}
+
+void CoreAudioSampleRateMonitor::requestCheck() noexcept {
+  permits_rendering_.store(false, std::memory_order_release);
+  pending_.store(true, std::memory_order_release);
+  pending_changed_.notify_one();
+}
+
+void CoreAudioSampleRateMonitor::waitForChange() noexcept {
+  std::unique_lock<std::mutex> lock(pending_mutex_);
+  pending_changed_.wait(lock, [this] { return pending_.load(std::memory_order_acquire); });
+}
+
+CoreAudioSampleRatePollResult CoreAudioSampleRateMonitor::poll() noexcept {
+  if (!pending_.load(std::memory_order_acquire)) {
+    return CoreAudioSampleRatePollResult::NoChange;
+  }
+
+  const AudioObjectPropertyAddress address = nominalSampleRateAddress();
+  bool restored = false;
+  for (const AudioDeviceID device_id : device_ids_) {
+    Float64 observed_rate = 0.0;
+    UInt32 size = sizeof(observed_rate);
+    if (property_api_.getPropertyData(device_id, &address, &size, &observed_rate) != noErr ||
+        size != sizeof(observed_rate)) {
+      return CoreAudioSampleRatePollResult::QueryFailed;
+    }
+
+    if (observed_rate == expected_sample_rate_) {
+      continue;
+    }
+
+    if (property_api_.setPropertyData(device_id, &address, sizeof(expected_sample_rate_),
+                                      &expected_sample_rate_) != noErr) {
+      return CoreAudioSampleRatePollResult::ReinitializationRequired;
+    }
+
+    observed_rate = 0.0;
+    size = sizeof(observed_rate);
+    if (property_api_.getPropertyData(device_id, &address, &size, &observed_rate) != noErr ||
+        size != sizeof(observed_rate)) {
+      return CoreAudioSampleRatePollResult::QueryFailed;
+    }
+    if (observed_rate != expected_sample_rate_) {
+      return CoreAudioSampleRatePollResult::ReinitializationRequired;
+    }
+    restored = true;
+  }
+
+  pending_.store(false, std::memory_order_release);
+  permits_rendering_.store(true, std::memory_order_release);
+  return restored ? CoreAudioSampleRatePollResult::RateRestored
+                  : CoreAudioSampleRatePollResult::NoChange;
+}
+
+bool CoreAudioSampleRateMonitor::permitsRendering() const noexcept {
+  return permits_rendering_.load(std::memory_order_acquire);
+}
+
+bool CoreAudioSampleRateMonitor::isPending() const noexcept {
+  return pending_.load(std::memory_order_acquire);
+}
+
+OSStatus CoreAudioSampleRateMonitor::propertyChanged(AudioObjectID, UInt32,
+                                                     const AudioObjectPropertyAddress*,
+                                                     void* context) noexcept {
+  auto* monitor = static_cast<CoreAudioSampleRateMonitor*>(context);
+  monitor->requestCheck();
+  return noErr;
+}
+
+AudioObjectPropertyAddress CoreAudioSampleRateMonitor::nominalSampleRateAddress() noexcept {
+  return {kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal,
+          kAudioObjectPropertyElementMain};
+}
+
+} // namespace orpheus

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
@@ -90,11 +90,16 @@ private:
                                   void* context) noexcept;
   static AudioObjectPropertyAddress nominalSampleRateAddress() noexcept;
 
+  static constexpr uint64_t kPendingBit = 1;
+  static constexpr uint64_t kStoppedBit = 2;
+  static constexpr uint64_t kGenerationIncrement = 4;
+
   ICoreAudioSampleRatePropertyApi& property_api_;
   const Float64 expected_sample_rate_;
   std::vector<AudioDeviceID> device_ids_;
-  std::atomic<bool> pending_{false};
-  std::atomic<bool> permits_rendering_{false};
+  // A single state word makes closing and reopening the render gate conditional
+  // on the exact listener-generation that poll() serviced.
+  std::atomic<uint64_t> state_{kStoppedBit};
   std::condition_variable pending_changed_;
   std::mutex pending_mutex_;
   size_t registered_count_{0};

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <CoreAudio/CoreAudio.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace orpheus {
+
+/// Result of servicing a nominal sample-rate notification off the render path.
+enum class CoreAudioSampleRatePollResult : uint8_t {
+  NoChange,
+  RateRestored,
+  ReinitializationRequired,
+  QueryFailed,
+};
+
+/// Injectable CoreAudio property access used to make listener lifecycle and
+/// recovery behavior deterministic without changing a real device's clock.
+class ICoreAudioSampleRatePropertyApi {
+public:
+  virtual ~ICoreAudioSampleRatePropertyApi() = default;
+
+  virtual OSStatus addPropertyListener(AudioObjectID device_id,
+                                       const AudioObjectPropertyAddress* address,
+                                       AudioObjectPropertyListenerProc listener,
+                                       void* context) noexcept = 0;
+  virtual OSStatus removePropertyListener(AudioObjectID device_id,
+                                          const AudioObjectPropertyAddress* address,
+                                          AudioObjectPropertyListenerProc listener,
+                                          void* context) noexcept = 0;
+  virtual OSStatus getPropertyData(AudioObjectID device_id,
+                                   const AudioObjectPropertyAddress* address, UInt32* size,
+                                   void* data) noexcept = 0;
+  virtual OSStatus setPropertyData(AudioObjectID device_id,
+                                   const AudioObjectPropertyAddress* address, UInt32 size,
+                                   const void* data) noexcept = 0;
+};
+
+/// Production adapter for CoreAudio's process-global property functions.
+class CoreAudioSampleRatePropertyApi final : public ICoreAudioSampleRatePropertyApi {
+public:
+  OSStatus addPropertyListener(AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+                               AudioObjectPropertyListenerProc listener,
+                               void* context) noexcept override;
+  OSStatus removePropertyListener(AudioObjectID device_id,
+                                  const AudioObjectPropertyAddress* address,
+                                  AudioObjectPropertyListenerProc listener,
+                                  void* context) noexcept override;
+  OSStatus getPropertyData(AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+                           UInt32* size, void* data) noexcept override;
+  OSStatus setPropertyData(AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+                           UInt32 size, const void* data) noexcept override;
+};
+
+/// Watches every physical route which can invalidate the configured AU format.
+/// The listener performs only atomic notification; callers service pending work
+/// from a control thread via poll().
+class CoreAudioSampleRateMonitor final {
+public:
+  CoreAudioSampleRateMonitor(ICoreAudioSampleRatePropertyApi& property_api,
+                             uint32_t expected_sample_rate, std::vector<AudioDeviceID> device_ids);
+  ~CoreAudioSampleRateMonitor();
+
+  CoreAudioSampleRateMonitor(const CoreAudioSampleRateMonitor&) = delete;
+  CoreAudioSampleRateMonitor& operator=(const CoreAudioSampleRateMonitor&) = delete;
+
+  /// Registers one listener per unique route device. Rolls back on failure.
+  bool start() noexcept;
+  /// Symmetric listener cleanup. Safe to repeat.
+  void stop() noexcept;
+
+  /// Forces a control-thread verification, including before output is started.
+  void requestCheck() noexcept;
+  /// Blocks until a listener notification or requestCheck().
+  void waitForChange() noexcept;
+  /// Reasserts the configured rate and verifies every monitored device.
+  CoreAudioSampleRatePollResult poll() noexcept;
+
+  /// The render callback must return silence while rate validation is pending.
+  bool permitsRendering() const noexcept;
+  bool isPending() const noexcept;
+
+private:
+  static OSStatus propertyChanged(AudioObjectID, UInt32, const AudioObjectPropertyAddress*,
+                                  void* context) noexcept;
+  static AudioObjectPropertyAddress nominalSampleRateAddress() noexcept;
+
+  ICoreAudioSampleRatePropertyApi& property_api_;
+  const Float64 expected_sample_rate_;
+  std::vector<AudioDeviceID> device_ids_;
+  std::atomic<bool> pending_{false};
+  std::atomic<bool> permits_rendering_{false};
+  std::condition_variable pending_changed_;
+  std::mutex pending_mutex_;
+  size_t registered_count_{0};
+};
+
+} // namespace orpheus

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -274,6 +274,7 @@ add_test(NAME dummy_driver_test COMMAND dummy_driver_test)
 if(ORPHEUS_ENABLE_COREAUDIO)
     add_executable(coreaudio_driver_test
         coreaudio_driver_test.cpp
+        coreaudio_sample_rate_monitor_test.cpp
     )
 
     target_link_libraries(coreaudio_driver_test

--- a/tests/audio_io/coreaudio_driver_test.cpp
+++ b/tests/audio_io/coreaudio_driver_test.cpp
@@ -343,6 +343,23 @@ TEST_F(CoreAudioDriverTest, StartAndStop) {
   EXPECT_FALSE(m_driver->isRunning());
 }
 
+TEST_F(CoreAudioDriverTest, PlaybackOnlyRouteStartsWithRuntimeRateMonitor) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 512;
+  config.num_inputs = 0;
+  config.num_outputs = 2;
+
+  ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+
+  const AudioDriverRuntimeOutcome outcome = m_driver->getTelemetry().runtime_outcome;
+  EXPECT_TRUE(outcome == AudioDriverRuntimeOutcome::Healthy ||
+              outcome == AudioDriverRuntimeOutcome::SampleRateRestored);
+
+  EXPECT_EQ(m_driver->stop(), SessionGraphError::OK);
+}
+
 TEST_F(CoreAudioDriverTest, StopWhenNotRunning) {
   auto error = m_driver->stop();
   EXPECT_EQ(error, SessionGraphError::OK);

--- a/tests/audio_io/coreaudio_sample_rate_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_sample_rate_monitor_test.cpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+#include <gtest/gtest.h>
+
+#include "coreaudio/coreaudio_sample_rate_monitor.h"
+
+#include <map>
+#include <vector>
+
+#ifdef ORPHEUS_ENABLE_COREAUDIO
+
+namespace orpheus {
+namespace {
+
+class FakeCoreAudioSampleRatePropertyApi final : public ICoreAudioSampleRatePropertyApi {
+public:
+  struct Listener {
+    AudioObjectID device_id;
+    AudioObjectPropertyListenerProc callback;
+    void* context;
+  };
+
+  void setRate(AudioObjectID device_id, Float64 rate) {
+    rates_[device_id] = rate;
+  }
+
+  void rejectRateChanges() {
+    accepts_rate_changes_ = false;
+  }
+
+  void failQueries() {
+    queries_fail_ = true;
+  }
+
+  void notifyRateChange(AudioObjectID device_id) {
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyNominalSampleRate,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    for (const Listener& listener : listeners_) {
+      if (listener.device_id == device_id) {
+        ++callback_deliveries_;
+        listener.callback(device_id, 1, &address, listener.context);
+      }
+    }
+  }
+
+  size_t listenerCount() const {
+    return listeners_.size();
+  }
+
+  size_t callbackDeliveries() const {
+    return callback_deliveries_;
+  }
+
+  OSStatus addPropertyListener(AudioObjectID device_id, const AudioObjectPropertyAddress*,
+                               AudioObjectPropertyListenerProc listener,
+                               void* context) noexcept override {
+    listeners_.push_back({device_id, listener, context});
+    return noErr;
+  }
+
+  OSStatus removePropertyListener(AudioObjectID device_id, const AudioObjectPropertyAddress*,
+                                  AudioObjectPropertyListenerProc listener,
+                                  void* context) noexcept override {
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+      if (it->device_id == device_id && it->callback == listener && it->context == context) {
+        listeners_.erase(it);
+        return noErr;
+      }
+    }
+    return kAudioHardwareBadObjectError;
+  }
+
+  OSStatus getPropertyData(AudioObjectID device_id, const AudioObjectPropertyAddress*, UInt32* size,
+                           void* data) noexcept override {
+    if (queries_fail_ || rates_.find(device_id) == rates_.end() || *size != sizeof(Float64)) {
+      return kAudioHardwareUnspecifiedError;
+    }
+    *static_cast<Float64*>(data) = rates_[device_id];
+    return noErr;
+  }
+
+  OSStatus setPropertyData(AudioObjectID device_id, const AudioObjectPropertyAddress*, UInt32 size,
+                           const void* data) noexcept override {
+    if (!accepts_rate_changes_ || size != sizeof(Float64)) {
+      return kAudioHardwareUnsupportedOperationError;
+    }
+    rates_[device_id] = *static_cast<const Float64*>(data);
+    return noErr;
+  }
+
+private:
+  std::map<AudioObjectID, Float64> rates_;
+  std::vector<Listener> listeners_;
+  bool accepts_rate_changes_{true};
+  bool queries_fail_{false};
+  size_t callback_deliveries_{0};
+};
+
+TEST(CoreAudioSampleRateMonitorTest, RegistersEachUniqueRouteAndCleansUpListeners) {
+  FakeCoreAudioSampleRatePropertyApi api;
+  api.setRate(11, 48000.0);
+  api.setRate(22, 48000.0);
+  CoreAudioSampleRateMonitor monitor(api, 48000, {11, 22, 11});
+
+  ASSERT_TRUE(monitor.start());
+  EXPECT_EQ(api.listenerCount(), 2u);
+  monitor.requestCheck();
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+  EXPECT_TRUE(monitor.permitsRendering());
+
+  monitor.stop();
+  EXPECT_EQ(api.listenerCount(), 0u);
+  api.notifyRateChange(11);
+  EXPECT_EQ(api.callbackDeliveries(), 0u);
+  EXPECT_FALSE(monitor.isPending());
+}
+
+TEST(CoreAudioSampleRateMonitorTest, ReassertsChangedRateBeforeRenderingResumes) {
+  FakeCoreAudioSampleRatePropertyApi api;
+  api.setRate(11, 48000.0);
+  CoreAudioSampleRateMonitor monitor(api, 48000, {11});
+
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+  ASSERT_TRUE(monitor.permitsRendering());
+
+  api.setRate(11, 44100.0);
+  api.notifyRateChange(11);
+  EXPECT_TRUE(monitor.isPending());
+  EXPECT_FALSE(monitor.permitsRendering());
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::RateRestored);
+  EXPECT_TRUE(monitor.permitsRendering());
+
+  monitor.requestCheck();
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+}
+
+TEST(CoreAudioSampleRateMonitorTest, RefusedReassertionKeepsRenderingBlocked) {
+  FakeCoreAudioSampleRatePropertyApi api;
+  api.setRate(11, 48000.0);
+  CoreAudioSampleRateMonitor monitor(api, 48000, {11});
+
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+
+  api.setRate(11, 44100.0);
+  api.rejectRateChanges();
+  api.notifyRateChange(11);
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::ReinitializationRequired);
+  EXPECT_FALSE(monitor.permitsRendering());
+}
+
+TEST(CoreAudioSampleRateMonitorTest, QueryFailureKeepsRenderingBlocked) {
+  FakeCoreAudioSampleRatePropertyApi api;
+  api.setRate(11, 48000.0);
+  CoreAudioSampleRateMonitor monitor(api, 48000, {11});
+
+  ASSERT_TRUE(monitor.start());
+  api.failQueries();
+  monitor.requestCheck();
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::QueryFailed);
+  EXPECT_FALSE(monitor.permitsRendering());
+}
+
+} // namespace
+} // namespace orpheus
+
+#endif // ORPHEUS_ENABLE_COREAUDIO

--- a/tests/audio_io/coreaudio_sample_rate_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_sample_rate_monitor_test.cpp
@@ -3,6 +3,7 @@
 
 #include "coreaudio/coreaudio_sample_rate_monitor.h"
 
+#include <functional>
 #include <map>
 #include <vector>
 
@@ -31,6 +32,10 @@ public:
     queries_fail_ = true;
   }
 
+
+  void notifyDuringNextPropertyRead(AudioObjectID device_id) {
+    on_next_property_read_ = [this, device_id] { notifyRateChange(device_id); };
+  }
   void notifyRateChange(AudioObjectID device_id) {
     const AudioObjectPropertyAddress address = {kAudioDevicePropertyNominalSampleRate,
                                                 kAudioObjectPropertyScopeGlobal,
@@ -76,6 +81,10 @@ public:
       return kAudioHardwareUnspecifiedError;
     }
     *static_cast<Float64*>(data) = rates_[device_id];
+    if (on_next_property_read_) {
+      std::function<void()> callback = std::move(on_next_property_read_);
+      callback();
+    }
     return noErr;
   }
 
@@ -94,6 +103,7 @@ private:
   bool accepts_rate_changes_{true};
   bool queries_fail_{false};
   size_t callback_deliveries_{0};
+  std::function<void()> on_next_property_read_;
 };
 
 TEST(CoreAudioSampleRateMonitorTest, RegistersEachUniqueRouteAndCleansUpListeners) {
@@ -134,6 +144,27 @@ TEST(CoreAudioSampleRateMonitorTest, ReassertsChangedRateBeforeRenderingResumes)
 
   monitor.requestCheck();
   EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+}
+
+TEST(CoreAudioSampleRateMonitorTest, RetainsNotificationArrivingDuringFinalPropertyRead) {
+  FakeCoreAudioSampleRatePropertyApi api;
+  api.setRate(11, 48000.0);
+  CoreAudioSampleRateMonitor monitor(api, 48000, {11});
+
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+  ASSERT_TRUE(monitor.permitsRendering());
+
+  api.notifyDuringNextPropertyRead(11);
+  monitor.requestCheck();
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+  EXPECT_TRUE(monitor.isPending());
+  EXPECT_FALSE(monitor.permitsRendering());
+
+  EXPECT_EQ(monitor.poll(), CoreAudioSampleRatePollResult::NoChange);
+  EXPECT_FALSE(monitor.isPending());
+  EXPECT_TRUE(monitor.permitsRendering());
 }
 
 TEST(CoreAudioSampleRateMonitorTest, RefusedReassertionKeepsRenderingBlocked) {

--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -38,6 +38,9 @@ endfunction()
 add_orpheus_fixture(orpheus_find_package_core main.cpp)
 target_link_libraries(orpheus_find_package_core PRIVATE Orpheus::core)
 
+add_orpheus_fixture(orpheus_find_package_audio_io_telemetry audio_io_telemetry.cpp)
+target_link_libraries(orpheus_find_package_audio_io_telemetry PRIVATE Orpheus::audio_io)
+
 add_orpheus_fixture(orpheus_find_package_diagnostics
   ${CMAKE_CURRENT_LIST_DIR}/../../verify_diagnostics_standalone.cpp)
 target_link_libraries(orpheus_find_package_diagnostics PRIVATE Orpheus::diagnostics)

--- a/tests/cmake/find_package/audio_io_telemetry.cpp
+++ b/tests/cmake/find_package/audio_io_telemetry.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/audio_driver.h>
+
+namespace {
+
+class TelemetryDriver final : public orpheus::IAudioDriver {
+public:
+  orpheus::SessionGraphError initialize(const orpheus::AudioDriverConfig& config) override {
+    config_ = config;
+    return orpheus::SessionGraphError::OK;
+  }
+
+  orpheus::SessionGraphError start(orpheus::IAudioCallback*) override {
+    return orpheus::SessionGraphError::OK;
+  }
+
+  orpheus::SessionGraphError stop() override {
+    return orpheus::SessionGraphError::OK;
+  }
+
+  bool isRunning() const override {
+    return false;
+  }
+
+  const orpheus::AudioDriverConfig& getConfig() const override {
+    return config_;
+  }
+
+  std::string getDriverName() const override {
+    return "TelemetryFixture";
+  }
+
+  uint32_t getLatencySamples() const override {
+    return 0;
+  }
+
+private:
+  orpheus::AudioDriverConfig config_;
+};
+
+} // namespace
+
+int main() {
+  TelemetryDriver driver;
+  const orpheus::AudioIoTelemetry telemetry = driver.getTelemetry();
+  return telemetry.input_render_failures != 0 ||
+                 telemetry.runtime_outcome != orpheus::AudioDriverRuntimeOutcome::Healthy
+             ? 1
+             : 0;
+}


### PR DESCRIPTION
## Summary
- Monitor nominal sample-rate changes across active aggregate and physical CoreAudio routes.
- Gate rendering while a control worker reasserts the configured rate; stop and expose a terminal telemetry outcome when recovery fails.
- Add deterministic listener/property tests and a live playback-only monitor-start smoke test.

## Verification
- ASan/UBSan Debug focused CoreAudio suite: 12 passed.
- `tools/realtime_audit.py --root . --fail-known-debt`: passed.
- Full Debug CTest: 155/158 test commands passed. Known environment/repository failures are documented in `PROGRESS.md`: missing docs links, ShmUI package export dependencies, and legacy default-two-input CoreAudio cases returning `InvalidParameter` on this host.

## Limitation
No controllable local device was available to record a physical 48 kHz to 44.1 kHz runtime transition; deterministic property-listener coverage exercises recovery and refusal paths.