### PR TITLE
feat(audio): add CoreAudio multi-device route-state contract

### DIFF
--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -6,7 +6,9 @@ Project documentation index for orpheus-sdk.
 
 - [[README]]
 
+
 ## Recent Documents
+- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] — proposed SDK contract handoff for FourTrack independent input/output routing, channel maps, active-route facts, split latency, and terminal route outcomes (2026-08-04)
 - [[ORP168 Streaming Seek Priming and Underrun Classification]] — corrected
   streaming Start/refire command-prime leasing and effective pre-trim-IN seek
   priming; rendered realtime regression evidence (2026-08-01)
@@ -99,7 +101,9 @@ Project documentation index for orpheus-sdk.
 - [[ORP159 Suite Synchronization and Integration Gate]]
 - [[ORP160 Master Tape Varispeed Primitive]]
 - [[ORP161 FourTrack Live Output Handoff Assessment]]
+
 - [[ORP168 Streaming Seek Priming and Underrun Classification]]
+- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]]
 
 ## Archived Documents
 

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -8,7 +8,8 @@ Project documentation index for orpheus-sdk.
 
 
 ## Recent Documents
-- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] — proposed SDK contract handoff for FourTrack independent input/output routing, channel maps, active-route facts, split latency, and terminal route outcomes (2026-08-04)
+- [[ORP172 Digital Audio Routing Practice Research]] — 2026 reconnaissance of AES67, ST 2110, Dante, NMOS IS-04/05/08, PTP, and portable routing/control-plane vocabulary (2026-08-04)
+- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] — implemented SDK route-state contract; release and downstream adoption pending (2026-08-04)
 - [[ORP168 Streaming Seek Priming and Underrun Classification]] — corrected
   streaming Start/refire command-prime leasing and effective pre-trim-IN seek
   priming; rendered realtime regression evidence (2026-08-01)
@@ -138,4 +139,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-08-01
+**Last Generated:** 2026-08-04

--- a/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
+++ b/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
@@ -337,7 +337,7 @@ remote PR, released SDK revision, and FourTrack's follow-up checks.
 
 | Item | Required value | Current value |
 |---|---|---|
-| Upstream issue/PR | URL and target branch | Not assigned |
+| Upstream issue/PR | URL and target branch | [PR #234](https://github.com/chrislyons/orpheus-sdk/pull/234) → `main` |
 | SDK implementation branch | branch name | `feature/orp-output-endpoint-contract` |
 | SDK contract commit | immutable commit | `ae350028` |
 | Released SDK revision | tag/package revision | Not available |

--- a/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
+++ b/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
@@ -339,7 +339,7 @@ remote PR, released SDK revision, and FourTrack's follow-up checks.
 |---|---|---|
 | Upstream issue/PR | URL and target branch | Not assigned |
 | SDK implementation branch | branch name | `feature/orp-output-endpoint-contract` |
-| SDK contract commit | immutable commit | `8f519259` |
+| SDK contract commit | immutable commit | `ae350028` |
 | Released SDK revision | tag/package revision | Not available |
 | FourTrack pin | immutable gitlink | `b452cbfa2b1d11a36bc3f5d69a15e2dea9a80099` |
 | FourTrack adoption | route activation/status path | Blocked pending release |

--- a/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
+++ b/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
@@ -2,8 +2,8 @@
 
 # ORP171 — FourTrack Multi-Device CoreAudio Route-State Contract Handoff
 
-**Document type:** SDK public-contract handoff
-**Status:** Proposed; upstream implementation and release pending
+**Document type:** SDK public-contract implementation handoff
+**Status:** Implemented on SDK branch; release and downstream adoption pending
 **Date:** 2026-08-04
 **Consumer:** FourTrack / EightTrack, FTR074
 **Current FourTrack SDK pin:** `b452cbfa2b1d11a36bc3f5d69a15e2dea9a80099`
@@ -20,10 +20,11 @@ timing, and endpoint-runtime outcomes. FourTrack must not open CoreAudio devices
 downcast a factory-created driver, infer a route from display names, or infer
 capture health from silent samples.
 
-This document is an SDK handoff, not an implementation record. It does not claim
-that the proposed route-state contract is implemented or released. FourTrack must
-not consume a dirty SDK worktree revision. The required upstream issue/PR URL and
-released SDK revision are intentionally still unassigned.
+This document now records the SDK implementation and verification boundary. The
+route-state contract is implemented on the SDK feature branch, but the branch
+must be committed and released before FourTrack consumes it. FourTrack must not
+consume a dirty SDK worktree revision. The required upstream issue/PR URL and
+released SDK revision remain unassigned until delivery.
 
 The existing directional endpoint-ID contract from ORP155 is already the correct
 foundation and must be retained. The remaining work is a new, versioned contract
@@ -221,6 +222,38 @@ No CoreAudio property query, device discovery, allocation, lock, or I/O may ente
 the render callback. `getActiveRoute()` and telemetry remain control-thread
 reads.
 
+## 4.4 Implemented SDK record
+
+The SDK implementation keeps the ORP155 directional UID contract and adds the
+canonical route-state types from §3:
+
+- `AudioDriverConfig::channel_map` validates each direction after independent
+  endpoint resolution. Empty maps become consecutive physical channels;
+  non-empty maps require the logical channel count, unique in-range values, and
+  are applied to the AUHAL output and capture scopes before start.
+- `ActiveAudioRoute` reports the two physical DeviceUIDs, resolved maps,
+  available directional channel counts, requested and actual rate/buffer facts,
+  alive state, and a split `AudioRouteLatency`.
+- CoreAudio uses a private aggregate only for distinct duplex endpoints, keeps
+  the physical UIDs in the active snapshot, applies the ORP162 capture offset,
+  and destroys the aggregate on reinitialize, cleanup, and destruction.
+- `CoreAudioRouteMonitor` registers alive, nominal-rate, buffer-size, virtual
+  format, and physical format listeners. Property callbacks publish only a
+  bounded pending generation. A control worker performs HAL reads, closes
+  render admission before unsafe state reaches `processAudio`, restores a
+  nominal rate only when verified, and publishes the route outcome otherwise.
+- CoreAudio latency assigns input device/safety/stream terms to capture, output
+  device/safety/stream terms to playback, and callback-buffer/AudioUnit terms to
+  processing. Missing mandatory terms leave `complete == false`; no estimate is
+  derived from wall time or buffer size.
+- Dummy and other non-CoreAudio drivers retain the default empty physical route
+  rather than fabricating endpoint identity, maps, liveness, or hardware timing.
+  `IAudioDriverManager` remains unchanged.
+
+The render callback uses only preallocated buffers and atomics/borrowed targets.
+HAL queries, listener lifecycle, route recovery, allocations, and route-state
+publication remain on control paths.
+
 ## 5. FourTrack consumption after release
 
 After the SDK contract is merged and released, FourTrack will:
@@ -242,8 +275,9 @@ persist output preferences inside the `.trk` bundle.
 
 ## 6. SDK verification contract
 
-The upstream implementation is not ready for FourTrack consumption until these
-contracts have deterministic coverage:
+The implementation has deterministic coverage for the route-state contract on
+the SDK branch. The release gate remains the immutable commit, package, and
+downstream pin described in §7.
 
 ### Endpoint and map resolution
 
@@ -278,16 +312,34 @@ and add-subdirectory consumer checks on the SDK branch. FourTrack then updates
 only to the released immutable revision and runs its deterministic mock-driver
 route tests before any hardware acceptance.
 
+### Observed SDK branch verification
+
+On 2026-08-04, the configured `build-sdk-fast` tree built successfully with
+`cmake --build build-sdk-fast --parallel 8`. Focused executables reported:
+
+- `coreaudio_driver_test`: 47 passed, including 7 injected route-monitor tests;
+- `dummy_driver_test`: 15 passed; and
+- `driver_manager_test`: 20 passed.
+
+The complete `ctest --test-dir build-sdk-fast --output-on-failure` run passed
+all 75 enabled tests out of 76 registered tests. `abi_link` remained the
+repository's intentional disabled test. The run included realtime/static,
+documentation, version, installed-package, and add-subdirectory checks. The
+Windows-only WASAPI implementation was not compiled or executed on this
+macOS host. FourTrack must still update only to a released immutable SDK
+revision and run its own mock-driver and hardware gates.
+
 ## 7. Release and handoff checklist
 
-The SDK handoff is complete only when the following values are recorded here and
-in the FourTrack FTR074 report:
+The SDK route-state implementation and macOS verification are complete in the
+immutable commit recorded below. Downstream adoption remains gated on the
+remote PR, released SDK revision, and FourTrack's follow-up checks.
 
 | Item | Required value | Current value |
 |---|---|---|
 | Upstream issue/PR | URL and target branch | Not assigned |
-| SDK implementation branch | branch name | `feature/orp-output-endpoint-contract` is a dirty worktree; not consumable |
-| SDK contract commit | immutable commit | Not available |
+| SDK implementation branch | branch name | `feature/orp-output-endpoint-contract` |
+| SDK contract commit | immutable commit | `8f519259` |
 | Released SDK revision | tag/package revision | Not available |
 | FourTrack pin | immutable gitlink | `b452cbfa2b1d11a36bc3f5d69a15e2dea9a80099` |
 | FourTrack adoption | route activation/status path | Blocked pending release |

--- a/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
+++ b/docs/orp/ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff.md
@@ -1,0 +1,316 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP171 — FourTrack Multi-Device CoreAudio Route-State Contract Handoff
+
+**Document type:** SDK public-contract handoff
+**Status:** Proposed; upstream implementation and release pending
+**Date:** 2026-08-04
+**Consumer:** FourTrack / EightTrack, FTR074
+**Current FourTrack SDK pin:** `b452cbfa2b1d11a36bc3f5d69a15e2dea9a80099`
+**Related:** ORP155, ORP156, ORP162; FourTrack `docs/ftr/FTR074 Multi-Device CoreAudio I O Investigation and SDK Handoff.md`
+
+---
+
+## 1. Decision requested
+
+FourTrack needs a production-safe, capability-driven CoreAudio route contract for
+independently selected input and output endpoints. The SDK must own endpoint
+activation, physical-to-logical channel mapping, negotiated route facts, route
+timing, and endpoint-runtime outcomes. FourTrack must not open CoreAudio devices,
+downcast a factory-created driver, infer a route from display names, or infer
+capture health from silent samples.
+
+This document is an SDK handoff, not an implementation record. It does not claim
+that the proposed route-state contract is implemented or released. FourTrack must
+not consume a dirty SDK worktree revision. The required upstream issue/PR URL and
+released SDK revision are intentionally still unassigned.
+
+The existing directional endpoint-ID contract from ORP155 is already the correct
+foundation and must be retained. The remaining work is a new, versioned contract
+for channel maps, active-route state, timing, and safe runtime change handling.
+
+## 2. Source-verified baseline
+
+### 2.1 Contract already delivered by ORP155/ORP156
+
+The pinned SDK public header exposes independent fields:
+
+```cpp
+struct AudioDriverConfig {
+  uint32_t sample_rate = 48000;
+  uint16_t buffer_size = 512;
+  uint16_t num_inputs = 2;
+  std::string input_device_id;   // empty = directional system default
+  uint16_t num_outputs = 2;
+  std::string output_device_id;  // empty = directional system default
+  std::string device_name;
+};
+```
+
+For CoreAudio:
+
+- each non-empty identifier is a persistent
+  `kAudioDevicePropertyDeviceUID`, not a display name or enumeration index;
+- input and output identifiers resolve independently;
+- an unknown or direction-incompatible explicit identifier returns
+  `SessionGraphError::InvalidParameter` without default fallback;
+- two valid distinct endpoints use an SDK-owned private aggregate; and
+- an empty identifier selects only that direction's current system default.
+
+This closes the original FTR020 UID-field blocker. It does **not** provide the
+full route-state contract below.
+
+### 2.2 Current consumer gap
+
+FourTrack's current path still constructs the real driver without a route
+configuration:
+
+1. `apps/fourtrack-mac/bridge/FourTrackBridge.mm::Doc::build_and_start()` creates
+   `createCoreAudioDriver()` and starts the engine without a route request.
+2. `src/fourtrack/engine/engine.cpp::Engine::start()` leaves both directional
+   SDK IDs empty and configures one input plus two outputs.
+3. The bridge's existing device setter records only the advisory capture hint and
+   discards the selected output UID.
+4. The Swift catalog presents UIDs and directional presence, but it is not proof
+   that a route is active.
+
+FTR074 records this path, the host/SDK ownership boundary, and the macOS route
+probe. `system_profiler SPAudioDataType` is inventory evidence only; it does not
+expose CoreAudio UIDs, channel labels, alive state, rate ranges, buffer values, or
+latency properties.
+
+## 3. Required public SDK contract
+
+The following is the recommended canonical shape. Before implementation, reconcile
+it with any parallel draft types in the SDK worktree. Do not ship two competing
+route-state or latency models.
+
+### 3.1 Channel maps
+
+```cpp
+struct AudioRouteChannelMap {
+  std::vector<uint16_t> input_channels;
+  std::vector<uint16_t> output_channels;
+};
+```
+
+Add `AudioRouteChannelMap channel_map{}` to `AudioDriverConfig`.
+
+Semantics:
+
+- an empty directional vector preserves the existing consecutive mapping
+  `0..num_inputs-1` or `0..num_outputs-1`;
+- a non-empty vector must exactly match that direction's logical channel count;
+- values must be unique; and
+- every value must be within the resolved physical direction's channel count.
+
+Validation occurs after both directional endpoints resolve and before the
+AudioUnit is started. Invalid maps return `SessionGraphError::InvalidParameter`.
+No host-side channel-count assumption is permitted.
+
+### 3.2 Active-route timing and state
+
+```cpp
+struct AudioRouteLatency {
+  uint32_t capture_frames = 0;
+  uint32_t playback_frames = 0;
+  uint32_t processing_frames = 0;
+  bool complete = false;
+};
+
+enum class AudioRouteRuntimeOutcome : uint8_t {
+  Healthy,
+  RouteUnavailable,
+  FormatChanged,
+  ReinitializationRequired,
+  BackendFailure,
+};
+
+struct ActiveAudioRoute {
+  std::string input_device_id;
+  std::string output_device_id;
+  std::vector<uint16_t> input_channels;
+  std::vector<uint16_t> output_channels;
+  uint16_t available_input_channels = 0;
+  uint16_t available_output_channels = 0;
+  uint32_t requested_sample_rate = 0;
+  uint32_t actual_sample_rate = 0;
+  uint32_t actual_buffer_frames = 0;
+  AudioRouteLatency latency;
+  bool input_alive = false;
+  bool output_alive = false;
+};
+```
+
+Add a control-thread-only `IAudioDriver::getActiveRoute() const` accessor with an
+empty/default result for backends that do not implement the contract.
+
+Extend `AudioIoTelemetry` with `AudioRouteRuntimeOutcome route_outcome`. Preserve
+existing sample-rate telemetry and source compatibility for existing consumers;
+do not silently replace the established backend-runtime outcome enum. The final
+public naming must use one canonical outcome model rather than parallel enums with
+ambiguous ownership.
+
+The timing invariant is:
+
+```text
+round_trip_frames = capture_frames + playback_frames + processing_frames
+```
+
+The SDK reports `complete = false` when a mandatory term cannot be read. It must
+not estimate a missing term from buffer size, codec assumptions, wall-clock time,
+or a guessed aggregate contribution.
+
+### 3.3 Non-CoreAudio behavior
+
+Non-CoreAudio backends may retain the default empty route, zero timing terms, and
+`Healthy` route outcome until they implement the contract. They must not fabricate
+physical endpoint IDs, maps, alive state, or timing.
+
+`IAudioDriverManager` must not be extended for this feature. Its current
+single-active-device and output-oriented `AudioDeviceInfo` abstraction cannot
+represent independent directional endpoints and maps.
+
+## 4. CoreAudio implementation contract
+
+### 4.1 Initialization
+
+`CoreAudioDriver` must:
+
+1. resolve the requested input and output UIDs independently;
+2. reject unknown or direction-incompatible explicit UIDs without consulting a
+   fallback default;
+3. retain the two physical endpoint UIDs even when a private aggregate is the
+   AudioUnit device;
+4. discover each resolved direction's physical channel count;
+5. validate and apply both channel maps at AudioUnit configuration time;
+6. retain requested and actual sample rate and buffer size; and
+7. publish a control-thread `ActiveAudioRoute` only after the route is configured.
+
+The aggregate is an implementation detail. The physical endpoint IDs in
+`ActiveAudioRoute` are the route identity FourTrack displays and persists as
+provenance.
+
+### 4.2 Timing
+
+The existing CoreAudio latency query returns a combined round-trip quantity. The
+new implementation must assign each available HAL/AudioUnit term to exactly one
+of capture, playback, or processing. It must document the assignment in the
+implementation record and test the sum invariant.
+
+If a mandatory property is unavailable, publish an incomplete route rather than a
+false complete compensation value. FourTrack will refuse automatic record
+placement for an incomplete route.
+
+### 4.3 Runtime route changes
+
+The SDK must listen off the render callback for at least:
+
+- endpoint alive state;
+- nominal sample rate;
+- stream format; and
+- buffer size.
+
+The CoreAudio property callback may only atomically mark a generation or pending
+change. A control worker performs HAL reads and recovery. It must close callback
+admission before a format mismatch can reach `processAudio`, publish
+`RouteUnavailable`, `FormatChanged`, or `ReinitializationRequired`, and stop
+rendering when safe in-place restoration is impossible.
+
+No CoreAudio property query, device discovery, allocation, lock, or I/O may enter
+the render callback. `getActiveRoute()` and telemetry remain control-thread
+reads.
+
+## 5. FourTrack consumption after release
+
+After the SDK contract is merged and released, FourTrack will:
+
+1. update its immutable submodule pin;
+2. map its platform-neutral `AudioRouteRequest` to the SDK directional IDs and
+   channel maps;
+3. retain its internal stereo master and project only at the realtime driver
+   boundary to one or two selected outputs;
+4. latch complete route timing for deterministic record placement;
+5. suspend to Idle on terminal route failure without committing an incomplete
+   temporary take;
+6. expose requested versus resolved route facts through the bridge and Settings;
+   and
+7. persist only the actual active capture endpoint as session provenance.
+
+FourTrack will not add a second CoreAudio abstraction, route by display name, or
+persist output preferences inside the `.trk` bundle.
+
+## 6. SDK verification contract
+
+The upstream implementation is not ready for FourTrack consumption until these
+contracts have deterministic coverage:
+
+### Endpoint and map resolution
+
+- unknown explicit input UID returns `InvalidParameter` without default access;
+- unknown explicit output UID returns `InvalidParameter` without default access;
+- direction-incompatible UIDs reject without fallback;
+- valid distinct endpoints create one SDK-owned private aggregate;
+- active-route state reports the two physical UIDs, not only the aggregate UID;
+- empty maps preserve consecutive mapping;
+- valid non-consecutive maps apply in logical order; and
+- duplicate, wrong-length, and out-of-range maps reject deterministically.
+
+### Active route and timing
+
+- actual rate, actual buffer, directional counts, maps, and alive state are
+  reported from CoreAudio properties;
+- complete timing satisfies the split-term sum invariant;
+- missing mandatory timing data makes `complete` false; and
+- control-thread reads do not query HAL from the render callback.
+
+### Runtime changes
+
+Injected property-API tests must cover alive loss, nominal-rate change,
+stream-format change, and buffer-size change. Each case must close render
+admission before unsafe audio reaches the host and publish the matching terminal
+outcome. Safe restoration and explicit reinitialization must remain distinct.
+
+### Package and consumer evidence
+
+Run the SDK's prescribed build, test, realtime audit, installed-package consumer,
+and add-subdirectory consumer checks on the SDK branch. FourTrack then updates
+only to the released immutable revision and runs its deterministic mock-driver
+route tests before any hardware acceptance.
+
+## 7. Release and handoff checklist
+
+The SDK handoff is complete only when the following values are recorded here and
+in the FourTrack FTR074 report:
+
+| Item | Required value | Current value |
+|---|---|---|
+| Upstream issue/PR | URL and target branch | Not assigned |
+| SDK implementation branch | branch name | `feature/orp-output-endpoint-contract` is a dirty worktree; not consumable |
+| SDK contract commit | immutable commit | Not available |
+| Released SDK revision | tag/package revision | Not available |
+| FourTrack pin | immutable gitlink | `b452cbfa2b1d11a36bc3f5d69a15e2dea9a80099` |
+| FourTrack adoption | route activation/status path | Blocked pending release |
+
+The current FourTrack pin describes as `v0.6.7-29-gb452cbfa`; no release tag
+points at that exact revision. Do not replace the pin with a local SDK worktree
+commit.
+
+When the upstream release exists, update this table, ORP171, FTR074, and the
+consumer pin together. Record the SDK verification outputs and the FourTrack
+adoption tests in the same checkpoint.
+
+## 8. Non-goals
+
+This handoff does not request:
+
+- a FourTrack-specific SDK factory;
+- a new `IAudioDriverManager` device abstraction;
+- display-name or transport-name heuristics;
+- automatic fallback from a missing explicit UID;
+- a guessed latency compensation path;
+- direct CoreAudio dependencies in FourTrack `src/` or `include/`; or
+- Bluetooth behavior claims not supported by CoreAudio-reported capabilities.
+
+The correct stopping point is an explicit unavailable/reconfiguration outcome,
+not silent default routing.

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -15,6 +15,12 @@ namespace orpheus {
 
 class IPerformanceMonitor;
 
+/// Physical-to-logical channel selections for a configured route.
+struct AudioRouteChannelMap {
+  std::vector<uint16_t> input_channels;
+  std::vector<uint16_t> output_channels;
+};
+
 /// Audio driver configuration.
 ///
 /// Backend endpoint identifiers are stable backend IDs. CoreAudio consumes
@@ -28,6 +34,50 @@ struct AudioDriverConfig {
   uint16_t num_outputs = 2;     ///< Number of output channels
   std::string output_device_id; ///< Stable output endpoint ID (empty = default)
   std::string device_name;      ///< Optional host-visible display name
+
+  /// Physical-to-logical channel selection for each direction.
+  /// An empty vector selects consecutive physical channels starting at zero.
+  AudioRouteChannelMap channel_map{};
+};
+
+/// Decomposed route latency reported by the backend.
+///
+/// `complete` is true only when all mandatory terms for the active route were
+/// measured. A missing term is never estimated from buffer size or wall time.
+struct AudioRouteLatency {
+  uint32_t capture_frames = 0;
+  uint32_t playback_frames = 0;
+  uint32_t processing_frames = 0;
+  bool complete = false;
+};
+
+/// Runtime outcome that can invalidate active audio I/O.
+enum class AudioRouteRuntimeOutcome : uint8_t {
+  Healthy,
+  RouteUnavailable,
+  FormatChanged,
+  ReinitializationRequired,
+  BackendFailure,
+};
+
+/// Control-thread snapshot of the physical route negotiated by a backend.
+///
+/// This is route identity and capability state, not a UI catalog row. IDs are
+/// persistent backend IDs; CoreAudio reports physical endpoint UIDs even when
+/// it uses a private aggregate as the AudioUnit device.
+struct ActiveAudioRoute {
+  std::string input_device_id;
+  std::string output_device_id;
+  std::vector<uint16_t> input_channels;
+  std::vector<uint16_t> output_channels;
+  uint16_t available_input_channels = 0;
+  uint16_t available_output_channels = 0;
+  uint32_t requested_sample_rate = 0;
+  uint32_t actual_sample_rate = 0;
+  uint32_t actual_buffer_frames = 0;
+  AudioRouteLatency latency;
+  bool input_alive = false;
+  bool output_alive = false;
 };
 
 /// Outcome of a backend runtime condition that can invalidate active audio I/O.
@@ -47,6 +97,7 @@ enum class AudioDriverRuntimeOutcome : uint8_t {
 struct AudioIoTelemetry {
   uint64_t input_render_failures = 0; ///< Cumulative failed capture renders
   AudioDriverRuntimeOutcome runtime_outcome = AudioDriverRuntimeOutcome::Healthy;
+  AudioRouteRuntimeOutcome route_outcome = AudioRouteRuntimeOutcome::Healthy;
 };
 
 /// Audio backend family.
@@ -108,8 +159,8 @@ struct AudioProcessBlock {
   bool discontinuity = false;
 };
 
-/// Audio driver callback interface
-/// Called on the audio thread - must be lock-free
+/// Audio driver callback interface.
+/// Called on the audio thread - must be lock-free.
 class IAudioCallback {
 public:
   virtual ~IAudioCallback() = default;
@@ -127,50 +178,37 @@ public:
   }
 };
 
-/// Audio driver interface
-/// Abstracts platform-specific audio I/O (CoreAudio, WASAPI, ASIO, dummy)
+/// Audio driver interface.
+/// Abstracts platform-specific audio I/O (CoreAudio, WASAPI, ASIO, dummy).
 class IAudioDriver {
 public:
   virtual ~IAudioDriver() = default;
 
-  /// Initialize the audio driver
-  /// @param config Driver configuration
-  /// @return SessionGraphError::OK on success
+  /// Initialize the audio driver.
   virtual SessionGraphError initialize(const AudioDriverConfig& config) = 0;
 
-  /// Start audio processing
-  /// @param callback Callback interface for audio processing (must not be nullptr)
-  /// @return SessionGraphError::OK on success
+  /// Start audio processing. Callback must not be nullptr.
   virtual SessionGraphError start(IAudioCallback* callback) = 0;
 
-  /// Stop audio processing
-  /// @return SessionGraphError::OK on success
+  /// Stop audio processing.
   virtual SessionGraphError stop() = 0;
 
-  /// Check if driver is currently running
+  /// Check whether the driver is running.
   virtual bool isRunning() const = 0;
 
-  /// Get current configuration
+  /// Get current configuration.
   virtual const AudioDriverConfig& getConfig() const = 0;
 
-  /// Get driver name (e.g., "Dummy", "CoreAudio", "WASAPI")
+  /// Get human-readable driver name.
   virtual std::string getDriverName() const = 0;
 
-  /// Get current device latency in samples.
-  /// @return Total round-trip latency (input + output)
+  /// Get total measured latency in samples, or zero when unavailable.
   virtual uint32_t getLatencySamples() const = 0;
 
-  /// Get lock-free backend I/O diagnostics. The default remains zero for
-  /// drivers that do not expose backend failures.
-  virtual AudioIoTelemetry getTelemetry() const noexcept {
-    return {};
-  }
-
-  /// Get runtime backend/device capabilities.
+  /// Get backend capabilities.
   ///
-  /// Default implementation is intentionally conservative so older/custom
-  /// driver implementations remain source-compatible until they can report
-  /// richer platform details.
+  /// The default is conservative so custom drivers can adopt richer route
+  /// reporting incrementally.
   virtual AudioDriverCapabilities getCapabilities() const {
     AudioDriverCapabilities caps;
     caps.min_output_channels = getConfig().num_outputs;
@@ -185,18 +223,26 @@ public:
     return caps;
   }
 
-  /// Attach a non-owning realtime performance sink; nullptr detaches it.
+  /// Get the negotiated physical route. Control-thread only.
+  virtual ActiveAudioRoute getActiveRoute() const {
+    return {};
+  }
+
+  /// Get cumulative backend diagnostics. Control-thread only.
+  virtual AudioIoTelemetry getTelemetry() const noexcept {
+    return {};
+  }
+
+  /// Set optional realtime performance monitor.
   virtual void setPerformanceMonitor(IPerformanceMonitor* monitor) {
     (void)monitor;
   }
 };
 
-/// Factory function for dummy audio driver (for testing)
-/// @return New dummy audio driver instance
+/// Factory function for dummy audio driver (for testing).
 ORPHEUS_API std::unique_ptr<IAudioDriver> createDummyAudioDriver();
 
-/// Factory function for CoreAudio driver (macOS only)
-/// @return New CoreAudio driver instance
+/// Factory function for CoreAudio driver (macOS only).
 #ifdef __APPLE__
 ORPHEUS_API std::unique_ptr<IAudioDriver> createCoreAudioDriver();
 #endif

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -205,6 +205,11 @@ public:
   /// Get total measured latency in samples, or zero when unavailable.
   virtual uint32_t getLatencySamples() const = 0;
 
+  /// Get cumulative backend diagnostics. Control-thread only.
+  virtual AudioIoTelemetry getTelemetry() const noexcept {
+    return {};
+  }
+
   /// Get backend capabilities.
   ///
   /// The default is conservative so custom drivers can adopt richer route
@@ -223,19 +228,16 @@ public:
     return caps;
   }
 
-  /// Get the negotiated physical route. Control-thread only.
-  virtual ActiveAudioRoute getActiveRoute() const {
-    return {};
-  }
-
-  /// Get cumulative backend diagnostics. Control-thread only.
-  virtual AudioIoTelemetry getTelemetry() const noexcept {
-    return {};
-  }
-
   /// Set optional realtime performance monitor.
   virtual void setPerformanceMonitor(IPerformanceMonitor* monitor) {
     (void)monitor;
+  }
+
+  /// Get the negotiated physical route. Control-thread only.
+  ///
+  /// Appended to preserve existing IAudioDriver virtual-table slots.
+  virtual ActiveAudioRoute getActiveRoute() const {
+    return {};
   }
 };
 

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -19,7 +19,7 @@ class IAudioDriver;
 /// Audio device information
 struct AudioDeviceInfo {
   std::string deviceId;                       ///< Unique device identifier
-  std::string name;                           ///< Human-readable name
+  std::string name;                           ///< Human-readable device name
   std::string driverType;                     ///< "CoreAudio", "ASIO", "WASAPI", "ALSA", "Dummy"
   uint32_t minChannels;                       ///< Minimum output channels
   uint32_t maxChannels;                       ///< Maximum output channels

--- a/src/core/audio_io/dummy_audio_driver.cpp
+++ b/src/core/audio_io/dummy_audio_driver.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include "dummy_audio_driver.h"
 
+#include <algorithm>
 #include <chrono>
-#include <cstring>
 
 namespace orpheus {
 
@@ -13,96 +13,76 @@ DummyAudioDriver::~DummyAudioDriver() {
 }
 
 SessionGraphError DummyAudioDriver::initialize(const AudioDriverConfig& config) {
-  std::lock_guard<std::mutex> lock(m_mutex);
-
-  if (m_running.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Cannot initialize while running
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (running_.load(std::memory_order_acquire)) {
+    return SessionGraphError::InternalError;
   }
-
-  // Validate configuration
-  if (config.sample_rate == 0 || config.buffer_size == 0) {
+  if (config.sample_rate == 0 || config.buffer_size == 0 || config.num_inputs > 32 ||
+      config.num_outputs > 32) {
     return SessionGraphError::InvalidParameter;
   }
 
-  if (config.num_inputs > 32 || config.num_outputs > 32) {
-    return SessionGraphError::InvalidParameter;
+  config_ = config;
+  input_buffer_storage_.assign(config_.num_inputs, std::vector<float>(config_.buffer_size, 0.0f));
+  output_buffer_storage_.assign(config_.num_outputs, std::vector<float>(config_.buffer_size, 0.0f));
+  input_ptrs_.resize(config_.num_inputs);
+  output_ptrs_.resize(config_.num_outputs);
+  for (size_t channel = 0; channel < input_buffer_storage_.size(); ++channel) {
+    input_ptrs_[channel] = input_buffer_storage_[channel].data();
+  }
+  for (size_t channel = 0; channel < output_buffer_storage_.size(); ++channel) {
+    output_ptrs_[channel] = output_buffer_storage_[channel].data();
   }
 
-  m_config = config;
-
-  // Pre-allocate buffers
-  m_input_buffer_storage.clear();
-  m_output_buffer_storage.clear();
-  m_input_ptrs.clear();
-  m_output_ptrs.clear();
-
-  for (size_t i = 0; i < m_config.num_inputs; ++i) {
-    m_input_buffer_storage.emplace_back(m_config.buffer_size, 0.0f);
-    m_input_ptrs.push_back(m_input_buffer_storage.back().data());
-  }
-
-  for (size_t i = 0; i < m_config.num_outputs; ++i) {
-    m_output_buffer_storage.emplace_back(m_config.buffer_size, 0.0f);
-    m_output_ptrs.push_back(m_output_buffer_storage.back().data());
-  }
-
+  // The dummy backend has no physical endpoint, so it must not fabricate route
+  // identity, liveness, channel mapping, or hardware latency facts.
+  active_route_ = {};
+  input_render_failures_.store(0, std::memory_order_release);
+  initialized_ = true;
   return SessionGraphError::OK;
 }
 
 SessionGraphError DummyAudioDriver::start(IAudioCallback* callback) {
-  std::lock_guard<std::mutex> lock(m_mutex);
-
-  if (!callback) {
+  if (running_.load(std::memory_order_acquire)) {
+    return SessionGraphError::InternalError;
+  }
+  if (!initialized_) {
+    return SessionGraphError::NotReady;
+  }
+  if (callback == nullptr) {
     return SessionGraphError::InvalidParameter;
   }
 
-  if (m_running.load(std::memory_order_acquire)) {
-    return SessionGraphError::InternalError; // Already running
+  callback_ = callback;
+  should_stop_.store(false, std::memory_order_release);
+  running_.store(true, std::memory_order_release);
+  try {
+    audio_thread_ = std::thread(&DummyAudioDriver::audioThreadMain, this);
+  } catch (...) {
+    running_.store(false, std::memory_order_release);
+    callback_ = nullptr;
+    return SessionGraphError::InternalError;
   }
-
-  // Check if initialized by verifying buffers are allocated
-  if (m_output_ptrs.empty()) {
-    return SessionGraphError::NotReady; // Must call initialize first
-  }
-
-  m_callback = callback;
-  m_should_stop.store(false, std::memory_order_release);
-  m_running.store(true, std::memory_order_release);
-
-  // Start audio thread
-  m_audio_thread = std::thread(&DummyAudioDriver::audioThreadMain, this);
-
   return SessionGraphError::OK;
 }
 
 SessionGraphError DummyAudioDriver::stop() {
-  {
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    if (!m_running.load(std::memory_order_acquire)) {
-      return SessionGraphError::OK; // Already stopped
-    }
-
-    m_should_stop.store(true, std::memory_order_release);
+  should_stop_.store(true, std::memory_order_release);
+  if (audio_thread_.joinable()) {
+    audio_thread_.join();
   }
-
-  // Wait for audio thread to finish (outside of lock to avoid deadlock)
-  if (m_audio_thread.joinable()) {
-    m_audio_thread.join();
-  }
-
-  m_running.store(false, std::memory_order_release);
-  m_callback = nullptr;
-
+  std::lock_guard<std::mutex> lock(mutex_);
+  running_.store(false, std::memory_order_release);
+  callback_ = nullptr;
   return SessionGraphError::OK;
 }
 
 bool DummyAudioDriver::isRunning() const {
-  return m_running.load(std::memory_order_acquire);
+  return running_.load(std::memory_order_acquire);
 }
 
 const AudioDriverConfig& DummyAudioDriver::getConfig() const {
-  return m_config;
+  return config_;
 }
 
 std::string DummyAudioDriver::getDriverName() const {
@@ -110,86 +90,77 @@ std::string DummyAudioDriver::getDriverName() const {
 }
 
 uint32_t DummyAudioDriver::getLatencySamples() const {
-  // Dummy driver reports buffer size as latency
-  return m_config.buffer_size;
+  return config_.buffer_size;
 }
 
 AudioDriverCapabilities DummyAudioDriver::getCapabilities() const {
   AudioDriverCapabilities caps;
   caps.backend = AudioBackend::Dummy;
   caps.platform = AudioPlatform::Unknown;
-  caps.min_output_channels = m_config.num_outputs == 0 ? 0 : 1;
-  caps.max_output_channels = m_config.num_outputs;
+  caps.min_output_channels = config_.num_outputs == 0 ? 0 : 1;
+  caps.max_output_channels = config_.num_outputs;
   caps.min_input_channels = 0;
-  caps.max_input_channels = m_config.num_inputs;
-  caps.native_sample_rates.push_back(m_config.sample_rate);
-  caps.native_buffer_sizes.push_back(m_config.buffer_size);
-  const std::string input_endpoint =
-      m_config.input_device_id.empty() ? "dummy:default" : m_config.input_device_id;
-  const std::string output_endpoint =
-      m_config.output_device_id.empty() ? "dummy:default" : m_config.output_device_id;
-  for (uint16_t channel = 0; channel < m_config.num_inputs; ++channel) {
-    caps.input_channel_ids.push_back(input_endpoint + ":input:" + std::to_string(channel));
-  }
-  for (uint16_t channel = 0; channel < m_config.num_outputs; ++channel) {
-    caps.output_channel_ids.push_back(output_endpoint + ":output:" + std::to_string(channel));
-  }
-  caps.supports_exclusive_mode = false;
+  caps.max_input_channels = config_.num_inputs;
+  caps.native_sample_rates.push_back(config_.sample_rate);
+  caps.native_buffer_sizes.push_back(config_.buffer_size);
   caps.supports_shared_mode = true;
+  caps.supports_input = config_.num_inputs > 0;
+  caps.supports_multichannel_output = config_.num_outputs > 2;
   caps.supports_device_hot_swap = false;
-  caps.supports_input = m_config.num_inputs > 0;
-  caps.supports_multichannel_output = m_config.num_outputs > 2;
   caps.reports_hardware_latency = false;
   return caps;
 }
 
+ActiveAudioRoute DummyAudioDriver::getActiveRoute() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return active_route_;
+}
+
+AudioIoTelemetry DummyAudioDriver::getTelemetry() const noexcept {
+  return {input_render_failures_.load(std::memory_order_acquire),
+          AudioDriverRuntimeOutcome::Healthy, AudioRouteRuntimeOutcome::Healthy};
+}
+
 void DummyAudioDriver::audioThreadMain() {
-  // Calculate sleep time to simulate real-time audio processing
-  // Sleep for slightly less than buffer duration to avoid drift
-  const double buffer_duration_sec =
-      static_cast<double>(m_config.buffer_size) / static_cast<double>(m_config.sample_rate);
-  const auto sleep_duration = std::chrono::microseconds(
-      static_cast<int64_t>(buffer_duration_sec * 1e6 * 0.95) // 95% to account for jitter
-  );
-
+  const auto buffer_duration = std::chrono::duration<double>(
+      static_cast<double>(config_.buffer_size) / static_cast<double>(config_.sample_rate));
+  const auto sleep_duration =
+      std::chrono::duration_cast<std::chrono::microseconds>(buffer_duration * 0.95);
   uint64_t stream_position = 0;
-  bool discontinuity = true;
 
-  while (!m_should_stop.load(std::memory_order_acquire)) {
-    // Clear input buffers (simulate silence from input device)
-    for (auto& buffer : m_input_buffer_storage) {
-      std::memset(buffer.data(), 0, buffer.size() * sizeof(float));
+  while (!should_stop_.load(std::memory_order_acquire)) {
+    const auto block_started = std::chrono::steady_clock::now();
+    IAudioCallback* callback = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      callback = callback_;
+    }
+    if (callback == nullptr) {
+      break;
     }
 
-    // Clear output buffers
-    for (auto& buffer : m_output_buffer_storage) {
-      std::memset(buffer.data(), 0, buffer.size() * sizeof(float));
+    for (auto& buffer : output_buffer_storage_) {
+      std::fill(buffer.begin(), buffer.end(), 0.0f);
     }
 
-    // Call audio callback (with safety check for shutdown race)
-    if (m_callback && m_running.load(std::memory_order_acquire)) {
-      const auto now = std::chrono::steady_clock::now().time_since_epoch();
-      AudioProcessBlock block;
-      block.input_buffers = m_config.num_inputs > 0 ? m_input_ptrs.data() : nullptr;
-      block.output_buffers = m_output_ptrs.data();
-      block.num_input_channels = m_config.num_inputs;
-      block.num_output_channels = m_config.num_outputs;
-      block.num_frames = m_config.buffer_size;
-      block.device_sample_position = stream_position;
-      block.host_time_nanoseconds =
-          static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-      block.discontinuity = discontinuity;
-      m_callback->processAudio(block);
-      stream_position += m_config.buffer_size;
-      discontinuity = false;
-    }
+    AudioProcessBlock block;
+    block.input_buffers = input_ptrs_.empty() ? nullptr : input_ptrs_.data();
+    block.output_buffers = output_ptrs_.empty() ? nullptr : output_ptrs_.data();
+    block.num_input_channels = config_.num_inputs;
+    block.num_output_channels = config_.num_outputs;
+    block.num_frames = config_.buffer_size;
+    block.device_sample_position = stream_position;
+    block.host_time_nanoseconds = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(block_started.time_since_epoch())
+            .count());
+    block.discontinuity = false;
+    callback->processAudio(block);
+    stream_position += config_.buffer_size;
 
-    // Sleep to simulate real-time constraints
     std::this_thread::sleep_for(sleep_duration);
   }
 }
 
-// Factory function
 std::unique_ptr<IAudioDriver> createDummyAudioDriver() {
   return std::make_unique<DummyAudioDriver>();
 }

--- a/src/core/audio_io/dummy_audio_driver.h
+++ b/src/core/audio_io/dummy_audio_driver.h
@@ -10,14 +10,13 @@
 
 namespace orpheus {
 
-/// Dummy audio driver for testing
-/// Simulates real audio hardware by calling the callback on a separate thread
+/// Dummy audio driver for testing.
+/// Simulates real audio hardware by calling the callback on a separate thread.
 class DummyAudioDriver : public IAudioDriver {
 public:
   DummyAudioDriver();
   ~DummyAudioDriver() override;
 
-  // IAudioDriver interface
   SessionGraphError initialize(const AudioDriverConfig& config) override;
   SessionGraphError start(IAudioCallback* callback) override;
   SessionGraphError stop() override;
@@ -26,24 +25,27 @@ public:
   std::string getDriverName() const override;
   uint32_t getLatencySamples() const override;
   AudioDriverCapabilities getCapabilities() const override;
+  ActiveAudioRoute getActiveRoute() const override;
+  AudioIoTelemetry getTelemetry() const noexcept override;
 
 private:
   void audioThreadMain();
 
-  AudioDriverConfig m_config;
-  IAudioCallback* m_callback{nullptr};
+  AudioDriverConfig config_;
+  bool initialized_{false};
+  IAudioCallback* callback_{nullptr};
+  std::atomic<bool> running_{false};
+  std::atomic<bool> should_stop_{false};
+  std::atomic<uint64_t> input_render_failures_{0};
+  std::thread audio_thread_;
 
-  std::atomic<bool> m_running{false};
-  std::atomic<bool> m_should_stop{false};
-  std::thread m_audio_thread;
+  std::vector<std::vector<float>> input_buffer_storage_;
+  std::vector<std::vector<float>> output_buffer_storage_;
+  std::vector<const float*> input_ptrs_;
+  std::vector<float*> output_ptrs_;
 
-  // Pre-allocated buffers (to avoid allocations in audio thread)
-  std::vector<std::vector<float>> m_input_buffer_storage;
-  std::vector<std::vector<float>> m_output_buffer_storage;
-  std::vector<const float*> m_input_ptrs;
-  std::vector<float*> m_output_ptrs;
-
-  mutable std::mutex m_mutex;
+  ActiveAudioRoute active_route_;
+  mutable std::mutex mutex_;
 };
 
 } // namespace orpheus

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -78,6 +78,7 @@ if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
     add_library(orpheus_audio_driver_coreaudio STATIC
         coreaudio/coreaudio_driver.cpp
         coreaudio/coreaudio_sample_rate_monitor.cpp
+        coreaudio/coreaudio_route_monitor.cpp
     )
 
     target_include_directories(orpheus_audio_driver_coreaudio

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -12,14 +12,140 @@
 
 namespace orpheus {
 
+namespace {
+
+std::optional<UInt32> getOptionalUInt32Property(AudioDeviceID device_id,
+                                                AudioObjectPropertySelector selector,
+                                                AudioObjectPropertyScope scope);
+std::optional<Float64> getOptionalFloat64Property(AudioDeviceID device_id,
+                                                  AudioObjectPropertySelector selector,
+                                                  AudioObjectPropertyScope scope);
+std::optional<UInt32> getOptionalStreamLatency(AudioDeviceID device_id,
+                                               AudioObjectPropertyScope scope);
+
+CFStringRef copyDeviceUID(AudioDeviceID device_id) {
+  AudioObjectPropertyAddress property_address = {kAudioDevicePropertyDeviceUID,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMain};
+  CFStringRef uid = nullptr;
+  UInt32 data_size = sizeof(CFStringRef);
+  const OSStatus status =
+      AudioObjectGetPropertyData(device_id, &property_address, 0, nullptr, &data_size, &uid);
+  return status == noErr ? uid : nullptr;
+}
+
+UInt32 getClockDomain(AudioDeviceID device_id) {
+  AudioObjectPropertyAddress property_address = {kAudioDevicePropertyClockDomain,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMain};
+  UInt32 domain = 0;
+  UInt32 data_size = sizeof(domain);
+  AudioObjectGetPropertyData(device_id, &property_address, 0, nullptr, &data_size, &domain);
+  return domain;
+}
+
+UInt32 getUInt32Property(AudioDeviceID device_id, AudioObjectPropertySelector selector,
+                         AudioObjectPropertyScope scope) {
+  if (device_id == 0) {
+    return 0;
+  }
+  AudioObjectPropertyAddress address = {selector, scope, kAudioObjectPropertyElementMain};
+  UInt32 value = 0;
+  UInt32 size = sizeof(value);
+  return AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) == noErr ? value
+                                                                                             : 0;
+}
+
+std::optional<UInt32> getOptionalUInt32Property(AudioDeviceID device_id,
+                                                AudioObjectPropertySelector selector,
+                                                AudioObjectPropertyScope scope) {
+  if (device_id == 0) {
+    return std::nullopt;
+  }
+  AudioObjectPropertyAddress address = {selector, scope, kAudioObjectPropertyElementMain};
+  UInt32 value = 0;
+  UInt32 size = sizeof(value);
+  if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) != noErr ||
+      size != sizeof(value)) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+std::optional<Float64> getOptionalFloat64Property(AudioDeviceID device_id,
+                                                  AudioObjectPropertySelector selector,
+                                                  AudioObjectPropertyScope scope) {
+  if (device_id == 0) {
+    return std::nullopt;
+  }
+  AudioObjectPropertyAddress address = {selector, scope, kAudioObjectPropertyElementMain};
+  Float64 value = 0.0;
+  UInt32 size = sizeof(value);
+  if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) != noErr ||
+      size != sizeof(value)) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+std::optional<UInt32> getOptionalStreamLatency(AudioDeviceID device_id,
+                                               AudioObjectPropertyScope scope) {
+  AudioObjectPropertyAddress streams_address = {kAudioDevicePropertyStreams, scope,
+                                                kAudioObjectPropertyElementMain};
+  UInt32 size = 0;
+  if (AudioObjectGetPropertyDataSize(device_id, &streams_address, 0, nullptr, &size) != noErr ||
+      size == 0) {
+    return std::nullopt;
+  }
+
+  std::vector<AudioStreamID> streams(size / sizeof(AudioStreamID));
+  if (streams.empty() || AudioObjectGetPropertyData(device_id, &streams_address, 0, nullptr, &size,
+                                                    streams.data()) != noErr) {
+    return std::nullopt;
+  }
+
+  UInt32 latency = 0;
+  bool observed = false;
+  for (const AudioStreamID stream : streams) {
+    AudioObjectPropertyAddress address = {kAudioStreamPropertyLatency,
+                                          kAudioObjectPropertyScopeGlobal,
+                                          kAudioObjectPropertyElementMain};
+    UInt32 stream_latency = 0;
+    UInt32 data_size = sizeof(stream_latency);
+    if (AudioObjectGetPropertyData(stream, &address, 0, nullptr, &data_size, &stream_latency) ==
+            noErr &&
+        data_size == sizeof(stream_latency)) {
+      latency = std::max(latency, stream_latency);
+      observed = true;
+    }
+  }
+  return observed ? std::optional<UInt32>(latency) : std::nullopt;
+}
+
+bool addLatencyTerm(const std::optional<UInt32>& term, uint32_t& total) {
+  if (!term.has_value()) {
+    return false;
+  }
+  const uint64_t sum = static_cast<uint64_t>(total) + *term;
+  total = static_cast<uint32_t>(std::min<uint64_t>(sum, std::numeric_limits<uint32_t>::max()));
+  return true;
+}
+
+} // namespace
+
 CoreAudioDriver::CoreAudioDriver() = default;
 
 CoreAudioDriver::~CoreAudioDriver() {
   stop();
+  stopRouteMonitor();
   cleanupAudioUnit();
 }
 
 SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
+  if (config.sample_rate == 0 || config.buffer_size == 0 || config.num_outputs == 0) {
+    return SessionGraphError::InvalidParameter;
+  }
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (is_running_.load(std::memory_order_acquire)) {
@@ -27,132 +153,149 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     }
   }
 
-  // A previous terminal runtime outcome leaves a joined-but-still-owned
-  // monitor. Tear it down before replacing the route.
-  stopSampleRateMonitor();
+  stopRouteMonitor();
 
   std::lock_guard<std::mutex> lock(mutex_);
   if (is_running_.load(std::memory_order_acquire)) {
     return SessionGraphError::NotReady;
   }
 
-  // Validate configuration
-  if (config.sample_rate == 0 || config.buffer_size == 0 || config.num_outputs == 0) {
-    return SessionGraphError::InvalidParameter;
-  }
-
-  // Clean up any existing AudioUnit
   cleanupAudioUnit();
-
   config_ = config;
+  input_channel_map_.clear();
+  output_channel_map_.clear();
+  active_route_ = {};
   expected_stream_sample_ = 0;
   stream_timeline_initialized_ = false;
-  input_storage_.clear();
-  input_buffers_.clear();
-  input_abl_storage_.clear();
+  runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+  route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
 
-  // Resolve both requested directions before creating the AudioUnit. A
-  // non-empty directional ID is a persistent HAL DeviceUID; resolution errors
-  // are terminal and must never silently select a default endpoint.
   device_id_ = resolveInputOutputDevice();
-  if (device_id_ == 0) {
+  if (device_id_ == 0 || !resolveChannelMaps(config)) {
+    route_outcome_.store(device_id_ == 0 ? AudioRouteRuntimeOutcome::RouteUnavailable
+                                         : AudioRouteRuntimeOutcome::ReinitializationRequired,
+                         std::memory_order_release);
+    cleanupAudioUnit();
     return SessionGraphError::InvalidParameter;
   }
 
-  // Set up AudioUnit
-  SessionGraphError result = setupAudioUnit(device_id_);
-  if (result != SessionGraphError::OK) {
-    cleanupAudioUnit();
-    return result;
-  }
-  createSampleRateMonitor();
-
-  // Pre-allocate audio buffers (no allocations in audio callback)
-  uint32_t num_outputs = config_.num_outputs;
-  uint32_t buffer_size = config_.buffer_size;
-
-  output_storage_.resize(num_outputs * buffer_size);
-  output_buffers_.resize(num_outputs);
-  for (uint32_t ch = 0; ch < num_outputs; ++ch) {
-    output_buffers_[ch] = &output_storage_[ch * buffer_size];
-  }
-
-  // Input buffers (if needed)
-  if (config_.num_inputs > 0) {
-    input_storage_.resize(config_.num_inputs * buffer_size);
+  try {
+    input_storage_.assign(static_cast<size_t>(config_.num_inputs) * config_.buffer_size, 0.0f);
+    output_storage_.assign(static_cast<size_t>(config_.num_outputs) * config_.buffer_size, 0.0f);
     input_buffers_.resize(config_.num_inputs);
-    for (uint32_t ch = 0; ch < config_.num_inputs; ++ch) {
-      input_buffers_[ch] = &input_storage_[ch * buffer_size];
+    output_buffers_.resize(config_.num_outputs);
+    for (uint16_t channel = 0; channel < config_.num_inputs; ++channel) {
+      input_buffers_[channel] =
+          input_storage_.data() + static_cast<size_t>(channel) * config_.buffer_size;
     }
+    for (uint16_t channel = 0; channel < config_.num_outputs; ++channel) {
+      output_buffers_[channel] =
+          output_storage_.data() + static_cast<size_t>(channel) * config_.buffer_size;
+    }
+    if (config_.num_inputs > 0) {
+      const size_t buffer_list_size =
+          sizeof(AudioBufferList) +
+          static_cast<size_t>(config_.num_inputs - 1) * sizeof(AudioBuffer);
+      input_abl_storage_.resize(buffer_list_size);
+    }
+  } catch (...) {
+    cleanupAudioUnit();
+    return SessionGraphError::InternalError;
+  }
 
-    // Pre-allocate the AudioBufferList used to pull captured input in the
-    // render callback. One AudioBuffer per input channel (planar), so its
-    // trailing flexible array holds num_inputs entries. Allocated here, never
-    // on the audio thread.
-    const size_t abl_bytes =
-        sizeof(AudioBufferList) + (config_.num_inputs - 1) * sizeof(AudioBuffer);
-    input_abl_storage_.assign(abl_bytes, 0);
+  const SessionGraphError setup_result = setupAudioUnit(device_id_);
+  if (setup_result != SessionGraphError::OK) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    cleanupAudioUnit();
+    return setup_result;
+  }
+
+  if (!createRouteMonitor()) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    cleanupAudioUnit();
+    return SessionGraphError::InternalError;
+  }
+
+  refreshActiveRouteLocked();
+  if (active_route_.output_device_id.empty() || active_route_.actual_sample_rate == 0 ||
+      active_route_.actual_buffer_frames == 0 ||
+      (config_.num_inputs > 0 && active_route_.input_device_id.empty())) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    cleanupAudioUnit();
+    active_route_ = {};
+    return SessionGraphError::InternalError;
+  }
+
+  if (active_route_.actual_sample_rate != config_.sample_rate ||
+      active_route_.actual_buffer_frames != config_.buffer_size) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::ReinitializationRequired,
+                         std::memory_order_release);
+    cleanupAudioUnit();
+    active_route_ = {};
+    return SessionGraphError::InvalidParameter;
   }
 
   input_render_failures_.store(0, std::memory_order_release);
   runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+  route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
   return SessionGraphError::OK;
 }
 
 SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  if (!audio_unit_) {
+  if (!audio_unit_ || !route_monitor_) {
     return SessionGraphError::NotReady;
   }
-
   if (is_running_.load(std::memory_order_acquire)) {
     return SessionGraphError::NotReady;
   }
-
   if (!callback) {
     return SessionGraphError::InvalidParameter;
   }
-
-  // A terminal monitor outcome stops the worker without joining it. Reap that
-  // completed worker before replacing std::thread on a later start().
-  if (sample_rate_monitor_thread_.joinable()) {
-    sample_rate_monitor_thread_.join();
+  if (route_outcome_.load(std::memory_order_acquire) != AudioRouteRuntimeOutcome::Healthy) {
+    return SessionGraphError::NotReady;
   }
 
-  // Listener registration and the initial rate verification happen before the
-  // AU is started. A device that already rejects the requested rate therefore
-  // never reaches processAudio() with a mismatched stream format.
-  if (!startSampleRateMonitorLocked()) {
+  if (route_monitor_thread_.joinable()) {
+    route_monitor_thread_.join();
+  }
+
+  if (!startRouteMonitorLocked()) {
+    route_monitor_->stop();
     return SessionGraphError::InternalError;
   }
 
   callback_target_.replaceAndDrain(callback);
-  // Every successful start opens a new callback-admission epoch.
   expected_stream_sample_ = 0;
   stream_timeline_initialized_ = false;
   is_running_.store(true, std::memory_order_release);
 
-  OSStatus status = AudioOutputUnitStart(audio_unit_);
+  const OSStatus status = AudioOutputUnitStart(audio_unit_);
   if (status != noErr) {
     is_running_.store(false, std::memory_order_release);
     callback_target_.replaceAndDrain(nullptr);
-    sample_rate_monitor_->stop();
+    route_monitor_->stop();
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
     return SessionGraphError::InternalError;
   }
 
-  sample_rate_monitor_active_.store(true, std::memory_order_release);
+  route_monitor_active_.store(true, std::memory_order_release);
   try {
-    sample_rate_monitor_thread_ = std::thread(&CoreAudioDriver::sampleRateMonitorLoop, this);
+    route_monitor_thread_ = std::thread(&CoreAudioDriver::routeMonitorLoop, this);
   } catch (...) {
-    sample_rate_monitor_active_.store(false, std::memory_order_release);
+    route_monitor_active_.store(false, std::memory_order_release);
     AudioOutputUnitStop(audio_unit_);
     callback_target_.replaceAndDrain(nullptr);
     is_running_.store(false, std::memory_order_release);
-    sample_rate_monitor_->stop();
+    route_monitor_->stop();
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
     return SessionGraphError::InternalError;
   }
 
+  route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
   return SessionGraphError::OK;
 }
 
@@ -161,7 +304,7 @@ SessionGraphError CoreAudioDriver::stop() {
     std::lock_guard<std::mutex> lock(mutex_);
     stopRenderingLocked();
   }
-  stopSampleRateMonitor();
+  stopRouteMonitor();
   return SessionGraphError::OK;
 }
 
@@ -179,15 +322,18 @@ std::string CoreAudioDriver::getDriverName() const {
 
 uint32_t CoreAudioDriver::getLatencySamples() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  // Query the physical routes, not the private aggregate wrapper. Consumer
-  // outputs (Bluetooth/AirPods in particular) report their transport delay on
-  // the output sub-device, and that report can change while a route is active.
   return queryDeviceLatency();
 }
 
 AudioIoTelemetry CoreAudioDriver::getTelemetry() const noexcept {
   return {input_render_failures_.load(std::memory_order_acquire),
-          runtime_outcome_.load(std::memory_order_acquire)};
+          runtime_outcome_.load(std::memory_order_acquire),
+          route_outcome_.load(std::memory_order_acquire)};
+}
+
+ActiveAudioRoute CoreAudioDriver::getActiveRoute() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return active_route_;
 }
 
 void CoreAudioDriver::setInputRenderFailuresForTesting(uint64_t count) noexcept {
@@ -197,7 +343,6 @@ void CoreAudioDriver::setInputRenderFailuresForTesting(uint64_t count) noexcept 
 void CoreAudioDriver::incrementInputRenderFailuresForTesting() noexcept {
   recordInputRenderFailure();
 }
-
 
 void CoreAudioDriver::recordInputRenderFailure() noexcept {
   detail::publishSaturatingIncrement(input_render_failures_);
@@ -236,7 +381,6 @@ void CoreAudioDriver::setPerformanceMonitor(IPerformanceMonitor* monitor) {
   performance_monitor_target_.replaceAndDrain(monitor);
 }
 
-// Static audio callback
 OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
                                          const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber,
                                          UInt32 inNumberFrames, AudioBufferList* ioData) {
@@ -245,8 +389,6 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   auto* driver = static_cast<CoreAudioDriver*>(inRefCon);
   assert(driver != nullptr);
 
-  // Zero output buffers before trying admission so a callback that races stop()
-  // always returns silence without reading any driver-owned callback state.
   for (UInt32 i = 0; i < ioData->mNumberBuffers; ++i) {
     std::memset(ioData->mBuffers[i].mData, 0, ioData->mBuffers[i].mDataByteSize);
   }
@@ -256,67 +398,42 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     return noErr;
   }
 
-  // Clamp frames to our allocated buffer size
-  uint32_t frames_to_process = std::min(static_cast<uint32_t>(inNumberFrames),
-                                        static_cast<uint32_t>(driver->config_.buffer_size));
-  uint32_t num_channels = driver->config_.num_outputs;
-
-  // Zero our output buffers before callback
-  for (uint32_t ch = 0; ch < num_channels; ++ch) {
-    std::memset(driver->output_buffers_[ch], 0, frames_to_process * sizeof(float));
+  const uint32_t frames_to_process = std::min(static_cast<uint32_t>(inNumberFrames),
+                                              static_cast<uint32_t>(driver->config_.buffer_size));
+  const uint32_t num_output_channels = driver->config_.num_outputs;
+  for (uint32_t channel = 0; channel < num_output_channels; ++channel) {
+    std::memset(driver->output_buffers_[channel], 0, frames_to_process * sizeof(float));
   }
 
-  // Zero our input buffers before capture so a failed/absent AudioUnitRender
-  // hands the host silence rather than stale samples.
   const uint32_t num_input_channels = driver->config_.num_inputs;
-  for (uint32_t ch = 0; ch < num_input_channels; ++ch) {
-    std::memset(driver->input_buffers_[ch], 0, frames_to_process * sizeof(float));
+  for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
+    std::memset(driver->input_buffers_[channel], 0, frames_to_process * sizeof(float));
   }
 
-  // CRITICAL: Check if we're still running before invoking callback
-  // This prevents use-after-free if callback is invoked during/after stop()
   if (!driver->is_running_.load(std::memory_order_acquire)) {
-    return noErr; // Driver is stopping, output silence
+    return noErr;
   }
-
-  // A nominal-rate notification closes this gate before the control worker
-  // touches CoreAudio. Never hand a host processAudio() a block whose AU
-  // format may no longer match the hardware clock.
-  if (!driver->sample_rate_monitor_ || !driver->sample_rate_monitor_->permitsRendering()) {
+  if (!driver->route_monitor_ || !driver->route_monitor_->permitsRendering()) {
     return noErr;
   }
 
   IAudioCallback* callback = callback_lease.get();
-
-  // Pull captured input (bus 1) into our planar input_buffers_ before invoking
-  // the host callback. A HAL output render callback fires for the *output* bus
-  // and must explicitly render the input bus; captured samples never arrive in
-  // ioData. RT-safe: the AudioBufferList and its backing storage are
-  // pre-allocated in initialize(); no allocation, lock, or I/O on this path.
   if (num_input_channels > 0 && !driver->input_abl_storage_.empty()) {
-    auto* inputABL = reinterpret_cast<AudioBufferList*>(driver->input_abl_storage_.data());
-    inputABL->mNumberBuffers = num_input_channels;
-    for (uint32_t ch = 0; ch < num_input_channels; ++ch) {
-      inputABL->mBuffers[ch].mNumberChannels = 1; // planar: one channel per buffer
-      inputABL->mBuffers[ch].mDataByteSize = frames_to_process * sizeof(float);
-      inputABL->mBuffers[ch].mData = driver->input_buffers_[ch];
+    auto* input_abl = reinterpret_cast<AudioBufferList*>(driver->input_abl_storage_.data());
+    input_abl->mNumberBuffers = num_input_channels;
+    for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
+      input_abl->mBuffers[channel].mNumberChannels = 1;
+      input_abl->mBuffers[channel].mDataByteSize = frames_to_process * sizeof(float);
+      input_abl->mBuffers[channel].mData = driver->input_buffers_[channel];
     }
 
-    // inputBus = 1. On failure the pre-zeroed buffers stand in as silence, so
-    // we never propagate a hard error up the audio graph for a transient
-    // miss -- but a persistent failure (e.g. capturing against a device with
-    // no input channels) is exactly what left this class of bug invisible;
-    // count it (lock-free, RT-safe) so a host or test can tell "always
-    // silent" apart from "never actually captured."
-    OSStatus render_status = AudioUnitRender(driver->audio_unit_, ioActionFlags, inTimeStamp,
-                                             /*inputBus=*/1, frames_to_process, inputABL);
+    const OSStatus render_status = AudioUnitRender(driver->audio_unit_, ioActionFlags, inTimeStamp,
+                                                   /*inputBus=*/1, frames_to_process, input_abl);
     if (render_status != noErr) {
       driver->recordInputRenderFailure();
     }
   }
 
-  // Invoke user callback (lock-free). Timing is opt-in for diagnostics builds;
-  // production callbacks should not pay for callback-duration instrumentation.
   const float** input_ptrs = driver->input_buffers_.empty()
                                  ? nullptr
                                  : const_cast<const float**>(driver->input_buffers_.data());
@@ -338,7 +455,7 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   block.input_buffers = input_ptrs;
   block.output_buffers = output_ptrs;
   block.num_input_channels = static_cast<uint16_t>(num_input_channels);
-  block.num_output_channels = static_cast<uint16_t>(num_channels);
+  block.num_output_channels = static_cast<uint16_t>(num_output_channels);
   block.num_frames = frames_to_process;
   block.device_sample_position =
       device_position_available ? static_cast<uint64_t>(reported_sample_time) : 0;
@@ -346,18 +463,14 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
       host_time_valid ? AudioConvertHostTimeToNanos(inTimeStamp->mHostTime) : 0;
   block.discontinuity = discontinuity;
 
-#if defined(ORPHEUS_ENABLE_AUDIO_CALLBACK_TIMING)
   auto monitor_lease = driver->performance_monitor_target_.tryAcquire();
-  const UInt64 callback_start =
-      monitor_lease ? AudioGetCurrentHostTime() : UInt64{0};
-#endif
+  const UInt64 callback_start = monitor_lease ? AudioGetCurrentHostTime() : UInt64{0};
   callback->processAudio(block);
   driver->expected_stream_sample_ = stream_time + frames_to_process;
   driver->stream_timeline_initialized_ = true;
-#if defined(ORPHEUS_ENABLE_AUDIO_CALLBACK_TIMING)
   if (auto* monitor = monitor_lease.get()) {
     const UInt64 callback_end = AudioGetCurrentHostTime();
-    const UInt64 duration_ns = AudioConvertHostTimeToNanos(callback_end - callback_start);
+    const uint64_t duration_ns = AudioConvertHostTimeToNanos(callback_end - callback_start);
     const uint64_t callback_duration_us = static_cast<uint64_t>(duration_ns / 1000u);
     const uint64_t buffer_duration_us =
         (static_cast<uint64_t>(frames_to_process) * 1'000'000ull) / driver->config_.sample_rate;
@@ -365,13 +478,11 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     monitor->recordAudioCallback(callback_duration_us, buffer_duration_us, active_clips,
                                  driver->config_.sample_rate, frames_to_process);
   }
-#endif
 
-  // Copy planar output buffers to CoreAudio non-interleaved buffers
-  for (uint32_t ch = 0; ch < num_channels && ch < ioData->mNumberBuffers; ++ch) {
-    float* src = driver->output_buffers_[ch];
-    auto* dst = static_cast<float*>(ioData->mBuffers[ch].mData);
-    std::memcpy(dst, src, frames_to_process * sizeof(float));
+  for (uint32_t channel = 0; channel < num_output_channels && channel < ioData->mNumberBuffers;
+       ++channel) {
+    std::memcpy(ioData->mBuffers[channel].mData, driver->output_buffers_[channel],
+                frames_to_process * sizeof(float));
   }
 
   return noErr;
@@ -379,137 +490,33 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
 
 std::vector<AudioDeviceID> CoreAudioDriver::enumerateDevices() {
   std::vector<AudioDeviceID> devices;
-
-  AudioObjectPropertyAddress propertyAddress = {kAudioHardwarePropertyDevices,
-                                                kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMain};
-
-  UInt32 dataSize = 0;
-  OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0,
-                                                   nullptr, &dataSize);
-
-  if (status != noErr || dataSize == 0) {
+  AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
+                                        kAudioObjectPropertyScopeGlobal,
+                                        kAudioObjectPropertyElementMain};
+  UInt32 data_size = 0;
+  if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &address, 0, nullptr, &data_size) !=
+          noErr ||
+      data_size == 0) {
     return devices;
   }
 
-  UInt32 deviceCount = dataSize / sizeof(AudioDeviceID);
-  devices.resize(deviceCount);
-
-  status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr,
-                                      &dataSize, devices.data());
-
-  if (status != noErr) {
+  devices.resize(data_size / sizeof(AudioDeviceID));
+  if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr, &data_size,
+                                 devices.data()) != noErr) {
     devices.clear();
   }
-
   return devices;
 }
 
 AudioDeviceID CoreAudioDriver::getDefaultDevice(AudioObjectPropertySelector selector) {
-  AudioObjectPropertyAddress propertyAddress = {selector, kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMain};
-
-  AudioDeviceID deviceID = 0;
-  UInt32 dataSize = sizeof(AudioDeviceID);
-
-  OSStatus status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0,
-                                               nullptr, &dataSize, &deviceID);
-
-  return (status == noErr && deviceID != kAudioObjectUnknown) ? deviceID : 0;
-}
-
-namespace {
-
-/// Copy a device's persistent UID string (caller releases). Used to describe
-/// sub-devices to AudioHardwareCreateAggregateDevice, which identifies them
-/// by UID rather than the (session-scoped) AudioDeviceID.
-CFStringRef copyDeviceUID(AudioDeviceID device_id) {
-  AudioObjectPropertyAddress propertyAddress = {kAudioDevicePropertyDeviceUID,
-                                                kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMain};
-  CFStringRef uid = nullptr;
-  UInt32 dataSize = sizeof(CFStringRef);
-  OSStatus status =
-      AudioObjectGetPropertyData(device_id, &propertyAddress, 0, nullptr, &dataSize, &uid);
-  return (status == noErr) ? uid : nullptr;
-}
-
-/// Query a device's clock domain. Devices sharing a non-zero domain are
-/// synchronized to the same underlying hardware clock (e.g. a MacBook's
-/// built-in microphone and built-in speakers both run off the machine's
-/// single audio clock) -- 0 or a mismatch means the OS cannot prove they
-/// share a clock and drift compensation is genuinely needed to bridge them.
-UInt32 getClockDomain(AudioDeviceID device_id) {
-  AudioObjectPropertyAddress propertyAddress = {kAudioDevicePropertyClockDomain,
-                                                kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMain};
-  UInt32 domain = 0;
-  UInt32 dataSize = sizeof(UInt32);
-  AudioObjectGetPropertyData(device_id, &propertyAddress, 0, nullptr, &dataSize, &domain);
-  return domain;
-}
-
-UInt32 getUInt32Property(AudioDeviceID device_id, AudioObjectPropertySelector selector,
-                         AudioObjectPropertyScope scope) {
-  if (device_id == 0) {
-    return 0;
-  }
-  AudioObjectPropertyAddress address = {selector, scope, kAudioObjectPropertyElementMain};
-  UInt32 value = 0;
-  UInt32 size = sizeof(value);
-  return AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) == noErr ? value
-                                                                                             : 0;
-}
-
-UInt32 getChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) {
-  if (device_id == 0) {
-    return 0;
-  }
-  AudioObjectPropertyAddress address = {kAudioDevicePropertyStreamConfiguration, scope,
+  AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
                                         kAudioObjectPropertyElementMain};
-  UInt32 size = 0;
-  if (AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &size) != noErr ||
-      size < sizeof(AudioBufferList)) {
-    return 0;
-  }
-
-  std::vector<uint8_t> storage(size);
-  auto* buffers = reinterpret_cast<AudioBufferList*>(storage.data());
-  if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, buffers) != noErr) {
-    return 0;
-  }
-
-  UInt32 channels = 0;
-  for (UInt32 index = 0; index < buffers->mNumberBuffers; ++index) {
-    channels += buffers->mBuffers[index].mNumberChannels;
-  }
-  return channels;
+  AudioDeviceID device_id = 0;
+  UInt32 data_size = sizeof(device_id);
+  const OSStatus status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr,
+                                                     &data_size, &device_id);
+  return status == noErr && device_id != kAudioObjectUnknown ? device_id : 0;
 }
-
-UInt32 getStreamLatency(AudioDeviceID device_id, AudioObjectPropertyScope scope) {
-  AudioObjectPropertyAddress streams_address = {kAudioDevicePropertyStreams, scope,
-                                                kAudioObjectPropertyElementMain};
-  UInt32 size = 0;
-  if (AudioObjectGetPropertyDataSize(device_id, &streams_address, 0, nullptr, &size) != noErr ||
-      size == 0) {
-    return 0;
-  }
-
-  std::vector<AudioStreamID> streams(size / sizeof(AudioStreamID));
-  if (AudioObjectGetPropertyData(device_id, &streams_address, 0, nullptr, &size, streams.data()) !=
-      noErr) {
-    return 0;
-  }
-
-  UInt32 latency = 0;
-  for (AudioStreamID stream : streams) {
-    latency = std::max(latency, getUInt32Property(stream, kAudioStreamPropertyLatency,
-                                                  kAudioObjectPropertyScopeGlobal));
-  }
-  return latency;
-}
-
-} // namespace
 
 AudioDeviceID CoreAudioDriver::findDeviceByUID(const std::string& device_uid) {
   if (device_uid.empty()) {
@@ -524,12 +531,12 @@ AudioDeviceID CoreAudioDriver::findDeviceByUID(const std::string& device_uid) {
 
   AudioDeviceID matched = 0;
   for (const AudioDeviceID candidate : enumerateDevices()) {
-    CFStringRef candidateUID = copyDeviceUID(candidate);
-    if (candidateUID && CFStringCompare(candidateUID, requested, 0) == kCFCompareEqualTo) {
+    CFStringRef candidate_uid = copyDeviceUID(candidate);
+    if (candidate_uid && CFStringCompare(candidate_uid, requested, 0) == kCFCompareEqualTo) {
       matched = candidate;
     }
-    if (candidateUID) {
-      CFRelease(candidateUID);
+    if (candidate_uid) {
+      CFRelease(candidate_uid);
     }
     if (matched != 0) {
       break;
@@ -544,12 +551,42 @@ bool CoreAudioDriver::supportsDirection(AudioDeviceID device_id,
   return getChannelCount(device_id, scope) > 0;
 }
 
+uint32_t CoreAudioDriver::getChannelCount(AudioDeviceID device_id,
+                                          AudioObjectPropertyScope scope) const {
+  if (device_id == 0) {
+    return 0;
+  }
+
+  AudioObjectPropertyAddress address = {kAudioDevicePropertyStreamConfiguration, scope,
+                                        kAudioObjectPropertyElementMain};
+  UInt32 data_size = 0;
+  if (AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &data_size) != noErr ||
+      data_size < sizeof(AudioBufferList)) {
+    return 0;
+  }
+
+  std::vector<uint8_t> storage(data_size);
+  auto* buffers = reinterpret_cast<AudioBufferList*>(storage.data());
+  if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, buffers) != noErr) {
+    return 0;
+  }
+
+  uint32_t channels = 0;
+  for (UInt32 index = 0; index < buffers->mNumberBuffers; ++index) {
+    channels += buffers->mBuffers[index].mNumberChannels;
+  }
+  return channels;
+}
+
 AudioDeviceID CoreAudioDriver::resolveInputOutputDevice() {
   input_channel_offset_ = 0;
-  const AudioDeviceID outputID = config_.output_device_id.empty()
-                                     ? getDefaultDevice(kAudioHardwarePropertyDefaultOutputDevice)
-                                     : findDeviceByUID(config_.output_device_id);
-  if (outputID == 0 || !supportsDirection(outputID, kAudioObjectPropertyScopeOutput)) {
+  available_input_channels_ = 0;
+  available_output_channels_ = 0;
+
+  const AudioDeviceID output_id = config_.output_device_id.empty()
+                                      ? getDefaultDevice(kAudioHardwarePropertyDefaultOutputDevice)
+                                      : findDeviceByUID(config_.output_device_id);
+  if (output_id == 0 || !supportsDirection(output_id, kAudioObjectPropertyScopeOutput)) {
     return 0;
   }
 
@@ -558,420 +595,573 @@ AudioDeviceID CoreAudioDriver::resolveInputOutputDevice() {
       return 0;
     }
     input_device_id_ = 0;
-    output_device_id_ = outputID;
-    return outputID;
+    output_device_id_ = output_id;
+    available_output_channels_ = getChannelCount(output_id, kAudioObjectPropertyScopeOutput);
+    return output_id;
   }
 
-  const AudioDeviceID inputID = config_.input_device_id.empty()
-                                    ? getDefaultDevice(kAudioHardwarePropertyDefaultInputDevice)
-                                    : findDeviceByUID(config_.input_device_id);
-  const UInt32 inputChannelCount = getChannelCount(inputID, kAudioObjectPropertyScopeInput);
-  if (inputID == 0 || inputChannelCount < config_.num_inputs) {
+  const AudioDeviceID input_id = config_.input_device_id.empty()
+                                     ? getDefaultDevice(kAudioHardwarePropertyDefaultInputDevice)
+                                     : findDeviceByUID(config_.input_device_id);
+  if (input_id == 0 || !supportsDirection(input_id, kAudioObjectPropertyScopeInput)) {
     return 0;
   }
 
-  input_device_id_ = inputID;
-  output_device_id_ = outputID;
-  if (inputID == outputID) {
-    input_channel_offset_ = 0;
-    return outputID;
+  input_device_id_ = input_id;
+  output_device_id_ = output_id;
+  available_input_channels_ = getChannelCount(input_id, kAudioObjectPropertyScopeInput);
+  available_output_channels_ = getChannelCount(output_id, kAudioObjectPropertyScopeOutput);
+
+  if (input_id == output_id) {
+    return output_id;
   }
 
-  // Aggregate input channels retain sub-device order. A duplex playback
-  // endpoint contributes its capture channels before the dedicated input
-  // endpoint, so map past them rather than silently metering/recording the
-  // playback device's first (often disconnected) input.
-  input_channel_offset_ = getChannelCount(outputID, kAudioObjectPropertyScopeInput);
-  const AudioDeviceID aggregateID = createAggregateDevice(inputID, outputID);
-  if (aggregateID == 0) {
+  input_channel_offset_ = getChannelCount(output_id, kAudioObjectPropertyScopeInput);
+  const AudioDeviceID aggregate_id = createAggregateDevice(input_id, output_id);
+  if (aggregate_id == 0) {
     input_device_id_ = 0;
     output_device_id_ = 0;
+    available_input_channels_ = 0;
+    available_output_channels_ = 0;
     return 0;
   }
-  aggregate_device_id_ = aggregateID;
-  return aggregateID;
+  aggregate_device_id_ = aggregate_id;
+  return aggregate_id;
 }
 
 AudioDeviceID CoreAudioDriver::createAggregateDevice(AudioDeviceID input_device_id,
                                                      AudioDeviceID output_device_id) {
-  CFStringRef inputUID = copyDeviceUID(input_device_id);
-  CFStringRef outputUID = copyDeviceUID(output_device_id);
-  if (!inputUID || !outputUID) {
-    if (inputUID)
-      CFRelease(inputUID);
-    if (outputUID)
-      CFRelease(outputUID);
+  CFStringRef input_uid = copyDeviceUID(input_device_id);
+  CFStringRef output_uid = copyDeviceUID(output_device_id);
+  if (!input_uid || !output_uid) {
+    if (input_uid)
+      CFRelease(input_uid);
+    if (output_uid)
+      CFRelease(output_uid);
     return 0;
   }
 
-  // Drift compensation resamples a non-master sub-device to track the
-  // master's clock -- necessary (and worth its latency cost) when the two
-  // devices run off genuinely independent hardware clocks, but pure
-  // overhead when they don't. Built-in devices on the same Mac (e.g. the
-  // microphone and speakers here) commonly share one hardware clock domain,
-  // in which case forcing compensation on adds real, otherwise-avoidable
-  // capture latency for no correctness benefit. Query it and only enable
-  // compensation on the (non-master) input sub-device when the domains
-  // actually differ.
-  const UInt32 inputClockDomain = getClockDomain(input_device_id);
-  const UInt32 outputClockDomain = getClockDomain(output_device_id);
-  const bool sameClockDomain = inputClockDomain != 0 && inputClockDomain == outputClockDomain;
-  const int driftCompensation = sameClockDomain ? 0 : 1;
+  const UInt32 input_clock_domain = getClockDomain(input_device_id);
+  const UInt32 output_clock_domain = getClockDomain(output_device_id);
+  const bool same_clock_domain =
+      input_clock_domain != 0 && input_clock_domain == output_clock_domain;
+  const int drift_compensation = same_clock_domain ? 0 : 1;
 
-  CFMutableDictionaryRef inputSubDevice = CFDictionaryCreateMutable(
+  CFMutableDictionaryRef input_sub_device = CFDictionaryCreateMutable(
       kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-  CFDictionarySetValue(inputSubDevice, CFSTR(kAudioSubDeviceUIDKey), inputUID);
-  CFNumberRef driftCompensationValue =
-      CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &driftCompensation);
-  CFDictionarySetValue(inputSubDevice, CFSTR(kAudioSubDeviceDriftCompensationKey),
-                       driftCompensationValue);
-  if (!sameClockDomain) {
-    const int maxQuality = kAudioSubDeviceDriftCompensationMaxQuality;
-    CFNumberRef qualityValue = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &maxQuality);
-    CFDictionarySetValue(inputSubDevice, CFSTR(kAudioSubDeviceDriftCompensationQualityKey),
-                         qualityValue);
-    CFRelease(qualityValue);
+  CFDictionarySetValue(input_sub_device, CFSTR(kAudioSubDeviceUIDKey), input_uid);
+  CFNumberRef drift_value =
+      CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &drift_compensation);
+  CFDictionarySetValue(input_sub_device, CFSTR(kAudioSubDeviceDriftCompensationKey), drift_value);
+  if (!same_clock_domain) {
+    const int max_quality = kAudioSubDeviceDriftCompensationMaxQuality;
+    CFNumberRef quality_value = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &max_quality);
+    CFDictionarySetValue(input_sub_device, CFSTR(kAudioSubDeviceDriftCompensationQualityKey),
+                         quality_value);
+    CFRelease(quality_value);
   }
-  CFRelease(driftCompensationValue);
+  CFRelease(drift_value);
 
-  // The master (clock source) sub-device is never compensated against
-  // itself.
-  CFMutableDictionaryRef outputSubDevice = CFDictionaryCreateMutable(
+  CFMutableDictionaryRef output_sub_device = CFDictionaryCreateMutable(
       kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-  CFDictionarySetValue(outputSubDevice, CFSTR(kAudioSubDeviceUIDKey), outputUID);
+  CFDictionarySetValue(output_sub_device, CFSTR(kAudioSubDeviceUIDKey), output_uid);
 
-  CFMutableArrayRef subDeviceList =
+  CFMutableArrayRef sub_device_list =
       CFArrayCreateMutable(kCFAllocatorDefault, 2, &kCFTypeArrayCallBacks);
-  CFArrayAppendValue(subDeviceList, outputSubDevice);
-  CFArrayAppendValue(subDeviceList, inputSubDevice);
+  CFArrayAppendValue(sub_device_list, output_sub_device);
+  CFArrayAppendValue(sub_device_list, input_sub_device);
 
-  // Unique per driver instance so two overlapping CoreAudioDriver instances
-  // (unusual, but not forbidden by this class) never collide on UID.
-  std::ostringstream uidStream;
-  uidStream << "com.orpheus.sdk.aggregate." << static_cast<const void*>(this);
-  CFStringRef aggregateUID = CFStringCreateWithCString(kCFAllocatorDefault, uidStream.str().c_str(),
-                                                       kCFStringEncodingUTF8);
+  std::ostringstream uid_stream;
+  uid_stream << "com.orpheus.sdk.aggregate." << static_cast<const void*>(this);
+  CFStringRef aggregate_uid = CFStringCreateWithCString(
+      kCFAllocatorDefault, uid_stream.str().c_str(), kCFStringEncodingUTF8);
 
-  CFMutableDictionaryRef aggregateDict = CFDictionaryCreateMutable(
+  CFMutableDictionaryRef aggregate_dict = CFDictionaryCreateMutable(
       kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-  // Private + non-stacked: never listed in System Settings -> Sound, and
-  // exists only for this driver instance's lifetime (destroyed in
-  // cleanupAudioUnit() via AudioHardwareDestroyAggregateDevice).
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceNameKey),
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceNameKey),
                        CFSTR("Orpheus SDK I/O Bridge"));
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceUIDKey), aggregateUID);
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceSubDeviceListKey), subDeviceList);
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceMasterSubDeviceKey), outputUID);
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceIsPrivateKey), kCFBooleanTrue);
-  CFDictionarySetValue(aggregateDict, CFSTR(kAudioAggregateDeviceIsStackedKey), kCFBooleanFalse);
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceUIDKey), aggregate_uid);
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceSubDeviceListKey),
+                       sub_device_list);
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceMasterSubDeviceKey), output_uid);
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceIsPrivateKey), kCFBooleanTrue);
+  CFDictionarySetValue(aggregate_dict, CFSTR(kAudioAggregateDeviceIsStackedKey), kCFBooleanFalse);
 
-  AudioDeviceID aggregateID = kAudioObjectUnknown;
-  OSStatus status = AudioHardwareCreateAggregateDevice(aggregateDict, &aggregateID);
+  AudioDeviceID aggregate_id = kAudioObjectUnknown;
+  const OSStatus status = AudioHardwareCreateAggregateDevice(aggregate_dict, &aggregate_id);
 
-  CFRelease(inputSubDevice);
-  CFRelease(outputSubDevice);
-  CFRelease(subDeviceList);
-  CFRelease(aggregateDict);
-  CFRelease(aggregateUID);
-  CFRelease(inputUID);
-  CFRelease(outputUID);
+  CFRelease(input_sub_device);
+  CFRelease(output_sub_device);
+  CFRelease(sub_device_list);
+  CFRelease(aggregate_dict);
+  CFRelease(aggregate_uid);
+  CFRelease(input_uid);
+  CFRelease(output_uid);
 
-  return (status == noErr) ? aggregateID : 0;
+  return status == noErr ? aggregate_id : 0;
 }
 
-uint32_t CoreAudioDriver::queryDeviceLatency() const {
-  uint64_t latency = 0;
+bool CoreAudioDriver::resolveChannelMaps(const AudioDriverConfig& config) {
+  const auto resolve = [](const std::vector<uint16_t>& requested, uint16_t logical_count,
+                          uint32_t physical_count, std::vector<uint16_t>& resolved) {
+    if (requested.empty()) {
+      resolved.resize(logical_count);
+      for (uint16_t channel = 0; channel < logical_count; ++channel) {
+        resolved[channel] = channel;
+      }
+      return true;
+    }
+    if (requested.size() != logical_count) {
+      return false;
+    }
 
-  const auto add_route = [&](AudioDeviceID device_id, AudioObjectPropertyScope scope) {
-    latency += getUInt32Property(device_id, kAudioDevicePropertyLatency, scope);
-    latency += getUInt32Property(device_id, kAudioDevicePropertySafetyOffset, scope);
-    latency += getStreamLatency(device_id, scope);
+    resolved.clear();
+    resolved.reserve(requested.size());
+    for (const uint16_t channel : requested) {
+      if (channel >= physical_count ||
+          std::find(resolved.begin(), resolved.end(), channel) != resolved.end()) {
+        return false;
+      }
+      resolved.push_back(channel);
+    }
+    return true;
   };
 
-  if (config_.num_inputs > 0) {
-    add_route(input_device_id_, kAudioObjectPropertyScopeInput);
-  }
-  if (config_.num_outputs > 0) {
-    add_route(output_device_id_, kAudioObjectPropertyScopeOutput);
-  }
-
-  // CoreAudio's round-trip formula counts the active I/O buffer once. The
-  // requested size is only advisory, so an unavailable readback means latency
-  // is undetected — never substitute an estimate.
-  const UInt32 buffer_frames = getUInt32Property(device_id_, kAudioDevicePropertyBufferFrameSize,
-                                                 kAudioObjectPropertyScopeGlobal);
-  if (buffer_frames == 0) {
-    return 0;
-  }
-  latency += buffer_frames;
-
-  // Includes converters and aggregate-device drift compensation not represented
-  // by the physical endpoint properties.
-  if (audio_unit_ != nullptr) {
-    Float64 seconds = 0.0;
-    UInt32 size = sizeof(seconds);
-    if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
-                             &seconds, &size) == noErr &&
-        seconds > 0.0) {
-      latency +=
-          static_cast<uint64_t>(std::llround(seconds * static_cast<Float64>(config_.sample_rate)));
-    }
-  }
-
-  return static_cast<uint32_t>(std::min<uint64_t>(latency, std::numeric_limits<uint32_t>::max()));
+  return resolve(config.channel_map.input_channels, config.num_inputs, available_input_channels_,
+                 input_channel_map_) &&
+         resolve(config.channel_map.output_channels, config.num_outputs, available_output_channels_,
+                 output_channel_map_);
 }
 
-SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
-  // Create AudioComponentDescription for HAL Output
-  AudioComponentDescription desc = {};
-  desc.componentType = kAudioUnitType_Output;
-  desc.componentSubType = kAudioUnitSubType_HALOutput;
-  desc.componentManufacturer = kAudioUnitManufacturer_Apple;
-  desc.componentFlags = 0;
-  desc.componentFlagsMask = 0;
-
-  // Find AudioComponent
-  AudioComponent component = AudioComponentFindNext(nullptr, &desc);
-  if (!component) {
-    return SessionGraphError::InternalError;
+std::vector<AudioStreamID> CoreAudioDriver::enumerateStreams(AudioDeviceID device_id,
+                                                             AudioObjectPropertyScope scope) const {
+  std::vector<AudioStreamID> streams;
+  if (device_id == 0) {
+    return streams;
   }
-
-  // Create AudioUnit instance
-  OSStatus status = AudioComponentInstanceNew(component, &audio_unit_);
-  if (status != noErr || !audio_unit_) {
-    return SessionGraphError::InternalError;
+  AudioObjectPropertyAddress address = {kAudioDevicePropertyStreams, scope,
+                                        kAudioObjectPropertyElementMain};
+  UInt32 data_size = 0;
+  if (AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &data_size) != noErr ||
+      data_size == 0) {
+    return streams;
   }
-
-  // Enable input IO (bus 1) only when the host asked for capture. Pure-playback
-  // hosts (num_inputs == 0) keep the historical output-only behavior. Bus 1 is
-  // the AudioUnit's input element; kAudioUnitSubType_HALOutput supports both
-  // capture (bus 1) and playback (bus 0) on a single unit.
-  UInt32 enableIO = config_.num_inputs > 0 ? 1 : 0;
-  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_EnableIO,
-                                kAudioUnitScope_Input, 1, &enableIO, sizeof(enableIO));
-
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
+  streams.resize(data_size / sizeof(AudioStreamID));
+  if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, streams.data()) !=
+      noErr) {
+    streams.clear();
   }
-
-  // Enable output
-  enableIO = 1;
-  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_EnableIO,
-                                kAudioUnitScope_Output, 0, &enableIO, sizeof(enableIO));
-
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
-  }
-
-  // Set current device
-  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_CurrentDevice,
-                                kAudioUnitScope_Global, 0, &device_id, sizeof(AudioDeviceID));
-
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
-  }
-
-  // CRITICAL FIX: Set the DEVICE's nominal sample rate to match our requested rate
-  // This must be done BEFORE setting the AudioUnit's stream format
-  Float64 requestedSampleRate = static_cast<Float64>(config_.sample_rate);
-  AudioObjectPropertyAddress deviceSRAddr = {kAudioDevicePropertyNominalSampleRate,
-                                             kAudioObjectPropertyScopeGlobal,
-                                             kAudioObjectPropertyElementMain};
-  status = AudioObjectSetPropertyData(device_id, &deviceSRAddr, 0, nullptr, sizeof(Float64),
-                                      &requestedSampleRate);
-  if (status != noErr) {
-    // Don't fail completely, but this will cause playback speed issues.
-  }
-
-  // Set stream format (planar float32)
-  AudioStreamBasicDescription streamFormat = {};
-  streamFormat.mSampleRate = config_.sample_rate;
-  streamFormat.mFormatID = kAudioFormatLinearPCM;
-  streamFormat.mFormatFlags =
-      kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved;
-  streamFormat.mBytesPerPacket = sizeof(float);
-  streamFormat.mFramesPerPacket = 1;
-  streamFormat.mBytesPerFrame = sizeof(float);
-  streamFormat.mChannelsPerFrame = config_.num_outputs;
-  streamFormat.mBitsPerChannel = 32;
-
-  status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,
-                                0, &streamFormat, sizeof(streamFormat));
-
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
-  }
-
-  // Set the input stream format when capture is enabled. This is the format the
-  // AudioUnit delivers to our AudioUnitRender pull on bus 1, so it goes on
-  // kAudioUnitScope_Output, element 1 (the output side of the input element).
-  // Mirror the output ASBD (planar float32) but with the input channel count so
-  // AudioUnitRender fills our planar input_buffers_ directly, no deinterleave.
-  if (config_.num_inputs > 0) {
-    AudioStreamBasicDescription inputFormat = streamFormat;
-    inputFormat.mChannelsPerFrame = config_.num_inputs;
-
-    status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_StreamFormat,
-                                  kAudioUnitScope_Output, 1, &inputFormat, sizeof(inputFormat));
-
-    if (status != noErr) {
-      return SessionGraphError::InternalError;
-    }
-    std::vector<SInt32> inputChannelMap(config_.num_inputs);
-    for (uint32_t channel = 0; channel < config_.num_inputs; ++channel) {
-      inputChannelMap[channel] = static_cast<SInt32>(input_channel_offset_ + channel);
-    }
-    status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_ChannelMap,
-                                  kAudioUnitScope_Output, 1, inputChannelMap.data(),
-                                  static_cast<UInt32>(inputChannelMap.size() * sizeof(SInt32)));
-    if (status != noErr) {
-      return SessionGraphError::InternalError;
-    }
-  }
-
-  // Set buffer size (if supported)
-  UInt32 bufferFrames = config_.buffer_size;
-  status = AudioUnitSetProperty(audio_unit_, kAudioDevicePropertyBufferFrameSize,
-                                kAudioUnitScope_Global, 0, &bufferFrames, sizeof(bufferFrames));
-
-  // Note: Buffer size setting may fail on some devices, but continue anyway
-
-  // Set render callback
-  AURenderCallbackStruct callbackStruct = {};
-  callbackStruct.inputProc = &CoreAudioDriver::renderCallback;
-  callbackStruct.inputProcRefCon = this;
-
-  status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_SetRenderCallback,
-                                kAudioUnitScope_Input, 0, &callbackStruct, sizeof(callbackStruct));
-
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
-  }
-
-  // Initialize AudioUnit
-  status = AudioUnitInitialize(audio_unit_);
-  if (status != noErr) {
-    return SessionGraphError::InternalError;
-  }
-
-  return SessionGraphError::OK;
+  return streams;
 }
 
-void CoreAudioDriver::createSampleRateMonitor() {
-  std::vector<AudioDeviceID> monitored_devices;
-  monitored_devices.reserve(3);
-  monitored_devices.push_back(device_id_);
-  monitored_devices.push_back(output_device_id_);
-  if (config_.num_inputs > 0) {
-    monitored_devices.push_back(input_device_id_);
+std::optional<AudioStreamBasicDescription>
+CoreAudioDriver::getStreamFormat(AudioStreamID stream_id,
+                                 AudioObjectPropertySelector selector) const {
+  if (stream_id == 0) {
+    return std::nullopt;
   }
-  sample_rate_monitor_ = std::make_unique<CoreAudioSampleRateMonitor>(
-      sample_rate_property_api_, config_.sample_rate, std::move(monitored_devices));
+  AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
+                                        kAudioObjectPropertyElementMain};
+  AudioStreamBasicDescription format{};
+  UInt32 data_size = sizeof(format);
+  if (AudioObjectGetPropertyData(stream_id, &address, 0, nullptr, &data_size, &format) != noErr ||
+      data_size != sizeof(format)) {
+    return std::nullopt;
+  }
+  return format;
 }
 
-bool CoreAudioDriver::startSampleRateMonitorLocked() {
-  std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
-  if (!sample_rate_monitor_ || !sample_rate_monitor_->start()) {
-    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateListenerFailure,
-                           std::memory_order_release);
+bool CoreAudioDriver::createRouteMonitor() {
+  std::vector<AudioDeviceID> device_ids;
+  device_ids.reserve(3);
+  device_ids.push_back(device_id_);
+  device_ids.push_back(output_device_id_);
+  if (config_.num_inputs > 0) {
+    device_ids.push_back(input_device_id_);
+  }
+
+  std::vector<CoreAudioRouteStream> streams;
+  const auto append_streams = [&](AudioDeviceID device_id, AudioObjectPropertyScope scope) {
+    for (const AudioStreamID stream_id : enumerateStreams(device_id, scope)) {
+      const auto virtual_format = getStreamFormat(stream_id, kAudioStreamPropertyVirtualFormat);
+      const auto physical_format = getStreamFormat(stream_id, kAudioStreamPropertyPhysicalFormat);
+      if (!virtual_format.has_value() || !physical_format.has_value()) {
+        return false;
+      }
+      const auto existing = std::find_if(streams.begin(), streams.end(),
+                                         [stream_id](const CoreAudioRouteStream& stream) {
+                                           return stream.stream_id == stream_id;
+                                         });
+      if (existing == streams.end()) {
+        streams.push_back({stream_id, *virtual_format, *physical_format});
+      }
+    }
+    return true;
+  };
+
+  if (!append_streams(output_device_id_, kAudioObjectPropertyScopeOutput) ||
+      (config_.num_inputs > 0 &&
+       !append_streams(input_device_id_, kAudioObjectPropertyScopeInput)) ||
+      streams.empty()) {
     return false;
   }
 
-  sample_rate_monitor_->requestCheck();
-  const CoreAudioSampleRatePollResult result = sample_rate_monitor_->poll();
-  switch (result) {
-  case CoreAudioSampleRatePollResult::NoChange:
-    runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
-    return true;
-  case CoreAudioSampleRatePollResult::RateRestored:
-    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateRestored,
+  try {
+    route_monitor_ = std::make_unique<CoreAudioRouteMonitor>(
+        route_property_api_, config_.sample_rate, config_.buffer_size, std::move(device_ids),
+        std::move(streams));
+  } catch (...) {
+    route_monitor_.reset();
+    return false;
+  }
+  return true;
+}
+
+bool CoreAudioDriver::startRouteMonitorLocked() {
+  std::lock_guard<std::mutex> monitor_lock(route_monitor_mutex_);
+  if (!route_monitor_ || !route_monitor_->start()) {
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateListenerFailure,
                            std::memory_order_release);
-    return true;
-  case CoreAudioSampleRatePollResult::ReinitializationRequired:
-    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateReinitializationRequired,
-                           std::memory_order_release);
-    break;
-  case CoreAudioSampleRatePollResult::QueryFailed:
-    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateQueryFailure,
-                           std::memory_order_release);
-    break;
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    return false;
   }
 
-  sample_rate_monitor_->stop();
+  route_monitor_->requestCheck();
+  const CoreAudioRoutePollResult result = route_monitor_->poll();
+  publishRoutePollResult(result);
+  if (result == CoreAudioRoutePollResult::NoChange ||
+      result == CoreAudioRoutePollResult::RateRestored) {
+    refreshActiveRouteLocked();
+    return true;
+  }
+
+  route_monitor_->stop();
   return false;
 }
 
-void CoreAudioDriver::stopSampleRateMonitor() {
-  sample_rate_monitor_active_.store(false, std::memory_order_release);
+void CoreAudioDriver::stopRouteMonitor() {
+  route_monitor_active_.store(false, std::memory_order_release);
   {
-    std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
-    if (sample_rate_monitor_) {
-      sample_rate_monitor_->stop();
-      sample_rate_monitor_->requestCheck();
+    std::lock_guard<std::mutex> monitor_lock(route_monitor_mutex_);
+    if (route_monitor_) {
+      route_monitor_->stop();
     }
   }
-  if (sample_rate_monitor_thread_.joinable()) {
-    sample_rate_monitor_thread_.join();
+  if (route_monitor_thread_.joinable()) {
+    route_monitor_thread_.join();
   }
 }
 
-void CoreAudioDriver::sampleRateMonitorLoop() {
-  while (sample_rate_monitor_active_.load(std::memory_order_acquire)) {
-    sample_rate_monitor_->waitForChange();
-    if (!sample_rate_monitor_active_.load(std::memory_order_acquire)) {
+void CoreAudioDriver::routeMonitorLoop() {
+  while (route_monitor_active_.load(std::memory_order_acquire)) {
+    route_monitor_->waitForChange();
+    if (!route_monitor_active_.load(std::memory_order_acquire)) {
       break;
     }
 
-    CoreAudioSampleRatePollResult result;
+    CoreAudioRoutePollResult result = CoreAudioRoutePollResult::BackendFailure;
     {
-      std::lock_guard<std::mutex> monitor_lock(sample_rate_monitor_mutex_);
-      if (!sample_rate_monitor_active_.load(std::memory_order_acquire)) {
+      std::lock_guard<std::mutex> monitor_lock(route_monitor_mutex_);
+      if (!route_monitor_active_.load(std::memory_order_acquire)) {
         break;
       }
-      result = sample_rate_monitor_->poll();
-      if (result == CoreAudioSampleRatePollResult::ReinitializationRequired ||
-          result == CoreAudioSampleRatePollResult::QueryFailed) {
-        sample_rate_monitor_->stop();
+      result = route_monitor_->poll();
+      if (result != CoreAudioRoutePollResult::NoChange &&
+          result != CoreAudioRoutePollResult::RateRestored) {
+        route_monitor_->stop();
       }
     }
 
-    switch (result) {
-    case CoreAudioSampleRatePollResult::NoChange:
-      runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+    publishRoutePollResult(result);
+    if (result == CoreAudioRoutePollResult::NoChange ||
+        result == CoreAudioRoutePollResult::RateRestored) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (is_running_.load(std::memory_order_acquire)) {
+        refreshActiveRouteLocked();
+      }
       continue;
-    case CoreAudioSampleRatePollResult::RateRestored:
-      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateRestored,
-                             std::memory_order_release);
-      continue;
-    case CoreAudioSampleRatePollResult::ReinitializationRequired:
-      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateReinitializationRequired,
-                             std::memory_order_release);
-      break;
-    case CoreAudioSampleRatePollResult::QueryFailed:
-      runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateQueryFailure,
-                             std::memory_order_release);
-      break;
     }
 
     {
       std::lock_guard<std::mutex> lock(mutex_);
       stopRenderingLocked();
     }
-    sample_rate_monitor_active_.store(false, std::memory_order_release);
+    route_monitor_active_.store(false, std::memory_order_release);
+    break;
   }
 }
 
-void CoreAudioDriver::stopRenderingLocked() {
-  is_running_.store(false, std::memory_order_release);
-  if (audio_unit_) {
-    AudioOutputUnitStop(audio_unit_);
+void CoreAudioDriver::publishRoutePollResult(CoreAudioRoutePollResult result) {
+  switch (result) {
+  case CoreAudioRoutePollResult::NoChange:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::RateRestored:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateRestored,
+                           std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::RouteUnavailable:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::FormatChanged:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::FormatChanged, std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::ReinitializationRequired:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::SampleRateReinitializationRequired,
+                           std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::ReinitializationRequired,
+                         std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::BackendFailure:
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    break;
   }
-  callback_target_.replaceAndDrain(nullptr);
+}
+
+void CoreAudioDriver::refreshActiveRouteLocked() {
+  active_route_.input_device_id = getDeviceUID(input_device_id_).value_or("");
+  active_route_.output_device_id = getDeviceUID(output_device_id_).value_or("");
+  active_route_.input_channels = input_channel_map_;
+  active_route_.output_channels = output_channel_map_;
+  active_route_.available_input_channels = static_cast<uint16_t>(
+      std::min<uint32_t>(available_input_channels_, std::numeric_limits<uint16_t>::max()));
+  active_route_.available_output_channels = static_cast<uint16_t>(
+      std::min<uint32_t>(available_output_channels_, std::numeric_limits<uint16_t>::max()));
+  active_route_.requested_sample_rate = config_.sample_rate;
+  active_route_.actual_sample_rate = 0;
+  active_route_.actual_buffer_frames = 0;
+
+  const auto actual_rate = getOptionalFloat64Property(
+      device_id_, kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal);
+  if (actual_rate.has_value() && *actual_rate > 0.0) {
+    active_route_.actual_sample_rate = static_cast<uint32_t>(*actual_rate);
+  }
+  active_route_.actual_buffer_frames =
+      getOptionalUInt32Property(device_id_, kAudioDevicePropertyBufferFrameSize,
+                                kAudioObjectPropertyScopeGlobal)
+          .value_or(0);
+  active_route_.latency = queryLatencyBreakdown();
+  active_route_.input_alive = config_.num_inputs > 0 &&
+                              getUInt32Property(input_device_id_, kAudioDevicePropertyDeviceIsAlive,
+                                                kAudioObjectPropertyScopeGlobal) != 0;
+  active_route_.output_alive =
+      getUInt32Property(output_device_id_, kAudioDevicePropertyDeviceIsAlive,
+                        kAudioObjectPropertyScopeGlobal) != 0;
+}
+
+AudioRouteLatency CoreAudioDriver::queryLatencyBreakdown() const {
+  AudioRouteLatency latency;
+  uint32_t capture_frames = 0;
+  uint32_t playback_frames = 0;
+  uint32_t processing_frames = 0;
+
+  const auto input_device_latency = getOptionalUInt32Property(
+      input_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeInput);
+  const auto input_safety_offset = getOptionalUInt32Property(
+      input_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeInput);
+  const auto input_stream_latency =
+      getOptionalStreamLatency(input_device_id_, kAudioObjectPropertyScopeInput);
+  const auto output_device_latency = getOptionalUInt32Property(
+      output_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeOutput);
+  const auto output_safety_offset = getOptionalUInt32Property(
+      output_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeOutput);
+  const auto output_stream_latency =
+      getOptionalStreamLatency(output_device_id_, kAudioObjectPropertyScopeOutput);
+  const auto callback_buffer_frames = getOptionalUInt32Property(
+      device_id_, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
+
+  std::optional<uint32_t> audio_unit_latency;
+  if (audio_unit_ != nullptr) {
+    Float64 seconds = 0.0;
+    UInt32 size = sizeof(seconds);
+    if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
+                             &seconds, &size) == noErr &&
+        size == sizeof(seconds) && seconds >= 0.0) {
+      const uint32_t rate = active_route_.actual_sample_rate != 0 ? active_route_.actual_sample_rate
+                                                                  : config_.sample_rate;
+      const uint64_t frames = static_cast<uint64_t>(std::llround(seconds * rate));
+      audio_unit_latency =
+          static_cast<uint32_t>(std::min<uint64_t>(frames, std::numeric_limits<uint32_t>::max()));
+    }
+  }
+
+  bool input_complete = config_.num_inputs == 0;
+  if (config_.num_inputs > 0) {
+    input_complete = addLatencyTerm(input_device_latency, capture_frames) &&
+                     addLatencyTerm(input_safety_offset, capture_frames) &&
+                     addLatencyTerm(input_stream_latency, capture_frames);
+  }
+  const bool output_complete = addLatencyTerm(output_device_latency, playback_frames) &&
+                               addLatencyTerm(output_safety_offset, playback_frames) &&
+                               addLatencyTerm(output_stream_latency, playback_frames);
+  const bool processing_complete = addLatencyTerm(callback_buffer_frames, processing_frames) &&
+                                   addLatencyTerm(audio_unit_latency, processing_frames);
+
+  latency.capture_frames = capture_frames;
+  latency.playback_frames = playback_frames;
+  latency.processing_frames = processing_frames;
+  latency.complete = input_complete && output_complete && processing_complete;
+  return latency;
+}
+
+uint32_t CoreAudioDriver::queryDeviceLatency() const {
+  const AudioRouteLatency latency = queryLatencyBreakdown();
+  if (!latency.complete) {
+    return 0;
+  }
+  const uint64_t total = static_cast<uint64_t>(latency.capture_frames) + latency.playback_frames +
+                         latency.processing_frames;
+  return static_cast<uint32_t>(std::min<uint64_t>(total, std::numeric_limits<uint32_t>::max()));
+}
+
+std::optional<std::string> CoreAudioDriver::getDeviceUID(AudioDeviceID device_id) const {
+  if (device_id == 0) {
+    return std::nullopt;
+  }
+  CFStringRef uid = copyDeviceUID(device_id);
+  if (uid == nullptr) {
+    return std::nullopt;
+  }
+  char buffer[1024] = {};
+  const Boolean converted = CFStringGetCString(uid, buffer, sizeof(buffer), kCFStringEncodingUTF8);
+  CFRelease(uid);
+  if (!converted) {
+    return std::nullopt;
+  }
+  return std::string(buffer);
+}
+
+SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
+  AudioComponentDescription description = {};
+  description.componentType = kAudioUnitType_Output;
+  description.componentSubType = kAudioUnitSubType_HALOutput;
+  description.componentManufacturer = kAudioUnitManufacturer_Apple;
+
+  AudioComponent component = AudioComponentFindNext(nullptr, &description);
+  if (!component) {
+    return SessionGraphError::InternalError;
+  }
+
+  OSStatus status = AudioComponentInstanceNew(component, &audio_unit_);
+  if (status != noErr || !audio_unit_) {
+    return SessionGraphError::InternalError;
+  }
+
+  UInt32 enable_input = config_.num_inputs > 0 ? 1 : 0;
+  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_EnableIO,
+                                kAudioUnitScope_Input, 1, &enable_input, sizeof(enable_input));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  UInt32 enable_output = 1;
+  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_EnableIO,
+                                kAudioUnitScope_Output, 0, &enable_output, sizeof(enable_output));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_CurrentDevice,
+                                kAudioUnitScope_Global, 0, &device_id, sizeof(device_id));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  Float64 requested_sample_rate = static_cast<Float64>(config_.sample_rate);
+  AudioObjectPropertyAddress sample_rate_address = {kAudioDevicePropertyNominalSampleRate,
+                                                    kAudioObjectPropertyScopeGlobal,
+                                                    kAudioObjectPropertyElementMain};
+  status = AudioObjectSetPropertyData(device_id, &sample_rate_address, 0, nullptr,
+                                      sizeof(requested_sample_rate), &requested_sample_rate);
+  if (status != noErr) {
+    const auto observed_rate = getOptionalFloat64Property(
+        device_id, kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal);
+    if (!observed_rate.has_value() || *observed_rate != requested_sample_rate) {
+      return SessionGraphError::InternalError;
+    }
+  }
+
+  AudioStreamBasicDescription output_format = {};
+  output_format.mSampleRate = config_.sample_rate;
+  output_format.mFormatID = kAudioFormatLinearPCM;
+  output_format.mFormatFlags =
+      kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved;
+  output_format.mBytesPerPacket = sizeof(float);
+  output_format.mFramesPerPacket = 1;
+  output_format.mBytesPerFrame = sizeof(float);
+  output_format.mChannelsPerFrame = config_.num_outputs;
+  output_format.mBitsPerChannel = 32;
+
+  status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,
+                                0, &output_format, sizeof(output_format));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  std::vector<SInt32> output_channel_map;
+  output_channel_map.reserve(output_channel_map_.size());
+  for (const uint16_t channel : output_channel_map_) {
+    output_channel_map.push_back(static_cast<SInt32>(channel));
+  }
+  status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_ChannelMap,
+                                kAudioUnitScope_Input, 0, output_channel_map.data(),
+                                static_cast<UInt32>(output_channel_map.size() * sizeof(SInt32)));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  if (config_.num_inputs > 0) {
+    AudioStreamBasicDescription input_format = output_format;
+    input_format.mChannelsPerFrame = config_.num_inputs;
+    status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_StreamFormat,
+                                  kAudioUnitScope_Output, 1, &input_format, sizeof(input_format));
+    if (status != noErr) {
+      return SessionGraphError::InternalError;
+    }
+
+    std::vector<SInt32> input_channel_map;
+    input_channel_map.reserve(input_channel_map_.size());
+    for (const uint16_t channel : input_channel_map_) {
+      input_channel_map.push_back(static_cast<SInt32>(input_channel_offset_ + channel));
+    }
+    status = AudioUnitSetProperty(audio_unit_, kAudioOutputUnitProperty_ChannelMap,
+                                  kAudioUnitScope_Output, 1, input_channel_map.data(),
+                                  static_cast<UInt32>(input_channel_map.size() * sizeof(SInt32)));
+    if (status != noErr) {
+      return SessionGraphError::InternalError;
+    }
+  }
+
+  UInt32 buffer_frames = config_.buffer_size;
+  status = AudioUnitSetProperty(audio_unit_, kAudioDevicePropertyBufferFrameSize,
+                                kAudioUnitScope_Global, 0, &buffer_frames, sizeof(buffer_frames));
+  if (status != noErr) {
+    const auto observed_buffer = getOptionalUInt32Property(
+        device_id, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
+    if (!observed_buffer.has_value() || *observed_buffer != config_.buffer_size) {
+      return SessionGraphError::InternalError;
+    }
+  }
+
+  AURenderCallbackStruct callback = {};
+  callback.inputProc = &CoreAudioDriver::renderCallback;
+  callback.inputProcRefCon = this;
+  status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_SetRenderCallback,
+                                kAudioUnitScope_Input, 0, &callback, sizeof(callback));
+  if (status != noErr) {
+    return SessionGraphError::InternalError;
+  }
+
+  status = AudioUnitInitialize(audio_unit_);
+  return status == noErr ? SessionGraphError::OK : SessionGraphError::InternalError;
 }
 
 void CoreAudioDriver::cleanupAudioUnit() {
-  // Callers stop and join the control worker before destroying the route.
-  sample_rate_monitor_.reset();
   if (audio_unit_) {
     AudioUnitUninitialize(audio_unit_);
     AudioComponentInstanceDispose(audio_unit_);
@@ -987,10 +1177,27 @@ void CoreAudioDriver::cleanupAudioUnit() {
   input_device_id_ = 0;
   output_device_id_ = 0;
   input_channel_offset_ = 0;
+  available_input_channels_ = 0;
+  available_output_channels_ = 0;
+  input_channel_map_.clear();
+  output_channel_map_.clear();
+  route_monitor_.reset();
+  input_buffers_.clear();
+  output_buffers_.clear();
+  input_storage_.clear();
+  output_storage_.clear();
+  input_abl_storage_.clear();
 }
 
-// Factory function
-std::unique_ptr<IAudioDriver> createCoreAudioDriver() {
+void CoreAudioDriver::stopRenderingLocked() {
+  is_running_.store(false, std::memory_order_release);
+  if (audio_unit_) {
+    AudioOutputUnitStop(audio_unit_);
+  }
+  callback_target_.replaceAndDrain(nullptr);
+}
+
+ORPHEUS_API std::unique_ptr<IAudioDriver> createCoreAudioDriver() {
   return std::make_unique<CoreAudioDriver>();
 }
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -704,6 +704,9 @@ AudioDeviceID CoreAudioDriver::createAggregateDevice(AudioDeviceID input_device_
 bool CoreAudioDriver::resolveChannelMaps(const AudioDriverConfig& config) {
   const auto resolve = [](const std::vector<uint16_t>& requested, uint16_t logical_count,
                           uint32_t physical_count, std::vector<uint16_t>& resolved) {
+    if (logical_count > physical_count) {
+      return false;
+    }
     if (requested.empty()) {
       resolved.resize(logical_count);
       for (uint16_t channel = 0; channel < logical_count; ++channel) {

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "coreaudio_sample_rate_monitor.h"
 #include "../../../core/common/realtime_borrowed_target.h"
+#include "coreaudio_route_monitor.h"
 #include <orpheus/audio_driver.h>
 
 #include <AudioToolbox/AudioToolbox.h>
@@ -11,31 +11,22 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
 namespace orpheus {
 
-// Forward declaration
 class IPerformanceMonitor;
 
-/// CoreAudio driver implementation for macOS
-///
-/// Provides low-latency audio I/O using AudioUnit (HAL Output).
-/// Supports device enumeration, configurable sample rate/buffer size,
-/// and latency reporting.
-///
-/// Thread Safety:
-/// - initialize(), start(), stop(): UI thread only
-/// - isRunning(), getConfig(), getDriverName(), getLatencySamples(): Thread-safe
-/// - Audio callback: Real-time audio thread (lock-free)
+/// CoreAudio HAL output driver with stable UID routing and control-thread
+/// route-state monitoring.
 class CoreAudioDriver : public IAudioDriver {
 public:
   CoreAudioDriver();
   ~CoreAudioDriver() override;
 
-  // IAudioDriver interface
   SessionGraphError initialize(const AudioDriverConfig& config) override;
   SessionGraphError start(IAudioCallback* callback) override;
   SessionGraphError stop() override;
@@ -45,136 +36,84 @@ public:
   uint32_t getLatencySamples() const override;
   AudioIoTelemetry getTelemetry() const noexcept override;
   AudioDriverCapabilities getCapabilities() const override;
+  ActiveAudioRoute getActiveRoute() const override;
 
-  /// Set performance monitor for audio metrics tracking
-  /// @param monitor Performance monitor instance (can be nullptr to disable)
-  /// @note Thread-safe: Can be called before or after start()
   void setPerformanceMonitor(IPerformanceMonitor* monitor) override;
 
-  /// Test-only helpers for deterministic backend failure accounting.
+  // Test-only helpers for deterministic backend failure accounting.
   void setInputRenderFailuresForTesting(uint64_t count) noexcept;
   void incrementInputRenderFailuresForTesting() noexcept;
 
 private:
-  /// Audio Unit render callback (invoked on audio thread)
   static OSStatus renderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
                                  const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber,
                                  UInt32 inNumberFrames, AudioBufferList* ioData);
 
   void recordInputRenderFailure() noexcept;
 
-  /// Enumerate available audio devices
-  /// @return Vector of device IDs
   std::vector<AudioDeviceID> enumerateDevices();
-
-  /// Find a device by its persistent CoreAudio DeviceUID.
-  /// @return Device ID or 0 if the UID is unknown
   AudioDeviceID findDeviceByUID(const std::string& device_uid);
-
-  /// Get the system default device for a given selector (e.g.
-  /// kAudioHardwarePropertyDefaultOutputDevice / ...DefaultInputDevice).
-  /// @return Device ID or 0 on failure
   AudioDeviceID getDefaultDevice(AudioObjectPropertySelector selector);
-
-  /// Resolve the configured physical input/output endpoints. Empty directional
-  /// IDs select the corresponding system defaults; separate endpoints require
-  /// a private aggregate. Resolution never falls back to a different endpoint.
-  /// @return Device ID (possibly an aggregate) or 0 on failure
   AudioDeviceID resolveInputOutputDevice();
-
-  /// Create a private, non-stacked Aggregate Device combining a capture
-  /// sub-device and a playback sub-device so one AUHAL unit can drive both.
-  /// Torn down in cleanupAudioUnit() via AudioHardwareDestroyAggregateDevice.
-  /// @return Aggregate device ID, or 0 on failure
   AudioDeviceID createAggregateDevice(AudioDeviceID input_device_id,
                                       AudioDeviceID output_device_id);
-
-  /// Check whether a device supports the requested direction.
   bool supportsDirection(AudioDeviceID device_id, AudioObjectPropertyScope scope) const;
+  uint32_t getChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const;
+  std::optional<std::string> getDeviceUID(AudioDeviceID device_id) const;
 
-  /// Query the complete capture-to-playback latency of the active physical
-  /// routes, including device latency, safety offsets, actual I/O buffer
-  /// depth, and AudioUnit processing latency. Queried live so a consumer
-  /// route's reported delay is refreshed for every host take.
-  /// @return Round-trip latency in samples, or 0 when it cannot be detected
-  uint32_t queryDeviceLatency() const;
-
-  /// Set up AudioUnit with configuration
-  /// @param device_id Device to use
-  /// @return SessionGraphError::OK on success
+  bool resolveChannelMaps(const AudioDriverConfig& config);
   SessionGraphError setupAudioUnit(AudioDeviceID device_id);
+  std::vector<AudioStreamID> enumerateStreams(AudioDeviceID device_id,
+                                              AudioObjectPropertyScope scope) const;
+  std::optional<AudioStreamBasicDescription>
+  getStreamFormat(AudioStreamID stream_id, AudioObjectPropertySelector selector) const;
+  bool createRouteMonitor();
+  bool startRouteMonitorLocked();
+  void stopRouteMonitor();
+  void routeMonitorLoop();
+  void publishRoutePollResult(CoreAudioRoutePollResult result);
+  void refreshActiveRouteLocked();
 
-  /// Cleanup AudioUnit resources
+  AudioRouteLatency queryLatencyBreakdown() const;
+  uint32_t queryDeviceLatency() const;
   void cleanupAudioUnit();
-
-  /// Creates the runtime monitor after route resolution has identified the
-  /// aggregate wrapper and each physical endpoint.
-  void createSampleRateMonitor();
-  /// Starts listeners and the control worker. mutex_ must be held.
-  bool startSampleRateMonitorLocked();
-  /// Removes listeners, wakes the control worker, and joins it.
-  void stopSampleRateMonitor();
-  /// Services listener notifications outside the audio callback.
-  void sampleRateMonitorLoop();
-  /// Stops the AudioUnit and drains admitted callbacks. mutex_ must be held.
   void stopRenderingLocked();
 
-  // Configuration
   AudioDriverConfig config_;
-
-  // CoreAudio state
   AudioUnit audio_unit_{nullptr};
   AudioDeviceID device_id_{0};
-  // Set only when resolveInputOutputDevice() had to bridge separate default
-  // input/output devices; torn down in cleanupAudioUnit().
   AudioDeviceID aggregate_device_id_{0};
-  // Physical endpoints behind device_id_. These differ when device_id_ is the
-  // private aggregate used to bridge separate default input/output devices.
   AudioDeviceID input_device_id_{0};
   AudioDeviceID output_device_id_{0};
-  // Capture channel 0 in a private aggregate may belong to the playback
-  // sub-device when that endpoint is duplex. This offset selects the first
-  // channel of the explicitly resolved input sub-device instead.
   uint32_t input_channel_offset_{0};
+  uint32_t available_input_channels_{0};
+  uint32_t available_output_channels_{0};
+  std::vector<uint16_t> input_channel_map_;
+  std::vector<uint16_t> output_channel_map_;
+
   std::atomic<bool> is_running_{false};
   std::atomic<uint64_t> input_render_failures_{0};
   std::atomic<AudioDriverRuntimeOutcome> runtime_outcome_{AudioDriverRuntimeOutcome::Healthy};
+  std::atomic<AudioRouteRuntimeOutcome> route_outcome_{AudioRouteRuntimeOutcome::Healthy};
 
-  // Listener registration belongs to the active route. The property callback
-  // only signals this monitor; a control worker performs all HAL queries and
-  // rate changes outside the audio callback.
-  CoreAudioSampleRatePropertyApi sample_rate_property_api_;
-  std::unique_ptr<CoreAudioSampleRateMonitor> sample_rate_monitor_;
-  std::atomic<bool> sample_rate_monitor_active_{false};
-  // Serializes listener registration/removal and control-thread polling; never
-  // acquired by the CoreAudio render callback or property-listener callback.
-  std::mutex sample_rate_monitor_mutex_;
-  std::thread sample_rate_monitor_thread_;
+  CoreAudioSampleRatePropertyApi route_property_api_;
+  std::unique_ptr<CoreAudioRouteMonitor> route_monitor_;
+  std::atomic<bool> route_monitor_active_{false};
+  std::mutex route_monitor_mutex_;
+  std::thread route_monitor_thread_;
 
-  // Non-owning host callback. Control-thread replacement closes admission and
-  // drains every admitted callback before changing the borrowed pointer.
   detail::RealtimeBorrowedTarget<IAudioCallback> callback_target_;
-
-  // Optional diagnostics monitor. Its lease spans timing, active-count query,
-  // elapsed conversion, and publication.
   detail::RealtimeBorrowedTarget<IPerformanceMonitor> performance_monitor_target_;
   int64_t expected_stream_sample_{0};
   bool stream_timeline_initialized_{false};
 
-  // Audio thread buffers (allocated once in initialize)
   std::vector<float*> input_buffers_;
   std::vector<float*> output_buffers_;
-  std::vector<float> input_storage_;  // Backing storage for input buffers
-  std::vector<float> output_storage_; // Backing storage for output buffers
-
-  // Pre-allocated AudioBufferList used to pull captured input in the render
-  // callback via AudioUnitRender (bus 1). Sized in initialize() when
-  // num_inputs > 0 so the audio thread never allocates. Backed by raw bytes
-  // because AudioBufferList has a trailing flexible array of mNumberBuffers
-  // AudioBuffer entries; its mData pointers alias input_storage_ (planar).
+  std::vector<float> input_storage_;
+  std::vector<float> output_storage_;
   std::vector<uint8_t> input_abl_storage_;
 
-  // Thread safety
+  ActiveAudioRoute active_route_;
   mutable std::mutex mutex_;
 };
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio_route_monitor.h"
+
+#include <algorithm>
+
+namespace orpheus {
+
+CoreAudioRouteMonitor::CoreAudioRouteMonitor(ICoreAudioSampleRatePropertyApi& property_api,
+                                             uint32_t expected_sample_rate,
+                                             uint32_t expected_buffer_frames,
+                                             std::vector<AudioDeviceID> device_ids,
+                                             std::vector<CoreAudioRouteStream> streams)
+    : property_api_(property_api),
+      expected_sample_rate_(static_cast<Float64>(expected_sample_rate)),
+      expected_buffer_frames_(expected_buffer_frames), device_ids_(std::move(device_ids)),
+      streams_(std::move(streams)) {
+  std::sort(device_ids_.begin(), device_ids_.end());
+  device_ids_.erase(std::unique(device_ids_.begin(), device_ids_.end()), device_ids_.end());
+  device_ids_.erase(std::remove(device_ids_.begin(), device_ids_.end(), AudioDeviceID{0}),
+                    device_ids_.end());
+
+  std::sort(streams_.begin(), streams_.end(),
+            [](const CoreAudioRouteStream& lhs, const CoreAudioRouteStream& rhs) {
+              return lhs.stream_id < rhs.stream_id;
+            });
+  streams_.erase(std::unique(streams_.begin(), streams_.end(),
+                             [](const CoreAudioRouteStream& lhs, const CoreAudioRouteStream& rhs) {
+                               return lhs.stream_id == rhs.stream_id;
+                             }),
+                 streams_.end());
+
+  registrations_.reserve(device_ids_.size() * 3 + streams_.size() * 2);
+  for (const AudioDeviceID device_id : device_ids_) {
+    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyDeviceIsAlive)});
+    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyNominalSampleRate)});
+    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyBufferFrameSize)});
+  }
+  for (const CoreAudioRouteStream& stream : streams_) {
+    registrations_.push_back({stream.stream_id, streamAddress(kAudioStreamPropertyVirtualFormat)});
+    registrations_.push_back({stream.stream_id, streamAddress(kAudioStreamPropertyPhysicalFormat)});
+  }
+}
+
+CoreAudioRouteMonitor::~CoreAudioRouteMonitor() {
+  stop();
+}
+
+bool CoreAudioRouteMonitor::start() noexcept {
+  if (registered_count_ != 0 || registrations_.empty()) {
+    return registered_count_ != 0;
+  }
+
+  state_.store(0, std::memory_order_release);
+  for (const ListenerRegistration& registration : registrations_) {
+    if (property_api_.addPropertyListener(registration.object_id, &registration.address,
+                                          &propertyChanged, this) != noErr) {
+      stop();
+      return false;
+    }
+    ++registered_count_;
+  }
+  return true;
+}
+
+void CoreAudioRouteMonitor::stop() noexcept {
+  while (registered_count_ != 0) {
+    --registered_count_;
+    const ListenerRegistration& registration = registrations_[registered_count_];
+    property_api_.removePropertyListener(registration.object_id, &registration.address,
+                                         &propertyChanged, this);
+  }
+  state_.fetch_or(kStoppedBit | kPendingBit, std::memory_order_release);
+  pending_changed_.notify_all();
+}
+
+void CoreAudioRouteMonitor::requestCheck() noexcept {
+  uint64_t state = state_.load(std::memory_order_acquire);
+  uint64_t requested_state = 0;
+  do {
+    requested_state = (state + kGenerationIncrement) | kPendingBit;
+  } while (!state_.compare_exchange_weak(state, requested_state, std::memory_order_acq_rel,
+                                         std::memory_order_acquire));
+  pending_changed_.notify_one();
+}
+
+void CoreAudioRouteMonitor::waitForChange() noexcept {
+  std::unique_lock<std::mutex> lock(pending_mutex_);
+  pending_changed_.wait(
+      lock, [this] { return (state_.load(std::memory_order_acquire) & kPendingBit) != 0; });
+}
+
+CoreAudioRoutePollResult CoreAudioRouteMonitor::poll() noexcept {
+  uint64_t serviced_state = state_.load(std::memory_order_acquire);
+  if ((serviced_state & kPendingBit) == 0) {
+    return CoreAudioRoutePollResult::NoChange;
+  }
+  if ((serviced_state & kStoppedBit) != 0) {
+    return CoreAudioRoutePollResult::NoChange;
+  }
+
+  const auto alive_address = deviceAddress(kAudioDevicePropertyDeviceIsAlive);
+  const auto rate_address = deviceAddress(kAudioDevicePropertyNominalSampleRate);
+  const auto buffer_address = deviceAddress(kAudioDevicePropertyBufferFrameSize);
+  bool rate_restored = false;
+
+  for (const AudioDeviceID device_id : device_ids_) {
+    UInt32 alive = 0;
+    if (!readUInt32(property_api_, device_id, alive_address, alive)) {
+      return CoreAudioRoutePollResult::BackendFailure;
+    }
+    if (alive == 0) {
+      return CoreAudioRoutePollResult::RouteUnavailable;
+    }
+
+    Float64 observed_rate = 0.0;
+    if (!readFloat64(property_api_, device_id, rate_address, observed_rate)) {
+      return CoreAudioRoutePollResult::BackendFailure;
+    }
+    if (observed_rate != expected_sample_rate_) {
+      if (property_api_.setPropertyData(device_id, &rate_address, sizeof(expected_sample_rate_),
+                                        &expected_sample_rate_) != noErr ||
+          !readFloat64(property_api_, device_id, rate_address, observed_rate)) {
+        return CoreAudioRoutePollResult::ReinitializationRequired;
+      }
+      if (observed_rate != expected_sample_rate_) {
+        return CoreAudioRoutePollResult::ReinitializationRequired;
+      }
+      rate_restored = true;
+    }
+
+    UInt32 observed_buffer_frames = 0;
+    if (!readUInt32(property_api_, device_id, buffer_address, observed_buffer_frames)) {
+      return CoreAudioRoutePollResult::BackendFailure;
+    }
+    if (observed_buffer_frames != expected_buffer_frames_) {
+      return CoreAudioRoutePollResult::ReinitializationRequired;
+    }
+  }
+
+  for (const CoreAudioRouteStream& stream : streams_) {
+    const auto virtual_address = streamAddress(kAudioStreamPropertyVirtualFormat);
+    const auto physical_address = streamAddress(kAudioStreamPropertyPhysicalFormat);
+    AudioStreamBasicDescription observed_virtual_format{};
+    AudioStreamBasicDescription observed_physical_format{};
+    if (!readFormat(property_api_, stream.stream_id, virtual_address, observed_virtual_format) ||
+        !readFormat(property_api_, stream.stream_id, physical_address, observed_physical_format)) {
+      return CoreAudioRoutePollResult::BackendFailure;
+    }
+    if (!formatsEqual(observed_virtual_format, stream.expected_virtual_format) ||
+        !formatsEqual(observed_physical_format, stream.expected_physical_format)) {
+      return CoreAudioRoutePollResult::FormatChanged;
+    }
+  }
+
+  if (!state_.compare_exchange_strong(serviced_state, serviced_state & ~kPendingBit,
+                                      std::memory_order_acq_rel, std::memory_order_acquire)) {
+    return CoreAudioRoutePollResult::NoChange;
+  }
+  return rate_restored ? CoreAudioRoutePollResult::RateRestored
+                       : CoreAudioRoutePollResult::NoChange;
+}
+
+bool CoreAudioRouteMonitor::permitsRendering() const noexcept {
+  const uint64_t state = state_.load(std::memory_order_acquire);
+  return (state & (kPendingBit | kStoppedBit)) == 0;
+}
+
+OSStatus CoreAudioRouteMonitor::propertyChanged(AudioObjectID, UInt32,
+                                                const AudioObjectPropertyAddress*,
+                                                void* context) noexcept {
+  auto* monitor = static_cast<CoreAudioRouteMonitor*>(context);
+  monitor->requestCheck();
+  return noErr;
+}
+
+AudioObjectPropertyAddress
+CoreAudioRouteMonitor::deviceAddress(AudioObjectPropertySelector selector) noexcept {
+  return {selector, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+}
+
+AudioObjectPropertyAddress
+CoreAudioRouteMonitor::streamAddress(AudioObjectPropertySelector selector) noexcept {
+  return {selector, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+}
+
+bool CoreAudioRouteMonitor::formatsEqual(const AudioStreamBasicDescription& lhs,
+                                         const AudioStreamBasicDescription& rhs) noexcept {
+  return lhs.mSampleRate == rhs.mSampleRate && lhs.mFormatID == rhs.mFormatID &&
+         lhs.mFormatFlags == rhs.mFormatFlags && lhs.mBytesPerPacket == rhs.mBytesPerPacket &&
+         lhs.mFramesPerPacket == rhs.mFramesPerPacket && lhs.mBytesPerFrame == rhs.mBytesPerFrame &&
+         lhs.mChannelsPerFrame == rhs.mChannelsPerFrame &&
+         lhs.mBitsPerChannel == rhs.mBitsPerChannel && lhs.mReserved == rhs.mReserved;
+}
+
+bool CoreAudioRouteMonitor::readUInt32(ICoreAudioSampleRatePropertyApi& property_api,
+                                       AudioObjectID object_id,
+                                       const AudioObjectPropertyAddress& address,
+                                       UInt32& value) noexcept {
+  UInt32 size = sizeof(value);
+  return property_api.getPropertyData(object_id, &address, &size, &value) == noErr &&
+         size == sizeof(value);
+}
+
+bool CoreAudioRouteMonitor::readFloat64(ICoreAudioSampleRatePropertyApi& property_api,
+                                        AudioObjectID object_id,
+                                        const AudioObjectPropertyAddress& address,
+                                        Float64& value) noexcept {
+  UInt32 size = sizeof(value);
+  return property_api.getPropertyData(object_id, &address, &size, &value) == noErr &&
+         size == sizeof(value);
+}
+
+bool CoreAudioRouteMonitor::readFormat(ICoreAudioSampleRatePropertyApi& property_api,
+                                       AudioObjectID object_id,
+                                       const AudioObjectPropertyAddress& address,
+                                       AudioStreamBasicDescription& value) noexcept {
+  UInt32 size = sizeof(value);
+  return property_api.getPropertyData(object_id, &address, &size, &value) == noErr &&
+         size == sizeof(value);
+}
+
+} // namespace orpheus

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "coreaudio_sample_rate_monitor.h"
+
+#include <CoreAudio/CoreAudio.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace orpheus {
+
+/// Control-thread result from servicing a CoreAudio route notification.
+enum class CoreAudioRoutePollResult : uint8_t {
+  NoChange,
+  RateRestored,
+  RouteUnavailable,
+  FormatChanged,
+  ReinitializationRequired,
+  BackendFailure,
+};
+
+/// One stream whose virtual and physical formats are part of the active route.
+struct CoreAudioRouteStream {
+  AudioStreamID stream_id = 0;
+  AudioStreamBasicDescription expected_virtual_format{};
+  AudioStreamBasicDescription expected_physical_format{};
+};
+
+/// Watches the physical route outside the render callback.
+///
+/// Property listeners perform only an atomic notification. The control worker
+/// calls poll(), which performs all HAL reads and any safe nominal-rate restore.
+/// A pending notification closes the render gate until the worker acknowledges
+/// it or reaches a terminal route outcome.
+class CoreAudioRouteMonitor final {
+public:
+  CoreAudioRouteMonitor(ICoreAudioSampleRatePropertyApi& property_api,
+                        uint32_t expected_sample_rate, uint32_t expected_buffer_frames,
+                        std::vector<AudioDeviceID> device_ids,
+                        std::vector<CoreAudioRouteStream> streams);
+  ~CoreAudioRouteMonitor();
+
+  CoreAudioRouteMonitor(const CoreAudioRouteMonitor&) = delete;
+  CoreAudioRouteMonitor& operator=(const CoreAudioRouteMonitor&) = delete;
+
+  /// Register alive/rate/buffer and stream-format listeners.
+  bool start() noexcept;
+  /// Remove every listener and close the render gate. Safe to repeat.
+  void stop() noexcept;
+
+  /// Close the render gate and request a control-thread verification.
+  void requestCheck() noexcept;
+  /// Wait for a property notification or requestCheck().
+  void waitForChange() noexcept;
+  /// Read and service route properties on the control thread.
+  CoreAudioRoutePollResult poll() noexcept;
+
+  /// Whether the render callback may pass audio to the host.
+  bool permitsRendering() const noexcept;
+
+private:
+  struct ListenerRegistration {
+    AudioObjectID object_id = 0;
+    AudioObjectPropertyAddress address{};
+  };
+
+  static OSStatus propertyChanged(AudioObjectID, UInt32, const AudioObjectPropertyAddress*,
+                                  void* context) noexcept;
+  static AudioObjectPropertyAddress deviceAddress(AudioObjectPropertySelector selector) noexcept;
+  static AudioObjectPropertyAddress streamAddress(AudioObjectPropertySelector selector) noexcept;
+  static bool formatsEqual(const AudioStreamBasicDescription& lhs,
+                           const AudioStreamBasicDescription& rhs) noexcept;
+  static bool readUInt32(ICoreAudioSampleRatePropertyApi& property_api, AudioObjectID object_id,
+                         const AudioObjectPropertyAddress& address, UInt32& value) noexcept;
+  static bool readFloat64(ICoreAudioSampleRatePropertyApi& property_api, AudioObjectID object_id,
+                          const AudioObjectPropertyAddress& address, Float64& value) noexcept;
+  static bool readFormat(ICoreAudioSampleRatePropertyApi& property_api, AudioObjectID object_id,
+                         const AudioObjectPropertyAddress& address,
+                         AudioStreamBasicDescription& value) noexcept;
+
+  static constexpr uint64_t kPendingBit = 1;
+  static constexpr uint64_t kStoppedBit = 2;
+  static constexpr uint64_t kGenerationIncrement = 4;
+
+  ICoreAudioSampleRatePropertyApi& property_api_;
+  const Float64 expected_sample_rate_;
+  const UInt32 expected_buffer_frames_;
+  std::vector<AudioDeviceID> device_ids_;
+  std::vector<CoreAudioRouteStream> streams_;
+  std::vector<ListenerRegistration> registrations_;
+  std::atomic<uint64_t> state_{kStoppedBit};
+  std::condition_variable pending_changed_;
+  std::mutex pending_mutex_;
+  size_t registered_count_{0};
+};
+
+} // namespace orpheus

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.cpp
@@ -23,6 +23,11 @@ OSStatus CoreAudioSampleRatePropertyApi::getPropertyData(AudioObjectID device_id
   return AudioObjectGetPropertyData(device_id, address, 0, nullptr, size, data);
 }
 
+OSStatus CoreAudioSampleRatePropertyApi::getPropertyDataSize(
+    AudioObjectID device_id, const AudioObjectPropertyAddress* address, UInt32* size) noexcept {
+  return AudioObjectGetPropertyDataSize(device_id, address, 0, nullptr, size);
+}
+
 OSStatus CoreAudioSampleRatePropertyApi::setPropertyData(AudioObjectID device_id,
                                                          const AudioObjectPropertyAddress* address,
                                                          UInt32 size, const void* data) noexcept {
@@ -89,9 +94,8 @@ void CoreAudioSampleRateMonitor::requestCheck() noexcept {
 
 void CoreAudioSampleRateMonitor::waitForChange() noexcept {
   std::unique_lock<std::mutex> lock(pending_mutex_);
-  pending_changed_.wait(lock, [this] {
-    return (state_.load(std::memory_order_acquire) & kPendingBit) != 0;
-  });
+  pending_changed_.wait(
+      lock, [this] { return (state_.load(std::memory_order_acquire) & kPendingBit) != 0; });
 }
 
 CoreAudioSampleRatePollResult CoreAudioSampleRateMonitor::poll() noexcept {
@@ -143,7 +147,6 @@ CoreAudioSampleRatePollResult CoreAudioSampleRateMonitor::poll() noexcept {
   return restored ? CoreAudioSampleRatePollResult::RateRestored
                   : CoreAudioSampleRatePollResult::NoChange;
 }
-
 
 bool CoreAudioSampleRateMonitor::permitsRendering() const noexcept {
   const uint64_t state = state_.load(std::memory_order_acquire);

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_monitor.h
@@ -36,6 +36,14 @@ public:
   virtual OSStatus getPropertyData(AudioObjectID device_id,
                                    const AudioObjectPropertyAddress* address, UInt32* size,
                                    void* data) noexcept = 0;
+  virtual OSStatus getPropertyDataSize(AudioObjectID device_id,
+                                       const AudioObjectPropertyAddress* address,
+                                       UInt32* size) noexcept {
+    (void)device_id;
+    (void)address;
+    (void)size;
+    return -1;
+  }
   virtual OSStatus setPropertyData(AudioObjectID device_id,
                                    const AudioObjectPropertyAddress* address, UInt32 size,
                                    const void* data) noexcept = 0;
@@ -55,6 +63,8 @@ public:
                            UInt32* size, void* data) noexcept override;
   OSStatus setPropertyData(AudioObjectID device_id, const AudioObjectPropertyAddress* address,
                            UInt32 size, const void* data) noexcept override;
+  OSStatus getPropertyDataSize(AudioObjectID device_id, const AudioObjectPropertyAddress* address,
+                               UInt32* size) noexcept override;
 };
 
 /// Watches every physical route which can invalidate the configured AU format.

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -28,12 +28,10 @@ namespace orpheus {
 
 namespace {
 
-/// Helper function to check if sample rate is supported
 bool isSampleRateSupported(const std::vector<uint32_t>& supported, uint32_t rate) {
   return std::find(supported.begin(), supported.end(), rate) != supported.end();
 }
 
-/// Helper function to check if buffer size is supported
 bool isBufferSizeSupported(const std::vector<uint32_t>& supported, uint32_t size) {
   return std::find(supported.begin(), supported.end(), size) != supported.end();
 }
@@ -79,7 +77,6 @@ public:
   explicit AudioDriverManager(DriverFactory factory);
   ~AudioDriverManager() override;
 
-  // IAudioDriverManager interface
   std::vector<AudioDeviceInfo> enumerateDevices() override;
   std::optional<AudioDeviceInfo> getDeviceInfo(const std::string& deviceId) override;
   SessionGraphError setActiveDevice(const std::string& deviceId, uint32_t sampleRate,
@@ -91,37 +88,24 @@ public:
   IAudioDriver* getActiveDriver() override;
 
 private:
-  /// Enumerate CoreAudio devices (macOS)
   std::vector<AudioDeviceInfo> enumerateCoreAudioDevices();
-
-  /// Enumerate Windows devices (WASAPI/ASIO) - stub for Phase 1
   std::vector<AudioDeviceInfo> enumerateWindowsDevices();
-
-  /// Enumerate Linux devices (ALSA) - stub for Phase 1
   std::vector<AudioDeviceInfo> enumerateLinuxDevices();
-
-  /// Get dummy driver device info (always available)
   AudioDeviceInfo getDummyDeviceInfo();
-
-  /// Create driver instance for device ID (default factory implementation).
   std::unique_ptr<IAudioDriver> createDriverForDevice(const std::string& deviceId);
+
   std::unique_ptr<IAudioDriver> m_activeDriver;
   DriverFactory m_driverFactory;
   std::string m_currentDeviceId;
   uint32_t m_currentSampleRate{48000};
   uint32_t m_currentBufferSize{512};
-
-  // Callback
   std::function<void()> m_deviceChangeCallback;
-
-  // Thread safety
   mutable std::mutex m_mutex;
 };
 
 AudioDriverManager::AudioDriverManager()
-    : m_driverFactory([this](const std::string& deviceId) {
-        return createDriverForDevice(deviceId);
-      }) {}
+    : m_driverFactory(
+          [this](const std::string& deviceId) { return createDriverForDevice(deviceId); }) {}
 
 AudioDriverManager::AudioDriverManager(DriverFactory factory)
     : m_driverFactory(std::move(factory)) {}
@@ -135,54 +119,42 @@ AudioDriverManager::~AudioDriverManager() {
 
 std::vector<AudioDeviceInfo> AudioDriverManager::enumerateDevices() {
   std::vector<AudioDeviceInfo> devices;
-
-  // Dummy driver is always first (for testing)
   devices.push_back(getDummyDeviceInfo());
 
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  // Enumerate CoreAudio devices (macOS)
-  auto coreAudioDevices = enumerateCoreAudioDevices();
-  devices.insert(devices.end(), coreAudioDevices.begin(), coreAudioDevices.end());
+  auto core_audio_devices = enumerateCoreAudioDevices();
+  devices.insert(devices.end(), core_audio_devices.begin(), core_audio_devices.end());
 #elif defined(_WIN32) && defined(ORPHEUS_ENABLE_WASAPI)
-  // Enumerate Windows devices (WASAPI/ASIO) - stub for Phase 1
-  auto windowsDevices = enumerateWindowsDevices();
-  devices.insert(devices.end(), windowsDevices.begin(), windowsDevices.end());
+  auto windows_devices = enumerateWindowsDevices();
+  devices.insert(devices.end(), windows_devices.begin(), windows_devices.end());
 #elif defined(__linux__)
-  // Enumerate Linux devices (ALSA) - stub for Phase 1
-  auto linuxDevices = enumerateLinuxDevices();
-  devices.insert(devices.end(), linuxDevices.begin(), linuxDevices.end());
+  auto linux_devices = enumerateLinuxDevices();
+  devices.insert(devices.end(), linux_devices.begin(), linux_devices.end());
 #endif
 
   return devices;
 }
 
-std::optional<AudioDeviceInfo> AudioDriverManager::getDeviceInfo(const std::string& deviceId) {
-  // Check if dummy driver
-  if (deviceId == "dummy") {
+std::optional<AudioDeviceInfo> AudioDriverManager::getDeviceInfo(const std::string& device_id) {
+  if (device_id == "dummy") {
     return getDummyDeviceInfo();
   }
 
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  // Check CoreAudio devices
-  auto devices = enumerateCoreAudioDevices();
-  for (const auto& device : devices) {
-    if (device.deviceId == deviceId) {
+  for (const auto& device : enumerateCoreAudioDevices()) {
+    if (device.deviceId == device_id) {
       return device;
     }
   }
 #elif defined(_WIN32) && defined(ORPHEUS_ENABLE_WASAPI)
-  // Check Windows devices (stub)
-  auto devices = enumerateWindowsDevices();
-  for (const auto& device : devices) {
-    if (device.deviceId == deviceId) {
+  for (const auto& device : enumerateWindowsDevices()) {
+    if (device.deviceId == device_id) {
       return device;
     }
   }
 #elif defined(__linux__)
-  // Check Linux devices (stub)
-  auto devices = enumerateLinuxDevices();
-  for (const auto& device : devices) {
-    if (device.deviceId == deviceId) {
+  for (const auto& device : enumerateLinuxDevices()) {
+    if (device.deviceId == device_id) {
       return device;
     }
   }
@@ -191,63 +163,55 @@ std::optional<AudioDeviceInfo> AudioDriverManager::getDeviceInfo(const std::stri
   return std::nullopt;
 }
 
-SessionGraphError AudioDriverManager::setActiveDevice(const std::string& deviceId,
-                                                      uint32_t sampleRate, uint32_t bufferSize) {
+SessionGraphError AudioDriverManager::setActiveDevice(const std::string& device_id,
+                                                      uint32_t sample_rate, uint32_t buffer_size) {
   std::function<void()> notification;
   std::unique_ptr<IAudioDriver> candidate;
-  std::string candidateDeviceId;
+  std::string candidate_device_id;
 
   {
     std::lock_guard<std::mutex> lock(m_mutex);
-
-    const auto deviceInfo = getDeviceInfo(deviceId);
-    if (!deviceInfo.has_value() ||
-        !isSampleRateSupported(deviceInfo->supportedSampleRates, sampleRate) ||
-        !isBufferSizeSupported(deviceInfo->supportedBufferSizes, bufferSize)) {
+    const auto device_info = getDeviceInfo(device_id);
+    if (!device_info.has_value() ||
+        !isSampleRateSupported(device_info->supportedSampleRates, sample_rate) ||
+        !isBufferSizeSupported(device_info->supportedBufferSizes, buffer_size)) {
       return SessionGraphError::InvalidParameter;
     }
 
     try {
-      // Copy all potentially-throwing commit inputs before stopping the old
-      // driver. Failure here leaves the current ownership and configuration
-      // untouched.
-      candidateDeviceId = deviceId;
+      candidate_device_id = device_id;
       notification = m_deviceChangeCallback;
 
       AudioDriverConfig config;
-      config.sample_rate = sampleRate;
-      config.buffer_size = static_cast<uint16_t>(bufferSize);
-      config.num_inputs = 0;  // Output only for now
-      config.num_outputs = 2; // Stereo output
+      config.sample_rate = sample_rate;
+      config.buffer_size = static_cast<uint16_t>(buffer_size);
+      config.num_inputs = 0;
+      config.num_outputs = 2;
       config.input_device_id = "";
-      config.output_device_id = (deviceId == "dummy") ? "" : deviceId;
-      config.device_name = (deviceId == "dummy") ? "" : deviceInfo->name;
+      config.output_device_id = (device_id == "dummy") ? "" : device_id;
+      config.device_name = (device_id == "dummy") ? "" : device_info->name;
 
-      // Candidate creation and initialization happen while the old driver is
-      // still owned and running.
       if (!m_driverFactory) {
         return SessionGraphError::InternalError;
       }
-      candidate = m_driverFactory(deviceId);
+      candidate = m_driverFactory(device_id);
       if (!candidate) {
         return SessionGraphError::InternalError;
       }
-      const SessionGraphError initResult = candidate->initialize(config);
-      if (initResult != SessionGraphError::OK) {
-        return initResult;
+      const SessionGraphError init_result = candidate->initialize(config);
+      if (init_result != SessionGraphError::OK) {
+        return init_result;
       }
 
       if (m_activeDriver) {
-        const SessionGraphError stopResult = m_activeDriver->stop();
-        if (stopResult != SessionGraphError::OK) {
-          return stopResult;
+        const SessionGraphError stop_result = m_activeDriver->stop();
+        if (stop_result != SessionGraphError::OK) {
+          return stop_result;
         }
       }
 
-      // Commit is non-throwing after the candidate has passed initialization
-      // and the old driver has stopped.
       m_activeDriver = std::move(candidate);
-      m_currentDeviceId.swap(candidateDeviceId);
+      m_currentDeviceId.swap(candidate_device_id);
       m_currentSampleRate = m_activeDriver->getConfig().sample_rate;
       m_currentBufferSize = m_activeDriver->getConfig().buffer_size;
     } catch (...) {
@@ -255,7 +219,6 @@ SessionGraphError AudioDriverManager::setActiveDevice(const std::string& deviceI
     }
   }
 
-  // Never call host code while the manager mutex is held.
   if (notification) {
     notification();
   }
@@ -306,152 +269,129 @@ AudioDeviceInfo AudioDriverManager::getDummyDeviceInfo() {
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
 std::vector<AudioDeviceInfo> AudioDriverManager::enumerateCoreAudioDevices() {
   std::vector<AudioDeviceInfo> devices;
-
-  // Query all audio devices
-  AudioObjectPropertyAddress propertyAddress = {kAudioHardwarePropertyDevices,
-                                                kAudioObjectPropertyScopeGlobal,
-                                                kAudioObjectPropertyElementMain};
-
-  UInt32 dataSize = 0;
-  OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0,
-                                                   nullptr, &dataSize);
-
-  if (status != noErr || dataSize == 0) {
+  AudioObjectPropertyAddress property_address = {kAudioHardwarePropertyDevices,
+                                                 kAudioObjectPropertyScopeGlobal,
+                                                 kAudioObjectPropertyElementMain};
+  UInt32 data_size = 0;
+  OSStatus status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &property_address, 0,
+                                                   nullptr, &data_size);
+  if (status != noErr || data_size == 0) {
     return devices;
   }
 
-  UInt32 deviceCount = dataSize / sizeof(AudioDeviceID);
-  std::vector<AudioDeviceID> deviceIDs(deviceCount);
-
-  status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr,
-                                      &dataSize, deviceIDs.data());
-
+  const UInt32 device_count = data_size / sizeof(AudioDeviceID);
+  std::vector<AudioDeviceID> device_ids(device_count);
+  status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &property_address, 0, nullptr,
+                                      &data_size, device_ids.data());
   if (status != noErr) {
     return devices;
   }
 
-  // Get default output device ID
-  AudioObjectPropertyAddress defaultDeviceAddress = {kAudioHardwarePropertyDefaultOutputDevice,
-                                                     kAudioObjectPropertyScopeGlobal,
-                                                     kAudioObjectPropertyElementMain};
+  AudioObjectPropertyAddress default_device_address = {kAudioHardwarePropertyDefaultOutputDevice,
+                                                       kAudioObjectPropertyScopeGlobal,
+                                                       kAudioObjectPropertyElementMain};
+  AudioDeviceID default_device_id = 0;
+  UInt32 default_device_size = sizeof(AudioDeviceID);
+  AudioObjectGetPropertyData(kAudioObjectSystemObject, &default_device_address, 0, nullptr,
+                             &default_device_size, &default_device_id);
 
-  AudioDeviceID defaultDeviceID = 0;
-  UInt32 defaultDeviceSize = sizeof(AudioDeviceID);
-  AudioObjectGetPropertyData(kAudioObjectSystemObject, &defaultDeviceAddress, 0, nullptr,
-                             &defaultDeviceSize, &defaultDeviceID);
+  for (AudioDeviceID device_id : device_ids) {
+    AudioObjectPropertyAddress name_address = {kAudioDevicePropertyDeviceNameCFString,
+                                               kAudioObjectPropertyScopeGlobal,
+                                               kAudioObjectPropertyElementMain};
+    CFStringRef cf_name = nullptr;
+    UInt32 name_size = sizeof(CFStringRef);
+    status = AudioObjectGetPropertyData(device_id, &name_address, 0, nullptr, &name_size, &cf_name);
+    if (status != noErr || !cf_name) {
+      continue;
+    }
 
-  // Enumerate each device
-  for (AudioDeviceID deviceID : deviceIDs) {
-    // Get device name
-    AudioObjectPropertyAddress nameAddress = {kAudioDevicePropertyDeviceNameCFString,
+    char name_buffer[256];
+    const Boolean name_success =
+        CFStringGetCString(cf_name, name_buffer, sizeof(name_buffer), kCFStringEncodingUTF8);
+    CFRelease(cf_name);
+    if (!name_success) {
+      continue;
+    }
+
+    AudioObjectPropertyAddress uid_address = {kAudioDevicePropertyDeviceUID,
                                               kAudioObjectPropertyScopeGlobal,
                                               kAudioObjectPropertyElementMain};
-
-    CFStringRef cfName = nullptr;
-    UInt32 nameSize = sizeof(CFStringRef);
-    status = AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nullptr, &nameSize, &cfName);
-
-    if (status != noErr || !cfName) {
+    CFStringRef cf_uid = nullptr;
+    UInt32 uid_size = sizeof(CFStringRef);
+    status = AudioObjectGetPropertyData(device_id, &uid_address, 0, nullptr, &uid_size, &cf_uid);
+    char uid_buffer[1024];
+    const Boolean has_uid =
+        status == noErr && cf_uid != nullptr &&
+        CFStringGetCString(cf_uid, uid_buffer, sizeof(uid_buffer), kCFStringEncodingUTF8);
+    if (cf_uid) {
+      CFRelease(cf_uid);
+    }
+    if (!has_uid) {
       continue;
     }
 
-    // Convert CFString to std::string
-    char nameBuffer[256];
-    Boolean success =
-        CFStringGetCString(cfName, nameBuffer, sizeof(nameBuffer), kCFStringEncodingUTF8);
-    CFRelease(cfName);
-
-    if (!success) {
+    AudioObjectPropertyAddress stream_config_address = {kAudioDevicePropertyStreamConfiguration,
+                                                        kAudioObjectPropertyScopeOutput,
+                                                        kAudioObjectPropertyElementMain};
+    UInt32 stream_config_size = 0;
+    status = AudioObjectGetPropertyDataSize(device_id, &stream_config_address, 0, nullptr,
+                                            &stream_config_size);
+    if (status != noErr || stream_config_size < sizeof(AudioBufferList)) {
       continue;
     }
-
-    AudioObjectPropertyAddress uidAddress = {kAudioDevicePropertyDeviceUID,
-                                             kAudioObjectPropertyScopeGlobal,
-                                             kAudioObjectPropertyElementMain};
-    CFStringRef cfUID = nullptr;
-    UInt32 uidSize = sizeof(CFStringRef);
-    status = AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nullptr, &uidSize, &cfUID);
-    char uidBuffer[1024];
-    const Boolean hasUID =
-        status == noErr && cfUID != nullptr &&
-        CFStringGetCString(cfUID, uidBuffer, sizeof(uidBuffer), kCFStringEncodingUTF8);
-    if (cfUID) {
-      CFRelease(cfUID);
-    }
-    if (!hasUID) {
-      continue;
-    }
-
-    // Check if device has output channels
-    AudioObjectPropertyAddress streamConfigAddress = {kAudioDevicePropertyStreamConfiguration,
-                                                      kAudioDevicePropertyScopeOutput,
-                                                      kAudioObjectPropertyElementMain};
-
-    AudioBufferList bufferList;
-    UInt32 bufferListSize = sizeof(bufferList);
-    status = AudioObjectGetPropertyData(deviceID, &streamConfigAddress, 0, nullptr, &bufferListSize,
-                                        &bufferList);
-
-    uint32_t totalChannels = 0;
+    std::vector<uint8_t> stream_config_storage(stream_config_size);
+    auto* buffer_list = reinterpret_cast<AudioBufferList*>(stream_config_storage.data());
+    status = AudioObjectGetPropertyData(device_id, &stream_config_address, 0, nullptr,
+                                        &stream_config_size, buffer_list);
+    uint32_t total_channels = 0;
     if (status == noErr) {
-      for (UInt32 i = 0; i < bufferList.mNumberBuffers; ++i) {
-        totalChannels += bufferList.mBuffers[i].mNumberChannels;
+      for (UInt32 index = 0; index < buffer_list->mNumberBuffers; ++index) {
+        total_channels += buffer_list->mBuffers[index].mNumberChannels;
       }
     }
-
-    // Skip devices with no output channels
-    if (totalChannels == 0) {
+    if (total_channels == 0) {
       continue;
     }
 
-    // Query supported sample rates
-    AudioObjectPropertyAddress sampleRateAddress = {kAudioDevicePropertyAvailableNominalSampleRates,
-                                                    kAudioObjectPropertyScopeGlobal,
-                                                    kAudioObjectPropertyElementMain};
-
-    UInt32 sampleRateSize = 0;
-    status =
-        AudioObjectGetPropertyDataSize(deviceID, &sampleRateAddress, 0, nullptr, &sampleRateSize);
-
-    std::vector<uint32_t> supportedSampleRates;
-    if (status == noErr && sampleRateSize > 0) {
-      UInt32 rangeCount = sampleRateSize / sizeof(AudioValueRange);
-      std::vector<AudioValueRange> ranges(rangeCount);
-      status = AudioObjectGetPropertyData(deviceID, &sampleRateAddress, 0, nullptr, &sampleRateSize,
-                                          ranges.data());
-
+    AudioObjectPropertyAddress sample_rate_address = {
+        kAudioDevicePropertyAvailableNominalSampleRates, kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain};
+    UInt32 sample_rate_size = 0;
+    status = AudioObjectGetPropertyDataSize(device_id, &sample_rate_address, 0, nullptr,
+                                            &sample_rate_size);
+    std::vector<uint32_t> supported_sample_rates;
+    if (status == noErr && sample_rate_size > 0) {
+      const UInt32 range_count = sample_rate_size / sizeof(AudioValueRange);
+      std::vector<AudioValueRange> ranges(range_count);
+      status = AudioObjectGetPropertyData(device_id, &sample_rate_address, 0, nullptr,
+                                          &sample_rate_size, ranges.data());
       if (status == noErr) {
-        // Common sample rates to check
-        std::vector<uint32_t> commonRates = {44100, 48000, 88200, 96000, 176400, 192000};
-        for (uint32_t rate : commonRates) {
+        const std::vector<uint32_t> common_rates = {44100, 48000, 88200, 96000, 176400, 192000};
+        for (uint32_t rate : common_rates) {
           for (const auto& range : ranges) {
             if (rate >= range.mMinimum && rate <= range.mMaximum) {
-              supportedSampleRates.push_back(rate);
+              supported_sample_rates.push_back(rate);
               break;
             }
           }
         }
       }
     }
-
-    // Fallback: If no sample rates found, assume common rates
-    if (supportedSampleRates.empty()) {
-      supportedSampleRates = {44100, 48000, 96000};
+    if (supported_sample_rates.empty()) {
+      supported_sample_rates = {44100, 48000, 96000};
     }
 
-    // CoreAudio endpoint IDs are persistent HAL UIDs, never session-scoped
-    // AudioDeviceID values or mutable display names.
-    AudioDeviceInfo deviceInfo;
-    deviceInfo.deviceId = uidBuffer;
-    deviceInfo.name = std::string(nameBuffer);
-    deviceInfo.driverType = "CoreAudio";
-    deviceInfo.minChannels = 2; // Stereo minimum
-    deviceInfo.maxChannels = totalChannels;
-    deviceInfo.supportedSampleRates = supportedSampleRates;
-    deviceInfo.supportedBufferSizes = {128, 256, 512, 1024, 2048}; // Common buffer sizes
-    deviceInfo.isDefaultDevice = (deviceID == defaultDeviceID);
-
-    devices.push_back(deviceInfo);
+    AudioDeviceInfo device_info;
+    device_info.deviceId = uid_buffer;
+    device_info.name = std::string(name_buffer);
+    device_info.driverType = "CoreAudio";
+    device_info.minChannels = 2;
+    device_info.maxChannels = total_channels;
+    device_info.supportedSampleRates = supported_sample_rates;
+    device_info.supportedBufferSizes = {128, 256, 512, 1024, 2048};
+    device_info.isDefaultDevice = device_id == default_device_id;
+    devices.push_back(std::move(device_info));
   }
 
   return devices;
@@ -461,16 +401,16 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateCoreAudioDevices() {
 #if defined(_WIN32) && defined(ORPHEUS_ENABLE_WASAPI)
 std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
   std::vector<AudioDeviceInfo> devices;
-  const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-  const bool uninitialize = SUCCEEDED(comResult);
-  if (FAILED(comResult) && comResult != RPC_E_CHANGED_MODE) {
+  const HRESULT com_result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  const bool uninitialize = SUCCEEDED(com_result);
+  if (FAILED(com_result) && com_result != RPC_E_CHANGED_MODE) {
     return devices;
   }
 
   IMMDeviceEnumerator* enumerator = nullptr;
   IMMDeviceCollection* collection = nullptr;
-  IMMDevice* defaultDevice = nullptr;
-  LPWSTR defaultId = nullptr;
+  IMMDevice* default_device = nullptr;
+  LPWSTR default_id = nullptr;
   if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                               __uuidof(IMMDeviceEnumerator),
                               reinterpret_cast<void**>(&enumerator))) ||
@@ -482,8 +422,8 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
     }
     return devices;
   }
-  if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &defaultDevice))) {
-    defaultDevice->GetId(&defaultId);
+  if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &default_device))) {
+    default_device->GetId(&default_id);
   }
 
   UINT count = 0;
@@ -493,7 +433,7 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
     IPropertyStore* properties = nullptr;
     IAudioClient* client = nullptr;
     LPWSTR id = nullptr;
-    WAVEFORMATEX* mixFormat = nullptr;
+    WAVEFORMATEX* mix_format = nullptr;
     PROPVARIANT name;
     PropVariantInit(&name);
 
@@ -502,10 +442,10 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
         FAILED(properties->GetValue(PKEY_Device_FriendlyName, &name)) ||
         FAILED(device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
                                 reinterpret_cast<void**>(&client))) ||
-        FAILED(client->GetMixFormat(&mixFormat)) || mixFormat == nullptr) {
+        FAILED(client->GetMixFormat(&mix_format)) || mix_format == nullptr) {
       PropVariantClear(&name);
       CoTaskMemFree(id);
-      CoTaskMemFree(mixFormat);
+      CoTaskMemFree(mix_format);
       releaseCom(client);
       releaseCom(properties);
       releaseCom(device);
@@ -513,58 +453,59 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
     }
 
     AudioDeviceInfo info{};
-    const std::string rawId = wideToUtf8(id);
-    info.deviceId = "wasapi:" + rawId;
-    info.name = name.vt == VT_LPWSTR ? wideToUtf8(name.pwszVal) : rawId;
+    const std::string raw_id = wideToUtf8(id);
+    info.deviceId = "wasapi:" + raw_id;
+    info.name = name.vt == VT_LPWSTR ? wideToUtf8(name.pwszVal) : raw_id;
     info.driverType = "WASAPI";
-    info.minChannels = mixFormat->nChannels;
-    info.maxChannels = mixFormat->nChannels;
-    info.isDefaultDevice = defaultId != nullptr && std::wcscmp(id, defaultId) == 0;
+    info.minChannels = mix_format->nChannels;
+    info.maxChannels = mix_format->nChannels;
+    info.isDefaultDevice = default_id != nullptr && std::wcscmp(id, default_id) == 0;
 
-    constexpr std::array<uint32_t, 6> sampleRates = {44100, 48000, 88200, 96000, 176400, 192000};
-    const size_t formatBytes = sizeof(WAVEFORMATEX) + mixFormat->cbSize;
-    for (const uint32_t sampleRate : sampleRates) {
-      std::vector<unsigned char> candidateBytes(reinterpret_cast<const unsigned char*>(mixFormat),
-                                                reinterpret_cast<const unsigned char*>(mixFormat) +
-                                                    formatBytes);
-      auto* candidate = reinterpret_cast<WAVEFORMATEX*>(candidateBytes.data());
-      candidate->nSamplesPerSec = sampleRate;
-      candidate->nAvgBytesPerSec = sampleRate * candidate->nBlockAlign;
+    constexpr std::array<uint32_t, 6> sample_rates = {44100, 48000, 88200, 96000, 176400, 192000};
+    const size_t format_bytes = sizeof(WAVEFORMATEX) + mix_format->cbSize;
+    for (const uint32_t sample_rate : sample_rates) {
+      std::vector<unsigned char> candidate_bytes(
+          reinterpret_cast<const unsigned char*>(mix_format),
+          reinterpret_cast<const unsigned char*>(mix_format) + format_bytes);
+      auto* candidate_format = reinterpret_cast<WAVEFORMATEX*>(candidate_bytes.data());
+      candidate_format->nSamplesPerSec = sample_rate;
+      candidate_format->nAvgBytesPerSec = sample_rate * candidate_format->nBlockAlign;
       WAVEFORMATEX* closest = nullptr;
-      if (client->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, candidate, &closest) == S_OK) {
-        appendUnique(info.supportedSampleRates, sampleRate);
+      if (client->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, candidate_format, &closest) == S_OK) {
+        appendUnique(info.supportedSampleRates, sample_rate);
       }
       CoTaskMemFree(closest);
     }
-    appendUnique(info.supportedSampleRates, mixFormat->nSamplesPerSec);
+    appendUnique(info.supportedSampleRates, mix_format->nSamplesPerSec);
     std::sort(info.supportedSampleRates.begin(), info.supportedSampleRates.end());
 
     IAudioClient3* client3 = nullptr;
     if (SUCCEEDED(
             client->QueryInterface(__uuidof(IAudioClient3), reinterpret_cast<void**>(&client3)))) {
-      UINT32 defaultFrames = 0;
-      UINT32 fundamentalFrames = 0;
-      UINT32 minimumFrames = 0;
-      UINT32 maximumFrames = 0;
-      if (SUCCEEDED(client3->GetSharedModeEnginePeriod(
-              mixFormat, &defaultFrames, &fundamentalFrames, &minimumFrames, &maximumFrames))) {
-        appendUnique(info.supportedBufferSizes, minimumFrames);
-        appendUnique(info.supportedBufferSizes, defaultFrames);
-        appendUnique(info.supportedBufferSizes, maximumFrames);
+      UINT32 default_frames = 0;
+      UINT32 fundamental_frames = 0;
+      UINT32 minimum_frames = 0;
+      UINT32 maximum_frames = 0;
+      if (SUCCEEDED(client3->GetSharedModeEnginePeriod(mix_format, &default_frames,
+                                                       &fundamental_frames, &minimum_frames,
+                                                       &maximum_frames))) {
+        appendUnique(info.supportedBufferSizes, minimum_frames);
+        appendUnique(info.supportedBufferSizes, default_frames);
+        appendUnique(info.supportedBufferSizes, maximum_frames);
       }
       releaseCom(client3);
     }
     if (info.supportedBufferSizes.empty()) {
-      REFERENCE_TIME defaultPeriod = 0;
-      REFERENCE_TIME minimumPeriod = 0;
-      if (SUCCEEDED(client->GetDevicePeriod(&defaultPeriod, &minimumPeriod))) {
+      REFERENCE_TIME default_period = 0;
+      REFERENCE_TIME minimum_period = 0;
+      if (SUCCEEDED(client->GetDevicePeriod(&default_period, &minimum_period))) {
         appendUnique(info.supportedBufferSizes,
                      static_cast<uint32_t>(
-                         (static_cast<uint64_t>(minimumPeriod) * mixFormat->nSamplesPerSec) /
+                         (static_cast<uint64_t>(minimum_period) * mix_format->nSamplesPerSec) /
                          10'000'000ULL));
         appendUnique(info.supportedBufferSizes,
                      static_cast<uint32_t>(
-                         (static_cast<uint64_t>(defaultPeriod) * mixFormat->nSamplesPerSec) /
+                         (static_cast<uint64_t>(default_period) * mix_format->nSamplesPerSec) /
                          10'000'000ULL));
       }
     }
@@ -573,14 +514,14 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
 
     PropVariantClear(&name);
     CoTaskMemFree(id);
-    CoTaskMemFree(mixFormat);
+    CoTaskMemFree(mix_format);
     releaseCom(client);
     releaseCom(properties);
     releaseCom(device);
   }
 
-  CoTaskMemFree(defaultId);
-  releaseCom(defaultDevice);
+  CoTaskMemFree(default_id);
+  releaseCom(default_device);
   releaseCom(collection);
   releaseCom(enumerator);
   if (uninitialize) {
@@ -592,33 +533,29 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateWindowsDevices() {
 
 #ifdef __linux__
 std::vector<AudioDeviceInfo> AudioDriverManager::enumerateLinuxDevices() {
-  // Phase 1: Stub implementation
-  // Phase 2: Implement ALSA device enumeration using snd_device_name_hint
   return {};
 }
 #endif
 
 std::unique_ptr<IAudioDriver>
-AudioDriverManager::createDriverForDevice(const std::string& deviceId) {
-  if (deviceId == "dummy") {
+AudioDriverManager::createDriverForDevice(const std::string& device_id) {
+  if (device_id == "dummy") {
     return createDummyAudioDriver();
   }
 
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  // CoreAudio device identifiers are bare persistent DeviceUID values.
-
   return createCoreAudioDriver();
 #endif
 
 #if defined(_WIN32) && defined(ORPHEUS_ENABLE_WASAPI)
-  if (deviceId.rfind("wasapi:", 0) == 0) {
+  if (device_id.rfind("wasapi:", 0) == 0) {
     return createWASAPIAudioDriver();
   }
 #endif
 
-  // Unsupported device type
   return nullptr;
 }
+
 namespace detail {
 
 std::unique_ptr<IAudioDriverManager> createAudioDriverManagerForTesting(
@@ -628,7 +565,6 @@ std::unique_ptr<IAudioDriverManager> createAudioDriverManagerForTesting(
 
 } // namespace detail
 
-// Factory function
 std::unique_ptr<IAudioDriverManager> createAudioDriverManager() {
   return std::make_unique<AudioDriverManager>();
 }

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -246,6 +246,7 @@ if(ORPHEUS_ENABLE_COREAUDIO AND ORPHEUS_ENABLE_EXTENDED_TESTS)
     add_executable(coreaudio_driver_test
         coreaudio_driver_test.cpp
         coreaudio_sample_rate_monitor_test.cpp
+        coreaudio_route_monitor_test.cpp
     )
 
     target_link_libraries(coreaudio_driver_test

--- a/tests/audio_io/coreaudio_driver_test.cpp
+++ b/tests/audio_io/coreaudio_driver_test.cpp
@@ -278,6 +278,7 @@ TEST_F(CoreAudioDriverTest, InitializeWithDefaultDevice) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   auto error = m_driver->initialize(config);
@@ -319,6 +320,7 @@ TEST_F(CoreAudioDriverTest, StartWithNullCallback) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -331,6 +333,7 @@ TEST_F(CoreAudioDriverTest, StartAndStop) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -361,6 +364,21 @@ TEST_F(CoreAudioDriverTest, PlaybackOnlyRouteStartsWithRuntimeRateMonitor) {
   EXPECT_EQ(m_driver->stop(), SessionGraphError::OK);
 }
 
+TEST_F(CoreAudioDriverTest, PlaybackOnlyRouteSupports256FrameBuffers) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 256;
+  config.num_inputs = 0;
+  config.num_outputs = 2;
+
+  ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
+  ASSERT_EQ(m_driver->getActiveRoute().actual_buffer_frames, 256u);
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_EQ(m_callback->getLastNumFrames(), 256u);
+  EXPECT_EQ(m_driver->stop(), SessionGraphError::OK);
+}
+
 TEST_F(CoreAudioDriverTest, StopWhenNotRunning) {
   auto error = m_driver->stop();
   EXPECT_EQ(error, SessionGraphError::OK);
@@ -370,6 +388,7 @@ TEST_F(CoreAudioDriverTest, CannotStartTwice) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -390,6 +409,7 @@ TEST_F(CoreAudioDriverTest, CallbackIsInvoked) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -412,6 +432,7 @@ TEST_F(CoreAudioDriverTest, PublishesCallbackActiveClipCount) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
   auto monitor = createStandalonePerformanceMonitor();
   m_callback->setActiveClipCount(7);
@@ -429,6 +450,7 @@ TEST_F(CoreAudioDriverTest, CallbackIsNotInvokedAfterStop) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -456,6 +478,7 @@ TEST_F(CoreAudioDriverTest, GetLatency) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -493,6 +516,7 @@ TEST_F(CoreAudioDriverTest, StereoConfiguration) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2; // Stereo
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -547,6 +571,7 @@ TEST_F(CoreAudioDriverTest, SampleRateAccuracy) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -593,6 +618,7 @@ TEST_F(CoreAudioDriverTest, ConcurrentInitialize) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   // Initialize, then try to initialize again while running
@@ -610,6 +636,7 @@ TEST_F(CoreAudioDriverTest, RapidStartStop) {
   AudioDriverConfig config;
   config.sample_rate = 48000;
   config.buffer_size = 512;
+  config.num_inputs = 0;
   config.num_outputs = 2;
 
   ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
@@ -902,6 +929,22 @@ TEST_F(CoreAudioDriverTest, RejectsInvalidDirectionalChannelMaps) {
   EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
 
   config.channel_map.output_channels = {std::numeric_limits<uint16_t>::max(), 1};
+  EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
+}
+
+TEST_F(CoreAudioDriverTest, RejectsImplicitMapBeyondPhysicalChannels) {
+  const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();
+  if (!endpoints.isValid()) {
+    GTEST_SKIP() << "A readable default output UID is unavailable";
+  }
+
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 512;
+  config.num_inputs = 0;
+  config.num_outputs = std::numeric_limits<uint16_t>::max();
+  config.output_device_id = endpoints.output_uid;
+
   EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
 }
 

--- a/tests/audio_io/coreaudio_driver_test.cpp
+++ b/tests/audio_io/coreaudio_driver_test.cpp
@@ -5,6 +5,7 @@
 
 #include "coreaudio/coreaudio_driver.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cmath>
@@ -881,6 +882,62 @@ EndpointPair getSameDeviceEndpointsForTest() {
 }
 
 } // namespace
+TEST_F(CoreAudioDriverTest, RejectsInvalidDirectionalChannelMaps) {
+  const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();
+  if (!endpoints.isValid()) {
+    GTEST_SKIP() << "A readable default output UID is unavailable";
+  }
+
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 512;
+  config.num_inputs = 0;
+  config.num_outputs = 2;
+  config.output_device_id = endpoints.output_uid;
+
+  config.channel_map.output_channels = {0};
+  EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
+
+  config.channel_map.output_channels = {0, 0};
+  EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
+
+  config.channel_map.output_channels = {std::numeric_limits<uint16_t>::max(), 1};
+  EXPECT_EQ(m_driver->initialize(config), SessionGraphError::InvalidParameter);
+}
+
+TEST_F(CoreAudioDriverTest, ExplicitOutputUidAndMapAreReflectedInActiveRoute) {
+  const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();
+  if (!endpoints.isValid()) {
+    GTEST_SKIP() << "Distinct default input/output devices with readable UIDs are unavailable";
+  }
+
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 512;
+  config.num_inputs = 0;
+  config.num_outputs = 2;
+  config.output_device_id = endpoints.output_uid;
+  config.channel_map.output_channels = {1, 0};
+
+  ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
+  const ActiveAudioRoute active_route = m_driver->getActiveRoute();
+  EXPECT_EQ(active_route.output_device_id, endpoints.output_uid);
+  EXPECT_TRUE(active_route.input_device_id.empty());
+  EXPECT_EQ(active_route.output_channels, config.channel_map.output_channels);
+  EXPECT_GE(active_route.available_output_channels, 2u);
+  EXPECT_EQ(active_route.requested_sample_rate, config.sample_rate);
+  EXPECT_EQ(active_route.actual_sample_rate, config.sample_rate);
+  EXPECT_EQ(active_route.actual_buffer_frames, config.buffer_size);
+  if (active_route.latency.complete) {
+    EXPECT_EQ(active_route.latency.capture_frames + active_route.latency.playback_frames +
+                  active_route.latency.processing_frames,
+              m_driver->getLatencySamples());
+  }
+
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+  EXPECT_EQ(m_driver->getTelemetry().route_outcome, AudioRouteRuntimeOutcome::Healthy);
+  ASSERT_EQ(m_driver->stop(), SessionGraphError::OK);
+}
 
 TEST_F(CoreAudioDriverTest, StopWaitsForAdmittedCallback) {
   const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();

--- a/tests/audio_io/coreaudio_route_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_route_monitor_test.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+#include <gtest/gtest.h>
+
+#include "coreaudio/coreaudio_route_monitor.h"
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <vector>
+
+#ifdef ORPHEUS_ENABLE_COREAUDIO
+
+namespace orpheus {
+namespace {
+
+struct PropertyKey {
+  AudioObjectID object_id;
+  AudioObjectPropertySelector selector;
+
+  bool operator<(const PropertyKey& other) const {
+    return std::tie(object_id, selector) < std::tie(other.object_id, other.selector);
+  }
+};
+
+class FakeCoreAudioRoutePropertyApi final : public ICoreAudioSampleRatePropertyApi {
+public:
+  struct Listener {
+    AudioObjectID object_id;
+    AudioObjectPropertyAddress address;
+    AudioObjectPropertyListenerProc callback;
+    void* context;
+  };
+
+  void setAlive(AudioObjectID object_id, UInt32 alive) {
+    uint32_values_[{object_id, kAudioDevicePropertyDeviceIsAlive}] = alive;
+  }
+
+  void setRate(AudioObjectID object_id, Float64 rate) {
+    float_values_[{object_id, kAudioDevicePropertyNominalSampleRate}] = rate;
+  }
+
+  void setBuffer(AudioObjectID object_id, UInt32 frames) {
+    uint32_values_[{object_id, kAudioDevicePropertyBufferFrameSize}] = frames;
+  }
+
+  void setFormat(AudioStreamID stream_id, AudioObjectPropertySelector selector,
+                 const AudioStreamBasicDescription& format) {
+    formats_[{stream_id, selector}] = format;
+  }
+
+  void allowRateWrites(bool allowed) {
+    allow_rate_writes_ = allowed;
+  }
+
+  void failQueries(bool failed) {
+    fail_queries_ = failed;
+  }
+
+  void notify(AudioObjectID object_id, AudioObjectPropertySelector selector) {
+    const AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    for (const Listener& listener : listeners_) {
+      if (listener.object_id == object_id && listener.address.mSelector == selector) {
+        ++callback_deliveries_;
+        listener.callback(object_id, 1, &address, listener.context);
+      }
+    }
+  }
+
+  size_t listenerCount() const {
+    return listeners_.size();
+  }
+
+  size_t callbackDeliveries() const {
+    return callback_deliveries_;
+  }
+
+  OSStatus addPropertyListener(AudioObjectID object_id, const AudioObjectPropertyAddress* address,
+                               AudioObjectPropertyListenerProc callback,
+                               void* context) noexcept override {
+    listeners_.push_back({object_id, *address, callback, context});
+    return noErr;
+  }
+
+  OSStatus removePropertyListener(AudioObjectID object_id,
+                                  const AudioObjectPropertyAddress* address,
+                                  AudioObjectPropertyListenerProc callback,
+                                  void* context) noexcept override {
+    const auto it =
+        std::find_if(listeners_.begin(), listeners_.end(), [&](const Listener& listener) {
+          return listener.object_id == object_id && listener.callback == callback &&
+                 listener.context == context && listener.address.mSelector == address->mSelector;
+        });
+    if (it == listeners_.end()) {
+      return -1;
+    }
+    listeners_.erase(it);
+    return noErr;
+  }
+
+  OSStatus getPropertyData(AudioObjectID object_id, const AudioObjectPropertyAddress* address,
+                           UInt32* size, void* data) noexcept override {
+    if (fail_queries_) {
+      return -1;
+    }
+    const PropertyKey key{object_id, address->mSelector};
+    if (address->mSelector == kAudioDevicePropertyDeviceIsAlive ||
+        address->mSelector == kAudioDevicePropertyBufferFrameSize) {
+      const auto it = uint32_values_.find(key);
+      if (it == uint32_values_.end() || *size < sizeof(UInt32)) {
+        return -1;
+      }
+      *size = sizeof(UInt32);
+      std::memcpy(data, &it->second, sizeof(UInt32));
+      return noErr;
+    }
+    if (address->mSelector == kAudioDevicePropertyNominalSampleRate) {
+      const auto it = float_values_.find(key);
+      if (it == float_values_.end() || *size < sizeof(Float64)) {
+        return -1;
+      }
+      *size = sizeof(Float64);
+      std::memcpy(data, &it->second, sizeof(Float64));
+      return noErr;
+    }
+
+    const auto it = formats_.find(key);
+    if (it == formats_.end() || *size < sizeof(AudioStreamBasicDescription)) {
+      return -1;
+    }
+    *size = sizeof(AudioStreamBasicDescription);
+    std::memcpy(data, &it->second, sizeof(AudioStreamBasicDescription));
+    return noErr;
+  }
+
+  OSStatus setPropertyData(AudioObjectID object_id, const AudioObjectPropertyAddress* address,
+                           UInt32 size, const void* data) noexcept override {
+    if (address->mSelector != kAudioDevicePropertyNominalSampleRate || !allow_rate_writes_ ||
+        size != sizeof(Float64)) {
+      return -1;
+    }
+    Float64 rate = 0.0;
+    std::memcpy(&rate, data, sizeof(rate));
+    float_values_[{object_id, address->mSelector}] = rate;
+    return noErr;
+  }
+
+private:
+  std::map<PropertyKey, UInt32> uint32_values_;
+  std::map<PropertyKey, Float64> float_values_;
+  std::map<PropertyKey, AudioStreamBasicDescription> formats_;
+  std::vector<Listener> listeners_;
+  bool allow_rate_writes_{true};
+  bool fail_queries_{false};
+  size_t callback_deliveries_{0};
+};
+
+AudioStreamBasicDescription testFormat() {
+  AudioStreamBasicDescription format{};
+  format.mSampleRate = 48000.0;
+  format.mFormatID = kAudioFormatLinearPCM;
+  format.mFormatFlags = kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked;
+  format.mBytesPerPacket = sizeof(float) * 2;
+  format.mFramesPerPacket = 1;
+  format.mBytesPerFrame = sizeof(float) * 2;
+  format.mChannelsPerFrame = 2;
+  format.mBitsPerChannel = 32;
+  return format;
+}
+
+class RouteMonitorFixture {
+public:
+  RouteMonitorFixture() : format(testFormat()), stream{100, format, format} {
+    api.setAlive(1, 1);
+    api.setRate(1, 48000.0);
+    api.setBuffer(1, 512);
+    api.setFormat(stream.stream_id, kAudioStreamPropertyVirtualFormat,
+                  stream.expected_virtual_format);
+    api.setFormat(stream.stream_id, kAudioStreamPropertyPhysicalFormat,
+                  stream.expected_physical_format);
+    monitor = std::make_unique<CoreAudioRouteMonitor>(
+        api, 48000, 512, std::vector<AudioDeviceID>{1}, std::vector<CoreAudioRouteStream>{stream});
+    initialization_ok = monitor->start();
+    if (initialization_ok) {
+      monitor->requestCheck();
+      initialization_ok =
+          monitor->poll() == CoreAudioRoutePollResult::NoChange && monitor->permitsRendering();
+    }
+  }
+
+  ~RouteMonitorFixture() {
+    if (monitor) {
+      monitor->stop();
+    }
+  }
+
+  FakeCoreAudioRoutePropertyApi api;
+  AudioStreamBasicDescription format;
+  CoreAudioRouteStream stream;
+  std::unique_ptr<CoreAudioRouteMonitor> monitor;
+  bool initialization_ok{false};
+};
+
+TEST(CoreAudioRouteMonitorTest, RegistersAllRoutePropertiesAndCleansUp) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  EXPECT_EQ(fixture.api.listenerCount(), 5u);
+  EXPECT_EQ(fixture.api.callbackDeliveries(), 0u);
+  fixture.monitor->stop();
+  EXPECT_EQ(fixture.api.listenerCount(), 0u);
+}
+
+TEST(CoreAudioRouteMonitorTest, AliveLossClosesGateAndReportsUnavailable) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  fixture.api.setAlive(1, 0);
+  fixture.api.notify(1, kAudioDevicePropertyDeviceIsAlive);
+
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::RouteUnavailable);
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, RateChangeRestoresBeforeReopeningGate) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  fixture.api.setRate(1, 44100.0);
+  fixture.api.notify(1, kAudioDevicePropertyNominalSampleRate);
+
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::RateRestored);
+  EXPECT_TRUE(fixture.monitor->permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, RefusedRateRestoreRequiresReinitialization) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  fixture.api.allowRateWrites(false);
+  fixture.api.setRate(1, 44100.0);
+  fixture.api.notify(1, kAudioDevicePropertyNominalSampleRate);
+
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::ReinitializationRequired);
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, StreamFormatChangeReportsFormatChanged) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  auto changed = fixture.format;
+  changed.mChannelsPerFrame = 1;
+  fixture.api.setFormat(fixture.stream.stream_id, kAudioStreamPropertyVirtualFormat, changed);
+  fixture.api.notify(fixture.stream.stream_id, kAudioStreamPropertyVirtualFormat);
+
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::FormatChanged);
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, BufferChangeRequiresReinitialization) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  fixture.api.setBuffer(1, 256);
+  fixture.api.notify(1, kAudioDevicePropertyBufferFrameSize);
+
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::ReinitializationRequired);
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, PropertyReadFailureReportsBackendFailure) {
+  RouteMonitorFixture fixture;
+  ASSERT_TRUE(fixture.initialization_ok);
+  fixture.api.failQueries(true);
+  fixture.api.notify(1, kAudioDevicePropertyDeviceIsAlive);
+
+  EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::BackendFailure);
+  EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+
+} // namespace
+} // namespace orpheus
+
+#endif // ORPHEUS_ENABLE_COREAUDIO

--- a/tests/audio_io/dummy_driver_test.cpp
+++ b/tests/audio_io/dummy_driver_test.cpp
@@ -128,6 +128,26 @@ TEST_F(DummyDriverTest, ReportsCapabilities) {
   EXPECT_FALSE(caps.reports_hardware_latency);
 }
 
+TEST_F(DummyDriverTest, RetainsRequestedChannelMapWithoutFabricatingPhysicalRoute) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 128;
+  config.num_outputs = 3;
+  config.channel_map.output_channels = {2, 0, 1};
+
+  ASSERT_EQ(m_driver->initialize(config), SessionGraphError::OK);
+  EXPECT_EQ(m_driver->getConfig().channel_map.output_channels, config.channel_map.output_channels);
+
+  const auto active_route = m_driver->getActiveRoute();
+  EXPECT_TRUE(active_route.input_device_id.empty());
+  EXPECT_TRUE(active_route.output_device_id.empty());
+  EXPECT_TRUE(active_route.input_channels.empty());
+  EXPECT_TRUE(active_route.output_channels.empty());
+  EXPECT_FALSE(active_route.input_alive);
+  EXPECT_FALSE(active_route.output_alive);
+  EXPECT_FALSE(active_route.latency.complete);
+}
+
 TEST_F(DummyDriverTest, InitializeRejectsInvalidConfig) {
   AudioDriverConfig config;
   config.sample_rate = 0; // Invalid

--- a/tests/package_runtime_consumer/CMakeLists.txt
+++ b/tests/package_runtime_consumer/CMakeLists.txt
@@ -11,7 +11,10 @@ find_package(OrpheusSDK ${ORPHEUS_REQUIRED_VERSION} CONFIG REQUIRED)
 
 add_executable(orpheus_package_runtime_consumer main.cpp)
 target_compile_features(orpheus_package_runtime_consumer PRIVATE cxx_std_20)
-target_link_libraries(orpheus_package_runtime_consumer PRIVATE Orpheus::transport)
+target_link_libraries(orpheus_package_runtime_consumer PRIVATE
+  Orpheus::transport
+  Orpheus::audio_io
+  Orpheus::audio_driver_manager)
 
 enable_testing()
 add_test(NAME orpheus_package_runtime_consumer COMMAND orpheus_package_runtime_consumer)

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
+#include <orpheus/audio_driver.h>
+#include <orpheus/audio_driver_manager.h>
 #include <orpheus/routing_matrix.h>
 #include <orpheus/transport_controller.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -31,6 +34,42 @@ int main() {
   constexpr uint32_t kSampleRate = 48000;
   constexpr orpheus::ClipHandle kHandle = 17;
   constexpr size_t kFrames = 64;
+
+  auto outputDriver = orpheus::createDummyAudioDriver();
+  if (!outputDriver) {
+    return 11;
+  }
+  orpheus::AudioDriverConfig outputConfig;
+  outputConfig.sample_rate = kSampleRate;
+  outputConfig.buffer_size = 128;
+  outputConfig.num_inputs = 0;
+  outputConfig.num_outputs = 2;
+  outputConfig.output_device_id = "dummy";
+  outputConfig.channel_map.output_channels = {1, 0};
+  if (outputDriver->initialize(outputConfig) != orpheus::SessionGraphError::OK) {
+    return 12;
+  }
+  if (outputDriver->getConfig().channel_map.output_channels !=
+      outputConfig.channel_map.output_channels) {
+    return 13;
+  }
+  const auto activeRoute = outputDriver->getActiveRoute();
+  if (!activeRoute.input_device_id.empty() || !activeRoute.output_device_id.empty() ||
+      activeRoute.input_alive || activeRoute.output_alive || !activeRoute.input_channels.empty() ||
+      !activeRoute.output_channels.empty() || activeRoute.latency.complete) {
+    return 14;
+  }
+
+  auto manager = orpheus::createAudioDriverManager();
+  if (!manager) {
+    return 15;
+  }
+  const auto devices = manager->enumerateDevices();
+  const auto dummy = std::find_if(devices.begin(), devices.end(),
+                                  [](const auto& device) { return device.deviceId == "dummy"; });
+  if (dummy == devices.end() || dummy->maxChannels != 2) {
+    return 16;
+  }
 
   auto transport = orpheus::createTransportController(
       nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});


### PR DESCRIPTION
## Summary\n- add independent input/output CoreAudio endpoint resolution with direction validation\n- expose channel maps, active-route facts, split latency, and explicit runtime outcomes\n- add property-injected route monitoring, dummy/package consumer coverage, and update the ORP171 FourTrack handoff\n\n## Verification\n- cmake --build build-sdk-fast --parallel 8\n- ctest --test-dir build-sdk-fast --output-on-failure: 75 enabled tests passed; abi_link remains intentionally disabled\n- focused: coreaudio_driver_test 47 passed, dummy_driver_test 15 passed, driver_manager_test 20 passed\n\nWindows-only WASAPI compilation and execution remain unverified on this macOS host. FourTrack and Clip Composer should consume the released immutable SDK revision, not this branch worktree.