### PR TITLE
feat(coreaudio): expose playback endpoint capabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,8 +69,7 @@ graph TD
 - **Shared app packages** (`packages/`) – Active C++/JUCE building blocks for
   downstream applications: `occ-app-platform` (session recovery, preferences,
   health telemetry) and `shmui-juce` (JUCE UI components). Not part of the
-  core SDK libraries. (The former TypeScript driver layer is archived — see
-  `docs/orp/_process/archive/DECISION_PACKAGES.md`.)
+  core SDK libraries. The former TypeScript driver layer is archived.
 - **In-tree apps** (`apps/`) – `wave-finder` (app-platform smoke-test shell)
   and `juce-demo-host` (JUCE demo host). Production applications — Clip
   Composer, FourTrack, FreqFinder — live in their own repositories and consume
@@ -202,9 +201,8 @@ of the core SDK libraries — the core stays UI-free.
 The former JavaScript/TypeScript driver packages (`@orpheus/engine-service`,
 `@orpheus/engine-native`, `@orpheus/engine-wasm`, `@orpheus/client`) and the
 JSON contract system built for them (ORP068 Phases 1-2) were **archived** when
-the project refocused on the C++ SDK. They are not in the tree. See
-[`docs/orp/_process/archive/DECISION_PACKAGES.md`](docs/orp/_process/archive/DECISION_PACKAGES.md)
-for the rationale and `docs/orp/` history (ORP068) for the original design.
+the project refocused on the C++ SDK. They are not in the tree; the current
+documentation index records the remaining SDK contracts.
 
 ---
 
@@ -754,10 +752,10 @@ Orpheus SDK has been extended with 7 major features for professional workflows:
 - [README.md](README.md) – Quick start guide (build SDK in <10 minutes)
 - [docs/orp/INDEX.md](docs/orp/INDEX.md) – current and historical documentation index
 
-### Implementation Plans
+### Current Contracts
 
-- [ORP132 – Master Sprint Index](docs/orp/ORP132%20SDK%20Hardening%20and%20Platform%20Roadmap%20-%20Master%20Sprint%20Index.md) – Current hardening program (ORP133–ORP136)
-- [ORP068 - SDK Integration Plan v2.0](<docs/orp/ORP068%20Implementation%20Plan%20(v2.0).md>) – Historical driver architecture (Phases 0-4)
+- [ORP171 – CoreAudio Route-State Contract Handoff](docs/orp/ORP171%20FourTrack%20Multi-Device%20CoreAudio%20Route-State%20Contract%20Handoff.md) – directional CoreAudio route contract and downstream handoff.
+- [docs/orp/INDEX.md](docs/orp/INDEX.md) – current SDK contract records.
 
 ### Application Documentation
 
@@ -773,4 +771,4 @@ Orpheus SDK has been extended with 7 major features for professional workflows:
 **Document Status:** Authoritative
 **Maintained By:** SDK Core Team
 **Next Review:** After v1.0.0 stable release
-**Last Updated:** November 9, 2025
+**Last Updated:** August 4, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controller teardown. Resampled reader failures propagate rather than becoming
   EOF silence.
 
+
+### Added
+
+- Direction-aware CoreAudio endpoint discovery and strict playback-only route
+  initialization. Public route snapshots now report selected and active
+  endpoints, channel maps, actual format, latency terms, and distinct input or
+  output endpoint loss. Endpoint-change notifications include default input and
+  output changes, run on a control worker, and are safe to replace, unregister,
+  or destroy from their own callback.
+
 ### Changed
 
 - Synchronized `packages/shmui-juce` to ShmUI `6129e3cb73f32922e588aa647bbafb87fccdc324`

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ ctest --test-dir build --output-on-failure
 
 - **Review current records:** See [`docs/orp/INDEX.md`](docs/orp/INDEX.md).
 - **View Changelog:** See [`CHANGELOG.md`](CHANGELOG.md)
-- **Review reliability completion:** See [`docs/orp/ORP143 Reliability and Adoption Sprint Completion and Child-App Handoff.md`](docs/orp/ORP143%20Reliability%20and%20Adoption%20Sprint%20Completion%20and%20Child-App%20Handoff.md)
-- **Plan child-app adoption:** See [`docs/orp/ORP142 Downstream Consumer Adoption Notes.md`](docs/orp/ORP142%20Downstream%20Consumer%20Adoption%20Notes.md)
 - **Review suite application checkpoint:** See [`ORP166`](docs/orp/ORP166%20Orpheus%20Suite%20Application%20Launch%20and%20Icon%20Checkpoint.md) for synchronized repository state, application launch paths, and icon verification.
 
 
@@ -58,45 +56,11 @@ target_link_libraries(my_app PRIVATE Orpheus::diagnostics Orpheus::audio_utils)
   `trigger_voice.h`, the allocation-free one-shot voice utility used by
   host-owned sequencers and generated tracks.
 
-## Reliability and Adoption Completion
+## CoreAudio Route Reliability
 
-ORP141 is implemented on `main`. The durable delivery and child-team handoff is
-[`ORP143`](docs/orp/ORP143%20Reliability%20and%20Adoption%20Sprint%20Completion%20and%20Child-App%20Handoff.md).
-The final implementation verification passed 143/143 configured CTest contracts,
-the installed `find_package` consumer, and the strict in-repository realtime
-audit.
-
-New workflow contracts include stable-ID session transactions and bounded
-message-thread telemetry:
-
-```cpp
-orpheus::core::SessionGraph graph;
-auto transaction = graph.begin_transaction();
-auto trackId = graph.create_track("Program");
-auto clipId = graph.create_clip(
-    trackId,
-    "Intro",
-    orpheus::TimeRange::fromStartLength(
-        orpheus::TimePoint::fromSamples(0), 48000));
-auto change = transaction.commit();
-
-auto transport = orpheus::createTransportController(&graph, 48000);
-auto* telemetry = transport->getRealtimeTelemetry();
-telemetry->setDecimationBlocks(8);
-
-orpheus::RealtimeTelemetrySnapshot snapshot;
-while (telemetry->tryRead(snapshot)) {
-  // Message-thread work only: presentation, history, or app-owned analysis.
-}
-```
-
-The SDK telemetry bridge is fixed-capacity and presentation-neutral. FFTs,
-histories, smoothing, analyzer selection, musical policy, and UI view models
-remain application state.
-
-Audio I/O selection is direction-specific. CoreAudio identifiers are persistent
-HAL DeviceUID values; an empty field alone requests that direction's current
-system default:
+CoreAudio I/O selection is direction-specific. Input and output identifiers are
+persistent HAL DeviceUID values; an empty identifier selects only that
+direction's current system default.
 
 ```cpp
 orpheus::AudioDriverConfig audio;
@@ -109,32 +73,20 @@ auto driver = orpheus::createCoreAudioDriver();
 if (driver->initialize(audio) == orpheus::SessionGraphError::OK) {
   const auto io = driver->getTelemetry();
   // io.input_render_failures distinguishes capture failure from real silence.
-  // A runtime nominal-rate change is never rendered silently. CoreAudio first
-  // reasserts audio.sample_rate; a terminal outcome has stopped the driver and
-  // requires an explicit initialize() with the host's chosen configuration.
-  if (io.runtime_outcome ==
-      orpheus::AudioDriverRuntimeOutcome::SampleRateReinitializationRequired) {
-    // Reconfigure the host deliberately; endpoint IDs remain unchanged.
-  }
+  // Terminal route outcomes stop the driver and require explicit reinitialization.
 }
 ```
 
 Distinct CoreAudio endpoints use a driver-owned private aggregate. Unknown or
 direction-incompatible UIDs fail with `InvalidParameter`; they never fall back
-to another device. `getTelemetry()` is available through `IAudioDriver`, so
-factory consumers do not downcast to platform implementations.
+to another endpoint. During an active route, listeners close the render gate
+and a control worker verifies the physical devices and format. A refused rate
+restore, endpoint loss, or format change stops rendering; the driver never
+silently changes an endpoint or rate.
 
-During an active CoreAudio route, the driver listens to the aggregate wrapper
-and each physical input/output endpoint's nominal sample rate. A notification
-closes the render gate, then a control worker reasserts the configured rate. If
-the device refuses or cannot be queried, rendering stops and
-`runtime_outcome` reports the exact terminal condition; the driver never
-silently substitutes another endpoint or rate.
-
-Child-app teams should use
-[`ORP143 §5`](docs/orp/ORP143%20Reliability%20and%20Adoption%20Sprint%20Completion%20and%20Child-App%20Handoff.md#5-child-app-handoff-matrix)
-for Clip Composer, FreqFinder, FourTrack, and ShmUI adoption checklists. No child
-application was migrated by the SDK sprint.
+See the [contract index](docs/orp/INDEX.md) and
+[`ORP171`](docs/orp/ORP171%20FourTrack%20Multi-Device%20CoreAudio%20Route-State%20Contract%20Handoff.md)
+for the current CoreAudio route-state delivery record.
 
 Windows/WASAPI is not yet a release-supported backend. The implementation is
 present, but hosted Windows package/ABI proof and a real-device acceptance
@@ -147,7 +99,7 @@ artifact remain required; see the [support posture in `AGENTS.md`](AGENTS.md#sou
 - [Feature Highlights](#feature-highlights)
 - [Core Capabilities](#core-capabilities)
 - [Repository Layout](#repository-layout)
-- [Reliability and Adoption Completion](#reliability-and-adoption-completion)
+- [CoreAudio Route Reliability](#coreaudio-route-reliability)
 - [Supported Platforms](#supported-platforms)
 - [Getting Started](#getting-started)
   - [C++ Toolchain](#c-toolchain)
@@ -243,6 +195,46 @@ routing->setClipOutputBus(clipHandle, 2);  // Route to channels 5-6
 
 **See:** [`CHANGELOG.md`](CHANGELOG.md) for full release notes
 **Current contracts:** See [`docs/orp/INDEX.md`](docs/orp/INDEX.md); release notes remain in [`CHANGELOG.md`](CHANGELOG.md).
+
+### Directional endpoint discovery and playback routing
+
+`IAudioDriverManager::enumerateEndpointCapabilities()` returns persistent
+backend device IDs, independent input/output channel descriptors, current
+format facts, and the directional system-default flags. Use those IDs for
+route selection; display names are not stable identifiers.
+
+```cpp
+auto manager = createAudioDriverManager();
+for (const auto& endpoint : manager->enumerateEndpointCapabilities()) {
+  if (endpoint.supports_output && endpoint.is_default_output) {
+    auto driver = createCoreAudioDriver();
+    AudioOutputRouteRequest route{
+        .output_device_id = endpoint.device_id,
+        .output_channel_map = {0, 1},
+        .requested_sample_rate = 48000,
+        .requested_buffer_size = 512,
+    };
+    if (driver->initializeAudioOutput(route) == SessionGraphError::OK) {
+      // Start the playback-only driver with the application callback.
+    }
+  }
+}
+```
+
+An empty `AudioOutputRouteRequest::output_device_id` follows the current
+default output. A non-empty ID is strict: unsupported, unavailable, or
+directionally incompatible IDs fail initialization rather than falling back.
+`getAudioIoRouteState()` exposes the selected IDs, active physical route,
+channel maps, actual format, latency terms, and a detail string. Poll it on a
+control thread after an I/O failure; `InputUnavailable` and
+`OutputUnavailable` identify a distinct failed duplex endpoint.
+
+`setEndpointChangeCallback()` is notification-only. On CoreAudio it runs on an
+internal control worker, never the realtime audio callback or the CoreAudio
+property-listener thread. The callback may replace or unregister itself, or
+destroy the manager. It must arrange application-thread re-enumeration and
+must not perform realtime work.
+
 
 ---
 
@@ -340,9 +332,8 @@ The Orpheus SDK provides deterministic session/transport control for professiona
   meters, transport widgets) consumed by downstream JUCE apps; not part of the
   core SDK libraries.
 - The former **TypeScript** packages (`@orpheus/engine-*`, `@orpheus/client`,
-  `@orpheus/shmui`) are **archived** — see
-  [`docs/orp/_process/archive/DECISION_PACKAGES.md`](docs/orp/_process/archive/DECISION_PACKAGES.md)
-  for the rationale (C++ SDK focus).
+  `@orpheus/shmui`) are **archived** as part of the C++ SDK focus; they are not
+  part of this repository.
 
 ## Supported Platforms
 
@@ -398,9 +389,8 @@ configuration:
   cmake --build build --target orpheus_demo_host_app
   ```
 
-- **Host integrations** – toggle adapters via CMake cache entries. See
-  [`docs/orp/_process/archive/ADAPTERS.md`](docs/orp/_process/archive/ADAPTERS.md)
-  for the full list of flags and host requirements.
+- **Host integrations** – toggle adapters with the documented CMake cache
+  entries in the top-level `CMakeLists.txt`.
 
 ### Running Tests
 
@@ -596,8 +586,7 @@ Documentation follows workspace pattern `docs/<prefix>/<PREFIX><NUM>.(md|mdx)` �
 
 ### Reference Documentation
 
-- [`docs/orp/_process/archive/ADAPTERS.md`](docs/orp/_process/archive/ADAPTERS.md) – adapter catalog, build flags, and
-  host-specific notes.
+- [`CMakeLists.txt`](CMakeLists.txt) – adapter and optional-target build flags.
 - [`ROADMAP.md`](ROADMAP.md) – planned milestones and long-term initiatives.
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) – design considerations for the modular
   core.

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -7,125 +7,30 @@ Project documentation index for orpheus-sdk.
 - [[README]]
 
 
-## Recent Documents
-- [[ORP172 Digital Audio Routing Practice Research]] — 2026 reconnaissance of AES67, ST 2110, Dante, NMOS IS-04/05/08, PTP, and portable routing/control-plane vocabulary (2026-08-04)
-- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] — implemented SDK route-state contract; release and downstream adoption pending (2026-08-04)
-- [[ORP168 Streaming Seek Priming and Underrun Classification]] — corrected
-  streaming Start/refire command-prime leasing and effective pre-trim-IN seek
-  priming; rendered realtime regression evidence (2026-08-01)
+## Current Records
 
-- [[ORP166 Orpheus Suite Application Launch and Icon Checkpoint]] — synchronized
-  Cloudkicker suite baseline; merged application icons; verified Clip Composer,
-  FreqFinder, and FourTrack launch paths (2026-07-28)
+- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] —
+  directional route-state contract and downstream handoff (2026-08-04)
+- [[ORP169 Orpheus Suite Remote Synchronization and PR Merge]] — repository
+  synchronization and merge checkpoint (2026-08-04)
+- [[ORP168 Streaming Seek Priming and Underrun Classification]] — streaming
+  command-prime and trim-aware seek regression record (2026-08-01)
+- [[ORP166 Orpheus Suite Application Launch and Icon Checkpoint]] — suite
+  application launch and icon verification (2026-07-28)
+- [[ORP162 CoreAudio Capture Channel Mapping and Downstream Pin Handoff]] —
+  capture-channel mapping contract (2026-07-21)
+- [[ORP128 CoreAudio Runtime Sample-Rate Resilience]] — CoreAudio nominal-rate
+  handling contract
 
+## Records
 
-- [[ORP162 CoreAudio Capture Channel Mapping and Downstream Pin Handoff]]
-- [[ORP161 FourTrack Live Output Handoff Assessment]]
-- [[ORP160 Master Tape Varispeed Primitive]]
-- [[ORP159 Suite Synchronization and Integration Gate]]
-- [[ORP158 Installed ShmUI-JUCE Package Qualification]]
-- [[ORP157 Suite Coherence and Package Consumer Mission]]
-- [[ORP157 Bounded Per-Clip DSP and Output Telemetry]]
-- [[ORP156 ORP155 Implementation Handoff]]
-- [[ORP155 FourTrack Recorder Adoption Friction - CoreAudio and Routing Contracts]]
-- [[ORP154 Sequencer Trigger Voice Primitive]]
-- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
-- [[ORP152 Clip Playback Controls]]
-- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
-- [[ORP150 Atomic Clip-Group Choke Admission]]
-- [[ORP126 Codex Integration Audit and Checkpoint]]
-- [[ORP125 Architecture Refactor Sprint - Completion Report]]
-- [[ORP124 Architecture Cross-Reference Matrix]]
-- [[ORP123 Wireframes and Documentation Update]]
-- [[ORP082 Loudness Metering and LUFS Implementation Note]]
-
-## All Documents
-
-- [[ORP068 Implementation Plan (v2.0)]]
-- [[ORP082]]
-- [[ORP084]]
-- [[ORP085]]
-- [[ORP086 Feature Request - Seamless Clip Restart API]]
-- [[ORP087 Seamless Clip Restart API — Sprint Completion Report]]
-- [[ORP088 Edit Law Enforcement & Position Tracking]]
-- [[ORP089 Sprint Completion Report]]
-- [[ORP090 Sprint Summary + Loop Mode Verification]]
-- [[ORP091 SDK OUT Point Enforcement Not Working]]
-- [[ORP092 Fix - Non-Loop Clips Illegal Loop-to-Zero Bug]]
-- [[ORP093 Sprint - Trim Point Boundary Enforcement]]
-- [[ORP094 Fix - Trim Point Boundary Enforcement]]
-- [[ORP095 Hot Buffer Size Change Implementation]]
-- [[ORP096 Fix Use-After-Free Bug]]
-- [[ORP097 SDK Transport - Fade Bug Fixes for OCC v020]]
-- [[ORP098 Shmui Rebuild]]
-- [[ORP099 SDK Track Phase 4 Completion and Testing]]
-- [[ORP100 Unit Tests Implementation Report]]
-- [[ORP101 Phase 4 Completion Report]]
-- [[ORP102 Repository Analysis and Sprint Recommendations]]
-- [[ORP103 Build System Analysis and Optimization Recommendations]]
-- [[ORP104 Codebase Optimization and Safety Audit]]
-- [[ORP105 CI Infrastructure Diagnosis]]
-- [[ORP106 Wave Finder Architecture Assessment - JUCE vs SDK Integration]]
-- [[ORP108 Network Audio Claims Cleanup]]
-- [[ORP109 SDK Feature Roadmap for Clip Composer Integration]]
-- [[ORP110A App-Level Integration Report]]
-- [[ORP110B Performance Monitor API Completion Report]]
-- [[ORP111 SDK Transport Enhancement - Clip Composer Edit Dialog Support]]
-- [[ORP112 SDK Transport Features Verification - ORP111 Complete]]
-- [[ORP113 Documentation Alignment Audit - ORP and OCC Planning vs Execution Analysis]]
-- [[ORP114 Critical Gain Staging Bug Investigation and Fix]]
-- [[ORP115 Thread-Safe Metadata Updates]]
-- [[ORP116 Bloat Remediation Sprint]]
-- [[ORP117 Routing Matrix Technical Explainer]]
-- [[ORP118 Multi-Voice Architecture and Audio Summing Topology]]
-- [[ORP138 Modernization Audit]]
-- [[ORP139 Audio Architecture Audit Findings]]
-- [[ORP119 Shmui Integration Strategy]]
-- [[ORP120 Codebase State Assessment - SDK, OCC, and Shmui Integration]]
-- [[ORP121 Audio Backend Refactoring Master Plan]]
-- [[ORP122 Phase 4 Quality Improvements Implementation Report]]
-- [[ORP123 Wireframes and Documentation Update]]
-- [[ORP124 Architecture Cross-Reference Matrix]]
-- [[ORP125 Architecture Refactor Sprint - Completion Report]]
-- [[ORP126 Codex Integration Audit and Checkpoint]]
-- [[ORP140 FreqFinder Architecture Revision - SDK Integration Confirmed]]
-- [[ORP150 Atomic Clip-Group Choke Admission]]
-- [[ORP151 Callback Loss Telemetry and Active Voice Reconciliation]]
-- [[ORP152 Clip Playback Controls]]
-- [[ORP153 Clip Composer Routing State Snapshot Adoption Handoff]]
-- [[ORP154 Sequencer Trigger Voice Primitive]]
-- [[ORP155 FourTrack Recorder Adoption Friction - CoreAudio and Routing Contracts]]
-- [[ORP156 ORP155 Implementation Handoff]]
-- [[ORP157 Bounded Per-Clip DSP and Output Telemetry]]
-- [[ORP157 Suite Coherence and Package Consumer Mission]]
-- [[ORP158 Installed ShmUI-JUCE Package Qualification]]
-- [[ORP159 Suite Synchronization and Integration Gate]]
-- [[ORP160 Master Tape Varispeed Primitive]]
-- [[ORP161 FourTrack Live Output Handoff Assessment]]
-
-- [[ORP168 Streaming Seek Priming and Underrun Classification]]
-- [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]]
-
-## Archived Documents
-
-- [[archive/ORP061]]
-- [[archive/ORP062]]
-- [[archive/ORP063]]
-- [[archive/ORP065]]
-- [[archive/ORP066]]
-- [[archive/ORP067]]
-- [[archive/ORP069 OCC Enhancements]]
-- [[archive/ORP070B Progress Tracker]]
-- [[archive/ORP070 OCC MVP Sprint]]
-- [[archive/ORP071 Shmui Enhancements]]
-- [[archive/ORP072 AES67 Network Audio Driver]]
-- [[archive/ORP073]]
-- [[archive/ORP074]]
-- [[archive/ORP075]]
-- [[archive/ORP076]]
-- [[archive/ORP077_LATENCY_AUDIT]]
-- [[archive/ORP081]]
-- [[archive/ORP107 FreqFinder Architecture Independence - ADR]]
+- [ORP128 CoreAudio Runtime Sample-Rate Resilience](ORP128%20CoreAudio%20Runtime%20Sample-Rate%20Resilience.md)
+- [ORP162 CoreAudio Capture Channel Mapping and Downstream Pin Handoff](ORP162%20CoreAudio%20Capture%20Channel%20Mapping%20and%20Downstream%20Pin%20Handoff.md)
+- [ORP166 Orpheus Suite Application Launch and Icon Checkpoint](ORP166%20Orpheus%20Suite%20Application%20Launch%20and%20Icon%20Checkpoint.md)
+- [ORP168 Streaming Seek Priming and Underrun Classification](ORP168%20Streaming%20Seek%20Priming%20and%20Underrun%20Classification.md)
+- [ORP169 Orpheus Suite Remote Synchronization and PR Merge](ORP169%20Orpheus%20Suite%20Remote%20Synchronization%20and%20PR%20Merge.md)
+- [ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff](ORP171%20FourTrack%20Multi-Device%20CoreAudio%20Route-State%20Contract%20Handoff.md)
+- [ORP documentation conventions](ORP.md)
 
 ## Navigation
 

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <string>
+#include <optional>
 #include <vector>
 
 namespace orpheus {
@@ -80,6 +80,60 @@ struct ActiveAudioRoute {
   bool output_alive = false;
 };
 
+/// Playback route lifecycle as observed by a backend.
+enum class AudioRouteState : uint8_t {
+  Inactive,
+  Starting,
+  Running,
+  DegradedDuplex,
+  ReconfigurationRequired,
+  InputUnavailable,
+  OutputUnavailable,
+  PermissionDenied,
+  Failed,
+};
+
+/// Direction-specific latency terms. Missing terms remain unknown; callers
+/// must not substitute requested buffer sizes or estimates for them.
+struct AudioLatencyBreakdown {
+  std::optional<uint32_t> input_device_frames;
+  std::optional<uint32_t> input_safety_offset_frames;
+  std::optional<uint32_t> input_stream_frames;
+  std::optional<uint32_t> input_converter_frames;
+  std::optional<uint32_t> output_device_frames;
+  std::optional<uint32_t> output_safety_offset_frames;
+  std::optional<uint32_t> output_stream_frames;
+  std::optional<uint32_t> output_converter_frames;
+  std::optional<uint32_t> callback_buffer_frames;
+  std::optional<uint32_t> aggregate_or_audio_unit_frames;
+  bool complete = false;
+};
+
+/// Strict output-only route request. Empty output_device_id follows the
+/// backend's current default output; non-empty IDs are never defaulted.
+struct AudioOutputRouteRequest {
+  std::string output_device_id;
+  std::vector<uint16_t> output_channel_map;
+  uint32_t requested_sample_rate = 48000;
+  uint32_t requested_buffer_size = 512;
+};
+
+/// Control-thread snapshot of selected and active I/O route state.
+struct AudioIoRouteState {
+  AudioRouteState state = AudioRouteState::Inactive;
+  std::string selected_input_device_id;
+  std::string selected_output_device_id;
+  std::string active_input_device_id;
+  std::string active_output_device_id;
+  std::vector<uint16_t> active_input_channel_map;
+  std::vector<uint16_t> active_output_channel_map;
+  uint32_t requested_sample_rate = 0;
+  uint32_t actual_sample_rate = 0;
+  uint32_t requested_buffer_size = 0;
+  uint32_t actual_buffer_size = 0;
+  AudioLatencyBreakdown latency;
+  std::string detail;
+};
 /// Outcome of a backend runtime condition that can invalidate active audio I/O.
 /// A terminal outcome means the driver has stopped rendering and requires an
 /// explicit initialize() call with a host-selected configuration.
@@ -184,7 +238,6 @@ class IAudioDriver {
 public:
   virtual ~IAudioDriver() = default;
 
-  /// Initialize the audio driver.
   virtual SessionGraphError initialize(const AudioDriverConfig& config) = 0;
 
   /// Start audio processing. Callback must not be nullptr.
@@ -239,8 +292,20 @@ public:
   virtual ActiveAudioRoute getActiveRoute() const {
     return {};
   }
-};
 
+  /// Initialize a strict playback-only output route with a physical map.
+  /// Appended after the existing route contract to preserve all established
+  /// virtual-table slots. Drivers without this capability return NotSupported.
+  virtual SessionGraphError initializeAudioOutput(const AudioOutputRouteRequest& request) {
+    (void)request;
+    return SessionGraphError::NotSupported;
+  }
+
+  /// Get selected/active route state on the control thread.
+  virtual AudioIoRouteState getAudioIoRouteState() const {
+    return {};
+  }
+};
 /// Factory function for dummy audio driver (for testing).
 ORPHEUS_API std::unique_ptr<IAudioDriver> createDummyAudioDriver();
 

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -82,6 +82,10 @@ struct ActiveAudioRoute {
 };
 
 /// Playback route lifecycle as observed by a backend.
+///
+/// `InputUnavailable` and `OutputUnavailable` identify a failed physical
+/// endpoint when the backend can distinguish a direction. Terminal states
+/// require an explicit initialize() before the route may render again.
 enum class AudioRouteState : uint8_t {
   Inactive,
   Starting,
@@ -112,6 +116,9 @@ struct AudioLatencyBreakdown {
 
 /// Strict output-only route request. Empty output_device_id follows the
 /// backend's current default output; non-empty IDs are never defaulted.
+///
+/// The driver creates no input route. Output channels identify distinct
+/// physical output indices and must be valid for the selected endpoint.
 struct AudioOutputRouteRequest {
   std::string output_device_id;
   std::vector<uint16_t> output_channel_map;
@@ -303,6 +310,9 @@ public:
   }
 
   /// Get selected/active route state on the control thread.
+  ///
+  /// A terminal state describes the last observed route failure. Hosts must
+  /// explicitly reinitialize rather than assuming automatic endpoint fallback.
   virtual AudioIoRouteState getAudioIoRouteState() const {
     return {};
   }

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace orpheus {

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -36,6 +36,10 @@ struct AudioChannelDescriptor {
 };
 
 /// Direction-specific endpoint capability facts.
+///
+/// `device_id` is a persistent backend identifier suitable for route
+/// selection; `display_name` is presentation-only. The manager may report a
+/// device that supports either or both directions.
 struct AudioEndpointCapabilities {
   std::string device_id;
   std::string display_name;
@@ -164,6 +168,10 @@ public:
 
   /// Notify the host that endpoint discovery may have changed. The callback is
   /// notification-only; hosts re-enumerate on their control/message thread.
+  ///
+  /// On CoreAudio the callback executes on an internal control worker, never
+  /// the CoreAudio property-listener thread or an audio callback. It may
+  /// replace or unregister itself, or destroy the manager.
   virtual void setEndpointChangeCallback(std::function<void()> callback) {
     (void)callback;
   }

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -16,6 +16,41 @@ namespace orpheus {
 // Forward declaration
 class IAudioDriver;
 
+/// Direction of a physical hardware endpoint.
+enum class AudioEndpointDirection : uint8_t { Input, Output };
+
+/// Endpoint availability on the current host.
+enum class AudioEndpointAvailability : uint8_t {
+  Available,
+  Unavailable,
+  PermissionDenied,
+  FormatUnavailable,
+  Unknown,
+};
+
+/// One physical endpoint channel.
+struct AudioChannelDescriptor {
+  uint16_t device_index = 0;
+  std::string stable_id;
+  std::string display_name;
+};
+
+/// Direction-specific endpoint capability facts.
+struct AudioEndpointCapabilities {
+  std::string device_id;
+  std::string display_name;
+  AudioEndpointAvailability availability = AudioEndpointAvailability::Unknown;
+  bool is_default_input = false;
+  bool is_default_output = false;
+  bool supports_input = false;
+  bool supports_output = false;
+  std::vector<AudioChannelDescriptor> input_channels;
+  std::vector<AudioChannelDescriptor> output_channels;
+  std::vector<uint32_t> supported_sample_rates;
+  std::vector<uint32_t> supported_buffer_sizes;
+  uint32_t nominal_sample_rate = 0;
+  uint32_t current_buffer_size = 0;
+};
 /// Audio device information
 struct AudioDeviceInfo {
   std::string deviceId;                       ///< Unique device identifier
@@ -79,6 +114,7 @@ public:
                                             uint32_t bufferSize) = 0;
 
   /// Get currently active device
+
   ///
   /// @return Device ID, or std::nullopt if no device active
   /// @note Thread-safe, can be called from any thread
@@ -114,6 +150,23 @@ public:
   ///       Synchronize its use with setActiveDevice() and do not retain it
   ///       across a possible replacement.
   virtual IAudioDriver* getActiveDriver() = 0;
+  /// Enumerate direction-specific endpoint capabilities. Control thread only.
+  virtual std::vector<AudioEndpointCapabilities> enumerateEndpointCapabilities() {
+    return {};
+  }
+
+  /// Find one endpoint by stable backend device ID.
+  virtual std::optional<AudioEndpointCapabilities> getEndpointCapabilities(
+      const std::string& deviceId) {
+    (void)deviceId;
+    return std::nullopt;
+  }
+
+  /// Notify the host that endpoint discovery may have changed. The callback is
+  /// notification-only; hosts re-enumerate on their control/message thread.
+  virtual void setEndpointChangeCallback(std::function<void()> callback) {
+    (void)callback;
+  }
 };
 
 /// Create driver manager instance

--- a/src/core/audio_io/dummy_audio_driver.cpp
+++ b/src/core/audio_io/dummy_audio_driver.cpp
@@ -42,6 +42,32 @@ SessionGraphError DummyAudioDriver::initialize(const AudioDriverConfig& config) 
   return SessionGraphError::OK;
 }
 
+SessionGraphError DummyAudioDriver::initializeAudioOutput(
+    const AudioOutputRouteRequest& request) {
+  if (request.output_channel_map.empty() || request.requested_sample_rate == 0 ||
+      request.requested_buffer_size == 0 || request.requested_buffer_size > 0xffffu ||
+      request.output_channel_map.size() > 32 ||
+      (!request.output_device_id.empty() && request.output_device_id != "dummy")) {
+    return SessionGraphError::InvalidParameter;
+  }
+  std::vector<bool> seen(32, false);
+  for (const uint16_t channel : request.output_channel_map) {
+    if (channel >= seen.size() || seen[channel]) {
+      return SessionGraphError::InvalidParameter;
+    }
+    seen[channel] = true;
+  }
+
+  AudioDriverConfig config;
+  config.sample_rate = request.requested_sample_rate;
+  config.buffer_size = static_cast<uint16_t>(request.requested_buffer_size);
+  config.num_inputs = 0;
+  config.num_outputs = static_cast<uint16_t>(request.output_channel_map.size());
+  config.output_device_id = request.output_device_id;
+  config.channel_map.output_channels = request.output_channel_map;
+  return initialize(config);
+}
+
 SessionGraphError DummyAudioDriver::start(IAudioCallback* callback) {
   if (running_.load(std::memory_order_acquire)) {
     return SessionGraphError::InternalError;
@@ -114,6 +140,29 @@ AudioDriverCapabilities DummyAudioDriver::getCapabilities() const {
 ActiveAudioRoute DummyAudioDriver::getActiveRoute() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return active_route_;
+}
+
+AudioIoRouteState DummyAudioDriver::getAudioIoRouteState() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  AudioIoRouteState state;
+  state.state = running_.load(std::memory_order_acquire) ? AudioRouteState::Running
+                                                         : AudioRouteState::Inactive;
+  state.selected_input_device_id = config_.input_device_id;
+  state.selected_output_device_id = config_.output_device_id;
+  state.requested_sample_rate = config_.sample_rate;
+  state.actual_sample_rate = config_.sample_rate;
+  state.requested_buffer_size = config_.buffer_size;
+  state.actual_buffer_size = config_.buffer_size;
+  state.active_output_channel_map = config_.channel_map.output_channels;
+  if (state.active_output_channel_map.empty()) {
+    state.active_output_channel_map.resize(config_.num_outputs);
+    for (uint16_t channel = 0; channel < config_.num_outputs; ++channel) {
+      state.active_output_channel_map[channel] = channel;
+    }
+  }
+  state.active_input_channel_map = config_.channel_map.input_channels;
+  state.detail = "Dummy driver has no physical endpoint or hardware latency.";
+  return state;
 }
 
 AudioIoTelemetry DummyAudioDriver::getTelemetry() const noexcept {

--- a/src/core/audio_io/dummy_audio_driver.h
+++ b/src/core/audio_io/dummy_audio_driver.h
@@ -18,6 +18,7 @@ public:
   ~DummyAudioDriver() override;
 
   SessionGraphError initialize(const AudioDriverConfig& config) override;
+  SessionGraphError initializeAudioOutput(const AudioOutputRouteRequest& request) override;
   SessionGraphError start(IAudioCallback* callback) override;
   SessionGraphError stop() override;
   bool isRunning() const override;
@@ -26,6 +27,7 @@ public:
   uint32_t getLatencySamples() const override;
   AudioDriverCapabilities getCapabilities() const override;
   ActiveAudioRoute getActiveRoute() const override;
+  AudioIoRouteState getAudioIoRouteState() const override;
   AudioIoTelemetry getTelemetry() const noexcept override;
 
 private:

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 # Audio Driver Manager (platform-agnostic device enumeration and management)
 add_library(orpheus_audio_driver_manager STATIC
     driver_manager.cpp
+    coreaudio/coreaudio_endpoint_catalog.cpp
 )
 
 target_include_directories(orpheus_audio_driver_manager

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -78,6 +78,7 @@ message(STATUS "Orpheus: Audio Driver Manager enabled")
 if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
     add_library(orpheus_audio_driver_coreaudio STATIC
         coreaudio/coreaudio_driver.cpp
+        coreaudio/coreaudio_endpoint_monitor.cpp
         coreaudio/coreaudio_sample_rate_monitor.cpp
         coreaudio/coreaudio_route_monitor.cpp
     )

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -169,6 +169,7 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   stream_timeline_initialized_ = false;
   runtime_outcome_.store(AudioDriverRuntimeOutcome::Healthy, std::memory_order_release);
   route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
+  unavailable_route_state_.store(AudioRouteState::Failed, std::memory_order_release);
 
   device_id_ = resolveInputOutputDevice();
   if (device_id_ == 0 || !resolveChannelMaps(config)) {
@@ -241,8 +242,7 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   return SessionGraphError::OK;
 }
 
-SessionGraphError CoreAudioDriver::initializeAudioOutput(
-    const AudioOutputRouteRequest& request) {
+SessionGraphError CoreAudioDriver::initializeAudioOutput(const AudioOutputRouteRequest& request) {
   if (request.output_channel_map.empty() || request.requested_sample_rate == 0 ||
       request.requested_buffer_size == 0 || request.requested_buffer_size > 0xffffu ||
       request.output_channel_map.size() > 0xffffu) {
@@ -361,19 +361,26 @@ ActiveAudioRoute CoreAudioDriver::getActiveRoute() const {
   return active_route_;
 }
 
-
 AudioIoRouteState CoreAudioDriver::getAudioIoRouteState() const {
   std::lock_guard<std::mutex> lock(mutex_);
   AudioIoRouteState state;
-  const AudioRouteRuntimeOutcome route_outcome =
-      route_outcome_.load(std::memory_order_acquire);
+  const AudioRouteRuntimeOutcome route_outcome = route_outcome_.load(std::memory_order_acquire);
   if (is_running_.load(std::memory_order_acquire) &&
       route_outcome == AudioRouteRuntimeOutcome::Healthy) {
     state.state = AudioRouteState::Running;
   } else if (route_outcome == AudioRouteRuntimeOutcome::RouteUnavailable) {
-    state.state = config_.num_inputs > 0 ? AudioRouteState::InputUnavailable
-                                         : AudioRouteState::OutputUnavailable;
-    state.detail = "The selected CoreAudio endpoint is unavailable.";
+    state.state = unavailable_route_state_.load(std::memory_order_acquire);
+    switch (state.state) {
+    case AudioRouteState::InputUnavailable:
+      state.detail = "The selected CoreAudio input endpoint is unavailable.";
+      break;
+    case AudioRouteState::OutputUnavailable:
+      state.detail = "The selected CoreAudio output endpoint is unavailable.";
+      break;
+    default:
+      state.detail = "The selected CoreAudio route is unavailable.";
+      break;
+    }
   } else if (route_outcome == AudioRouteRuntimeOutcome::FormatChanged ||
              route_outcome == AudioRouteRuntimeOutcome::ReinitializationRequired) {
     state.state = AudioRouteState::ReconfigurationRequired;
@@ -837,12 +844,12 @@ CoreAudioDriver::getStreamFormat(AudioStreamID stream_id,
 }
 
 bool CoreAudioDriver::createRouteMonitor() {
-  std::vector<AudioDeviceID> device_ids;
-  device_ids.reserve(3);
-  device_ids.push_back(device_id_);
-  device_ids.push_back(output_device_id_);
+  std::vector<CoreAudioRouteDevice> devices;
+  devices.reserve(3);
+  devices.push_back({device_id_, false, false});
+  devices.push_back({output_device_id_, false, true});
   if (config_.num_inputs > 0) {
-    device_ids.push_back(input_device_id_);
+    devices.push_back({input_device_id_, true, false});
   }
 
   std::vector<CoreAudioRouteStream> streams;
@@ -873,7 +880,7 @@ bool CoreAudioDriver::createRouteMonitor() {
 
   try {
     route_monitor_ = std::make_unique<CoreAudioRouteMonitor>(
-        route_property_api_, config_.sample_rate, config_.buffer_size, std::move(device_ids),
+        route_property_api_, config_.sample_rate, config_.buffer_size, std::move(devices),
         std::move(streams));
   } catch (...) {
     route_monitor_.reset();
@@ -967,7 +974,18 @@ void CoreAudioDriver::publishRoutePollResult(CoreAudioRoutePollResult result) {
                            std::memory_order_release);
     route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
     break;
+  case CoreAudioRoutePollResult::InputUnavailable:
+    unavailable_route_state_.store(AudioRouteState::InputUnavailable, std::memory_order_release);
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+    break;
+  case CoreAudioRoutePollResult::OutputUnavailable:
+    unavailable_route_state_.store(AudioRouteState::OutputUnavailable, std::memory_order_release);
+    runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
+    route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+    break;
   case CoreAudioRoutePollResult::RouteUnavailable:
+    unavailable_route_state_.store(AudioRouteState::Failed, std::memory_order_release);
     runtime_outcome_.store(AudioDriverRuntimeOutcome::BackendFailure, std::memory_order_release);
     route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
     break;
@@ -1099,9 +1117,8 @@ AudioLatencyBreakdown CoreAudioDriver::queryDetailedLatencyBreakdown() const {
     if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
                              &seconds, &size) == noErr &&
         size == sizeof(seconds) && seconds >= 0.0) {
-      const uint32_t rate = active_route_.actual_sample_rate != 0
-                                ? active_route_.actual_sample_rate
-                                : config_.sample_rate;
+      const uint32_t rate = active_route_.actual_sample_rate != 0 ? active_route_.actual_sample_rate
+                                                                  : config_.sample_rate;
       const uint64_t frames = static_cast<uint64_t>(std::llround(seconds * rate));
       latency.aggregate_or_audio_unit_frames =
           static_cast<uint32_t>(std::min<uint64_t>(frames, std::numeric_limits<uint32_t>::max()));

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -241,6 +241,31 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   return SessionGraphError::OK;
 }
 
+SessionGraphError CoreAudioDriver::initializeAudioOutput(
+    const AudioOutputRouteRequest& request) {
+  if (request.output_channel_map.empty() || request.requested_sample_rate == 0 ||
+      request.requested_buffer_size == 0 || request.requested_buffer_size > 0xffffu ||
+      request.output_channel_map.size() > 0xffffu) {
+    return SessionGraphError::InvalidParameter;
+  }
+  for (size_t index = 0; index < request.output_channel_map.size(); ++index) {
+    for (size_t previous = 0; previous < index; ++previous) {
+      if (request.output_channel_map[index] == request.output_channel_map[previous]) {
+        return SessionGraphError::InvalidParameter;
+      }
+    }
+  }
+
+  AudioDriverConfig config;
+  config.sample_rate = request.requested_sample_rate;
+  config.buffer_size = static_cast<uint16_t>(request.requested_buffer_size);
+  config.num_inputs = 0;
+  config.num_outputs = static_cast<uint16_t>(request.output_channel_map.size());
+  config.output_device_id = request.output_device_id;
+  config.channel_map.output_channels = request.output_channel_map;
+  return initialize(config);
+}
+
 SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -336,6 +361,43 @@ ActiveAudioRoute CoreAudioDriver::getActiveRoute() const {
   return active_route_;
 }
 
+
+AudioIoRouteState CoreAudioDriver::getAudioIoRouteState() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  AudioIoRouteState state;
+  const AudioRouteRuntimeOutcome route_outcome =
+      route_outcome_.load(std::memory_order_acquire);
+  if (is_running_.load(std::memory_order_acquire) &&
+      route_outcome == AudioRouteRuntimeOutcome::Healthy) {
+    state.state = AudioRouteState::Running;
+  } else if (route_outcome == AudioRouteRuntimeOutcome::RouteUnavailable) {
+    state.state = config_.num_inputs > 0 ? AudioRouteState::InputUnavailable
+                                         : AudioRouteState::OutputUnavailable;
+    state.detail = "The selected CoreAudio endpoint is unavailable.";
+  } else if (route_outcome == AudioRouteRuntimeOutcome::FormatChanged ||
+             route_outcome == AudioRouteRuntimeOutcome::ReinitializationRequired) {
+    state.state = AudioRouteState::ReconfigurationRequired;
+    state.detail = "The active CoreAudio format or route changed; reinitialize explicitly.";
+  } else if (route_outcome == AudioRouteRuntimeOutcome::BackendFailure) {
+    state.state = AudioRouteState::Failed;
+    state.detail = "CoreAudio reported a terminal route failure.";
+  } else {
+    state.state = AudioRouteState::Inactive;
+  }
+
+  state.selected_input_device_id = config_.input_device_id;
+  state.selected_output_device_id = config_.output_device_id;
+  state.active_input_device_id = active_route_.input_device_id;
+  state.active_output_device_id = active_route_.output_device_id;
+  state.active_input_channel_map = active_route_.input_channels;
+  state.active_output_channel_map = active_route_.output_channels;
+  state.requested_sample_rate = active_route_.requested_sample_rate;
+  state.actual_sample_rate = active_route_.actual_sample_rate;
+  state.requested_buffer_size = config_.buffer_size;
+  state.actual_buffer_size = active_route_.actual_buffer_frames;
+  state.latency = queryDetailedLatencyBreakdown();
+  return state;
+}
 void CoreAudioDriver::setInputRenderFailuresForTesting(uint64_t count) noexcept {
   input_render_failures_.store(count, std::memory_order_release);
 }
@@ -1008,6 +1070,53 @@ AudioRouteLatency CoreAudioDriver::queryLatencyBreakdown() const {
   latency.capture_frames = capture_frames;
   latency.playback_frames = playback_frames;
   latency.processing_frames = processing_frames;
+  latency.complete = input_complete && output_complete && processing_complete;
+  return latency;
+}
+
+AudioLatencyBreakdown CoreAudioDriver::queryDetailedLatencyBreakdown() const {
+  AudioLatencyBreakdown latency;
+  if (config_.num_inputs > 0) {
+    latency.input_device_frames = getOptionalUInt32Property(
+        input_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeInput);
+    latency.input_safety_offset_frames = getOptionalUInt32Property(
+        input_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeInput);
+    latency.input_stream_frames =
+        getOptionalStreamLatency(input_device_id_, kAudioObjectPropertyScopeInput);
+  }
+  latency.output_device_frames = getOptionalUInt32Property(
+      output_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeOutput);
+  latency.output_safety_offset_frames = getOptionalUInt32Property(
+      output_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeOutput);
+  latency.output_stream_frames =
+      getOptionalStreamLatency(output_device_id_, kAudioObjectPropertyScopeOutput);
+  latency.callback_buffer_frames = getOptionalUInt32Property(
+      device_id_, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
+
+  if (audio_unit_ != nullptr) {
+    Float64 seconds = 0.0;
+    UInt32 size = sizeof(seconds);
+    if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
+                             &seconds, &size) == noErr &&
+        size == sizeof(seconds) && seconds >= 0.0) {
+      const uint32_t rate = active_route_.actual_sample_rate != 0
+                                ? active_route_.actual_sample_rate
+                                : config_.sample_rate;
+      const uint64_t frames = static_cast<uint64_t>(std::llround(seconds * rate));
+      latency.aggregate_or_audio_unit_frames =
+          static_cast<uint32_t>(std::min<uint64_t>(frames, std::numeric_limits<uint32_t>::max()));
+    }
+  }
+
+  const bool input_complete =
+      config_.num_inputs == 0 ||
+      (latency.input_device_frames.has_value() && latency.input_safety_offset_frames.has_value() &&
+       latency.input_stream_frames.has_value());
+  const bool output_complete = latency.output_device_frames.has_value() &&
+                               latency.output_safety_offset_frames.has_value() &&
+                               latency.output_stream_frames.has_value();
+  const bool processing_complete = latency.callback_buffer_frames.has_value() &&
+                                   latency.aggregate_or_audio_unit_frames.has_value();
   latency.complete = input_complete && output_complete && processing_complete;
   return latency;
 }

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -98,6 +98,7 @@ private:
   std::atomic<uint64_t> input_render_failures_{0};
   std::atomic<AudioDriverRuntimeOutcome> runtime_outcome_{AudioDriverRuntimeOutcome::Healthy};
   std::atomic<AudioRouteRuntimeOutcome> route_outcome_{AudioRouteRuntimeOutcome::Healthy};
+  std::atomic<AudioRouteState> unavailable_route_state_{AudioRouteState::Failed};
 
   CoreAudioSampleRatePropertyApi route_property_api_;
   std::unique_ptr<CoreAudioRouteMonitor> route_monitor_;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -37,6 +37,8 @@ public:
   AudioIoTelemetry getTelemetry() const noexcept override;
   AudioDriverCapabilities getCapabilities() const override;
   ActiveAudioRoute getActiveRoute() const override;
+  SessionGraphError initializeAudioOutput(const AudioOutputRouteRequest& request) override;
+  AudioIoRouteState getAudioIoRouteState() const override;
 
   void setPerformanceMonitor(IPerformanceMonitor* monitor) override;
 
@@ -75,6 +77,7 @@ private:
   void refreshActiveRouteLocked();
 
   AudioRouteLatency queryLatencyBreakdown() const;
+  AudioLatencyBreakdown queryDetailedLatencyBreakdown() const;
   uint32_t queryDeviceLatency() const;
   void cleanupAudioUnit();
   void stopRenderingLocked();

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio_endpoint_catalog.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+namespace orpheus::detail {
+namespace {
+
+constexpr std::array<uint32_t, 6> kCommonSampleRates = {
+    44100, 48000, 88200, 96000, 176400, 192000};
+constexpr std::array<uint32_t, 14> kCommonBufferSizes = {
+    32, 64, 96, 128, 160, 192, 256, 384, 512, 768, 1024, 1536, 2048, 4096};
+
+bool isInRange(double value, const CoreAudioEndpointRange& range) {
+  return value >= range.minimum && value <= range.maximum;
+}
+
+void appendUnique(std::vector<uint32_t>& values, uint32_t value) {
+  if (value != 0 && std::find(values.begin(), values.end(), value) == values.end()) {
+    values.push_back(value);
+  }
+}
+
+void appendChannels(std::vector<AudioChannelDescriptor>& channels, uint32_t count,
+                    const std::string& deviceId, const std::string& displayName,
+                    const char* stableDirection, const char* displayDirection) {
+  if (count > std::numeric_limits<uint16_t>::max()) {
+    return;
+  }
+  channels.reserve(count);
+  for (uint32_t channel = 0; channel < count; ++channel) {
+    channels.push_back({static_cast<uint16_t>(channel),
+                        deviceId + ":" + stableDirection + ":" + std::to_string(channel),
+                        displayName + " " + displayDirection + " " +
+                            std::to_string(channel + 1)});
+  }
+}
+
+} // namespace
+
+AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(
+    const CoreAudioEndpointFacts& facts) {
+  AudioEndpointCapabilities endpoint;
+  endpoint.device_id = facts.device_id;
+  endpoint.display_name = facts.display_name.empty() ? facts.device_id : facts.display_name;
+  endpoint.is_default_input = facts.is_default_input;
+  endpoint.is_default_output = facts.is_default_output;
+
+  const bool channel_counts_representable =
+      facts.input_channel_count <= std::numeric_limits<uint16_t>::max() &&
+      facts.output_channel_count <= std::numeric_limits<uint16_t>::max();
+  endpoint.supports_input = facts.input_channel_count != 0 && channel_counts_representable;
+  endpoint.supports_output = facts.output_channel_count != 0 && channel_counts_representable;
+  endpoint.availability = !channel_counts_representable
+                              ? AudioEndpointAvailability::FormatUnavailable
+                              : (endpoint.supports_input || endpoint.supports_output
+                                     ? AudioEndpointAvailability::Available
+                                     : AudioEndpointAvailability::FormatUnavailable);
+
+  if (endpoint.supports_input) {
+    appendChannels(endpoint.input_channels, facts.input_channel_count, facts.device_id,
+                   endpoint.display_name, "input", "Input");
+  }
+  if (endpoint.supports_output) {
+    appendChannels(endpoint.output_channels, facts.output_channel_count, facts.device_id,
+                   endpoint.display_name, "output", "Output");
+  }
+
+  for (const uint32_t rate : kCommonSampleRates) {
+    if (std::any_of(facts.sample_rate_ranges.begin(), facts.sample_rate_ranges.end(),
+                    [rate](const CoreAudioEndpointRange& range) {
+                      return isInRange(static_cast<double>(rate), range);
+                    })) {
+      endpoint.supported_sample_rates.push_back(rate);
+    }
+  }
+  endpoint.nominal_sample_rate = facts.nominal_sample_rate;
+  appendUnique(endpoint.supported_sample_rates, endpoint.nominal_sample_rate);
+  std::sort(endpoint.supported_sample_rates.begin(), endpoint.supported_sample_rates.end());
+
+  for (const uint32_t buffer : kCommonBufferSizes) {
+    if (std::any_of(facts.buffer_size_ranges.begin(), facts.buffer_size_ranges.end(),
+                    [buffer](const CoreAudioEndpointRange& range) {
+                      return isInRange(static_cast<double>(buffer), range);
+                    })) {
+      endpoint.supported_buffer_sizes.push_back(buffer);
+    }
+  }
+  endpoint.current_buffer_size = facts.current_buffer_size;
+  appendUnique(endpoint.supported_buffer_sizes, endpoint.current_buffer_size);
+  std::sort(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end());
+
+  return endpoint;
+}
+
+} // namespace orpheus::detail

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <orpheus/audio_driver_manager.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace orpheus::detail {
+
+/// CoreAudio properties normalized for capability projection and deterministic tests.
+/// This private seam keeps CoreAudio property-query types out of the public API.
+struct CoreAudioEndpointRange {
+  double minimum = 0.0;
+  double maximum = 0.0;
+};
+
+struct CoreAudioEndpointFacts {
+  std::string device_id;
+  std::string display_name;
+  bool is_default_input = false;
+  bool is_default_output = false;
+  uint32_t input_channel_count = 0;
+  uint32_t output_channel_count = 0;
+  std::vector<CoreAudioEndpointRange> sample_rate_ranges;
+  std::vector<CoreAudioEndpointRange> buffer_size_ranges;
+  uint32_t nominal_sample_rate = 0;
+  uint32_t current_buffer_size = 0;
+};
+
+AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(const CoreAudioEndpointFacts& facts);
+
+} // namespace orpheus::detail

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_monitor.cpp
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio_endpoint_monitor.h"
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace orpheus {
+namespace {
+
+class NativeCoreAudioEndpointPropertyApi final : public ICoreAudioEndpointPropertyApi {
+public:
+  OSStatus addPropertyListener(AudioObjectID object_id, const AudioObjectPropertyAddress* address,
+                               AudioObjectPropertyListenerProc callback,
+                               void* context) noexcept override {
+    return AudioObjectAddPropertyListener(object_id, address, callback, context);
+  }
+
+  OSStatus removePropertyListener(AudioObjectID object_id,
+                                  const AudioObjectPropertyAddress* address,
+                                  AudioObjectPropertyListenerProc callback,
+                                  void* context) noexcept override {
+    return AudioObjectRemovePropertyListener(object_id, address, callback, context);
+  }
+};
+
+const std::array<AudioObjectPropertyAddress, 3>& endpointPropertyAddresses() {
+  static const std::array<AudioObjectPropertyAddress, 3> addresses = {
+      AudioObjectPropertyAddress{kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
+                                 kAudioObjectPropertyElementMain},
+      AudioObjectPropertyAddress{kAudioHardwarePropertyDefaultInputDevice,
+                                 kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain},
+      AudioObjectPropertyAddress{kAudioHardwarePropertyDefaultOutputDevice,
+                                 kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain},
+  };
+  return addresses;
+}
+
+} // namespace
+
+struct CoreAudioEndpointMonitor::State {
+  std::atomic<bool> active{false};
+  std::atomic<bool> pending{false};
+  std::condition_variable changed;
+  std::mutex changed_mutex;
+  std::mutex callback_mutex;
+  std::function<void()> callback;
+};
+
+CoreAudioEndpointMonitor::CoreAudioEndpointMonitor(ICoreAudioEndpointPropertyApi& property_api)
+    : property_api_(property_api), state_(std::make_shared<State>()) {}
+
+CoreAudioEndpointMonitor::~CoreAudioEndpointMonitor() {
+  stop();
+}
+
+void CoreAudioEndpointMonitor::setCallback(std::function<void()> callback) {
+  bool should_start = false;
+  {
+    std::lock_guard<std::mutex> lock(state_->callback_mutex);
+    state_->callback = std::move(callback);
+    should_start = static_cast<bool>(state_->callback);
+  }
+
+  if (!should_start) {
+    stop();
+    return;
+  }
+
+  std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+  if (state_->active.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+
+  for (const AudioObjectPropertyAddress& address : endpointPropertyAddresses()) {
+    if (property_api_.addPropertyListener(kAudioObjectSystemObject, &address, &propertyChanged,
+                                          state_.get()) != noErr) {
+      for (size_t index = 0; index < listener_count_; ++index) {
+        const AudioObjectPropertyAddress& registered = endpointPropertyAddresses()[index];
+        property_api_.removePropertyListener(kAudioObjectSystemObject, &registered,
+                                             &propertyChanged, state_.get());
+      }
+      listener_count_ = 0;
+      state_->active.store(false, std::memory_order_release);
+      return;
+    }
+    ++listener_count_;
+  }
+
+  try {
+    worker_ = std::thread(&CoreAudioEndpointMonitor::monitorLoop, state_);
+  } catch (...) {
+    for (size_t index = 0; index < listener_count_; ++index) {
+      const AudioObjectPropertyAddress& registered = endpointPropertyAddresses()[index];
+      property_api_.removePropertyListener(kAudioObjectSystemObject, &registered, &propertyChanged,
+                                           state_.get());
+    }
+    listener_count_ = 0;
+    state_->active.store(false, std::memory_order_release);
+  }
+}
+
+void CoreAudioEndpointMonitor::stop() noexcept {
+  std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+  if (!state_->active.exchange(false, std::memory_order_acq_rel) && !worker_.joinable()) {
+    return;
+  }
+
+  for (size_t index = 0; index < listener_count_; ++index) {
+    const AudioObjectPropertyAddress& address = endpointPropertyAddresses()[index];
+    property_api_.removePropertyListener(kAudioObjectSystemObject, &address, &propertyChanged,
+                                         state_.get());
+  }
+  listener_count_ = 0;
+  state_->pending.store(true, std::memory_order_release);
+  state_->changed.notify_one();
+
+  if (worker_.joinable()) {
+    if (worker_.get_id() == std::this_thread::get_id()) {
+      worker_.detach();
+    } else {
+      worker_.join();
+    }
+  }
+}
+
+OSStatus CoreAudioEndpointMonitor::propertyChanged(AudioObjectID object_id, UInt32 address_count,
+                                                   const AudioObjectPropertyAddress* addresses,
+                                                   void* context) noexcept {
+  (void)object_id;
+  (void)address_count;
+  (void)addresses;
+  auto* state = static_cast<State*>(context);
+  if (state == nullptr || !state->active.load(std::memory_order_acquire)) {
+    return noErr;
+  }
+  state->pending.store(true, std::memory_order_release);
+  state->changed.notify_one();
+  return noErr;
+}
+
+void CoreAudioEndpointMonitor::monitorLoop(std::shared_ptr<State> state) {
+  while (state->active.load(std::memory_order_acquire)) {
+    std::unique_lock<std::mutex> lock(state->changed_mutex);
+    state->changed.wait(lock, [&state] {
+      return state->pending.load(std::memory_order_acquire) ||
+             !state->active.load(std::memory_order_acquire);
+    });
+    state->pending.store(false, std::memory_order_release);
+    if (!state->active.load(std::memory_order_acquire)) {
+      return;
+    }
+
+    std::function<void()> callback;
+    {
+      std::lock_guard<std::mutex> callback_lock(state->callback_mutex);
+      callback = state->callback;
+    }
+    lock.unlock();
+    if (callback) {
+      callback();
+    }
+  }
+}
+
+std::unique_ptr<CoreAudioEndpointMonitor> createCoreAudioEndpointMonitor() {
+  static NativeCoreAudioEndpointPropertyApi property_api;
+  return std::make_unique<CoreAudioEndpointMonitor>(property_api);
+}
+
+} // namespace orpheus

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_monitor.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <CoreAudio/CoreAudio.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+namespace orpheus {
+
+/// Minimal CoreAudio property-listener surface used by endpoint discovery.
+class ICoreAudioEndpointPropertyApi {
+public:
+  virtual ~ICoreAudioEndpointPropertyApi() = default;
+
+  virtual OSStatus addPropertyListener(AudioObjectID object_id,
+                                       const AudioObjectPropertyAddress* address,
+                                       AudioObjectPropertyListenerProc callback,
+                                       void* context) noexcept = 0;
+  virtual OSStatus removePropertyListener(AudioObjectID object_id,
+                                          const AudioObjectPropertyAddress* address,
+                                          AudioObjectPropertyListenerProc callback,
+                                          void* context) noexcept = 0;
+};
+
+/// Coalesces CoreAudio endpoint-catalog changes onto one control worker.
+///
+/// The callback runs off the CoreAudio listener thread. It may unregister
+/// itself or destroy this monitor; its worker state remains alive until the
+/// in-flight callback returns.
+class CoreAudioEndpointMonitor final {
+public:
+  explicit CoreAudioEndpointMonitor(ICoreAudioEndpointPropertyApi& property_api);
+  ~CoreAudioEndpointMonitor();
+
+  CoreAudioEndpointMonitor(const CoreAudioEndpointMonitor&) = delete;
+  CoreAudioEndpointMonitor& operator=(const CoreAudioEndpointMonitor&) = delete;
+
+  /// Replaces the notification callback. An empty callback stops monitoring.
+  void setCallback(std::function<void()> callback);
+  /// Stops monitoring. Safe from the notification callback and safe to repeat.
+  void stop() noexcept;
+
+private:
+  struct State;
+
+  static OSStatus propertyChanged(AudioObjectID, UInt32, const AudioObjectPropertyAddress*,
+                                  void* context) noexcept;
+  static void monitorLoop(std::shared_ptr<State> state);
+
+  ICoreAudioEndpointPropertyApi& property_api_;
+  std::shared_ptr<State> state_;
+  std::thread worker_;
+  std::mutex lifecycle_mutex_;
+  size_t listener_count_{0};
+};
+
+/// Builds an endpoint monitor backed by CoreAudio's native property API.
+std::unique_ptr<CoreAudioEndpointMonitor> createCoreAudioEndpointMonitor();
+
+} // namespace orpheus

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
@@ -8,16 +8,32 @@ namespace orpheus {
 CoreAudioRouteMonitor::CoreAudioRouteMonitor(ICoreAudioSampleRatePropertyApi& property_api,
                                              uint32_t expected_sample_rate,
                                              uint32_t expected_buffer_frames,
-                                             std::vector<AudioDeviceID> device_ids,
+                                             std::vector<CoreAudioRouteDevice> devices,
                                              std::vector<CoreAudioRouteStream> streams)
     : property_api_(property_api),
       expected_sample_rate_(static_cast<Float64>(expected_sample_rate)),
-      expected_buffer_frames_(expected_buffer_frames), device_ids_(std::move(device_ids)),
+      expected_buffer_frames_(expected_buffer_frames), devices_(std::move(devices)),
       streams_(std::move(streams)) {
-  std::sort(device_ids_.begin(), device_ids_.end());
-  device_ids_.erase(std::unique(device_ids_.begin(), device_ids_.end()), device_ids_.end());
-  device_ids_.erase(std::remove(device_ids_.begin(), device_ids_.end(), AudioDeviceID{0}),
-                    device_ids_.end());
+  std::sort(devices_.begin(), devices_.end(),
+            [](const CoreAudioRouteDevice& lhs, const CoreAudioRouteDevice& rhs) {
+              return lhs.device_id < rhs.device_id;
+            });
+  std::vector<CoreAudioRouteDevice> unique_devices;
+  unique_devices.reserve(devices_.size());
+  for (const CoreAudioRouteDevice& device : devices_) {
+    if (device.device_id == 0) {
+      continue;
+    }
+    if (!unique_devices.empty() && unique_devices.back().device_id == device.device_id) {
+      unique_devices.back().monitors_input =
+          unique_devices.back().monitors_input || device.monitors_input;
+      unique_devices.back().monitors_output =
+          unique_devices.back().monitors_output || device.monitors_output;
+      continue;
+    }
+    unique_devices.push_back(device);
+  }
+  devices_ = std::move(unique_devices);
 
   std::sort(streams_.begin(), streams_.end(),
             [](const CoreAudioRouteStream& lhs, const CoreAudioRouteStream& rhs) {
@@ -29,11 +45,13 @@ CoreAudioRouteMonitor::CoreAudioRouteMonitor(ICoreAudioSampleRatePropertyApi& pr
                              }),
                  streams_.end());
 
-  registrations_.reserve(device_ids_.size() * 3 + streams_.size() * 2);
-  for (const AudioDeviceID device_id : device_ids_) {
-    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyDeviceIsAlive)});
-    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyNominalSampleRate)});
-    registrations_.push_back({device_id, deviceAddress(kAudioDevicePropertyBufferFrameSize)});
+  registrations_.reserve(devices_.size() * 3 + streams_.size() * 2);
+  for (const CoreAudioRouteDevice& device : devices_) {
+    registrations_.push_back({device.device_id, deviceAddress(kAudioDevicePropertyDeviceIsAlive)});
+    registrations_.push_back(
+        {device.device_id, deviceAddress(kAudioDevicePropertyNominalSampleRate)});
+    registrations_.push_back(
+        {device.device_id, deviceAddress(kAudioDevicePropertyBufferFrameSize)});
   }
   for (const CoreAudioRouteStream& stream : streams_) {
     registrations_.push_back({stream.stream_id, streamAddress(kAudioStreamPropertyVirtualFormat)});
@@ -102,24 +120,33 @@ CoreAudioRoutePollResult CoreAudioRouteMonitor::poll() noexcept {
   const auto rate_address = deviceAddress(kAudioDevicePropertyNominalSampleRate);
   const auto buffer_address = deviceAddress(kAudioDevicePropertyBufferFrameSize);
   bool rate_restored = false;
+  bool aggregate_unavailable = false;
 
-  for (const AudioDeviceID device_id : device_ids_) {
+  for (const CoreAudioRouteDevice& device : devices_) {
     UInt32 alive = 0;
-    if (!readUInt32(property_api_, device_id, alive_address, alive)) {
+    if (!readUInt32(property_api_, device.device_id, alive_address, alive)) {
       return CoreAudioRoutePollResult::BackendFailure;
     }
     if (alive == 0) {
-      return CoreAudioRoutePollResult::RouteUnavailable;
+      if (device.monitors_input && !device.monitors_output) {
+        return CoreAudioRoutePollResult::InputUnavailable;
+      }
+      if (device.monitors_output && !device.monitors_input) {
+        return CoreAudioRoutePollResult::OutputUnavailable;
+      }
+      aggregate_unavailable = true;
+      continue;
     }
 
     Float64 observed_rate = 0.0;
-    if (!readFloat64(property_api_, device_id, rate_address, observed_rate)) {
+    if (!readFloat64(property_api_, device.device_id, rate_address, observed_rate)) {
       return CoreAudioRoutePollResult::BackendFailure;
     }
     if (observed_rate != expected_sample_rate_) {
-      if (property_api_.setPropertyData(device_id, &rate_address, sizeof(expected_sample_rate_),
+      if (property_api_.setPropertyData(device.device_id, &rate_address,
+                                        sizeof(expected_sample_rate_),
                                         &expected_sample_rate_) != noErr ||
-          !readFloat64(property_api_, device_id, rate_address, observed_rate)) {
+          !readFloat64(property_api_, device.device_id, rate_address, observed_rate)) {
         return CoreAudioRoutePollResult::ReinitializationRequired;
       }
       if (observed_rate != expected_sample_rate_) {
@@ -129,12 +156,15 @@ CoreAudioRoutePollResult CoreAudioRouteMonitor::poll() noexcept {
     }
 
     UInt32 observed_buffer_frames = 0;
-    if (!readUInt32(property_api_, device_id, buffer_address, observed_buffer_frames)) {
+    if (!readUInt32(property_api_, device.device_id, buffer_address, observed_buffer_frames)) {
       return CoreAudioRoutePollResult::BackendFailure;
     }
     if (observed_buffer_frames != expected_buffer_frames_) {
       return CoreAudioRoutePollResult::ReinitializationRequired;
     }
+  }
+  if (aggregate_unavailable) {
+    return CoreAudioRoutePollResult::RouteUnavailable;
   }
 
   for (const CoreAudioRouteStream& stream : streams_) {

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
@@ -18,9 +18,18 @@ enum class CoreAudioRoutePollResult : uint8_t {
   NoChange,
   RateRestored,
   RouteUnavailable,
+  InputUnavailable,
+  OutputUnavailable,
   FormatChanged,
   ReinitializationRequired,
   BackendFailure,
+};
+
+/// A physical device contributing one or both directions of an active route.
+struct CoreAudioRouteDevice {
+  AudioDeviceID device_id = 0;
+  bool monitors_input = false;
+  bool monitors_output = false;
 };
 
 /// One stream whose virtual and physical formats are part of the active route.
@@ -40,7 +49,7 @@ class CoreAudioRouteMonitor final {
 public:
   CoreAudioRouteMonitor(ICoreAudioSampleRatePropertyApi& property_api,
                         uint32_t expected_sample_rate, uint32_t expected_buffer_frames,
-                        std::vector<AudioDeviceID> device_ids,
+                        std::vector<CoreAudioRouteDevice> devices,
                         std::vector<CoreAudioRouteStream> streams);
   ~CoreAudioRouteMonitor();
 
@@ -89,7 +98,7 @@ private:
   ICoreAudioSampleRatePropertyApi& property_api_;
   const Float64 expected_sample_rate_;
   const UInt32 expected_buffer_frames_;
-  std::vector<AudioDeviceID> device_ids_;
+  std::vector<CoreAudioRouteDevice> devices_;
   std::vector<CoreAudioRouteStream> streams_;
   std::vector<ListenerRegistration> registrations_;
   std::atomic<uint64_t> state_{kStoppedBit};

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -5,9 +5,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cwchar>
 #include <mutex>
 #include <sstream>
+#include <thread>
 #include <utility>
 
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
@@ -86,13 +88,25 @@ public:
   uint32_t getCurrentBufferSize() const override;
   void setDeviceChangeCallback(std::function<void()> callback) override;
   IAudioDriver* getActiveDriver() override;
+  std::vector<AudioEndpointCapabilities> enumerateEndpointCapabilities() override;
+  std::optional<AudioEndpointCapabilities> getEndpointCapabilities(
+      const std::string& deviceId) override;
+  void setEndpointChangeCallback(std::function<void()> callback) override;
 
 private:
   std::vector<AudioDeviceInfo> enumerateCoreAudioDevices();
   std::vector<AudioDeviceInfo> enumerateWindowsDevices();
   std::vector<AudioDeviceInfo> enumerateLinuxDevices();
+  std::vector<AudioEndpointCapabilities> enumerateCoreAudioEndpointCapabilities();
   AudioDeviceInfo getDummyDeviceInfo();
   std::unique_ptr<IAudioDriver> createDriverForDevice(const std::string& deviceId);
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+  static OSStatus endpointPropertyChanged(AudioObjectID, UInt32,
+                                          const AudioObjectPropertyAddress*, void*) noexcept;
+  void startEndpointMonitor();
+  void stopEndpointMonitor();
+  void endpointMonitorLoop();
+#endif
 
   std::unique_ptr<IAudioDriver> m_activeDriver;
   DriverFactory m_driverFactory;
@@ -100,6 +114,11 @@ private:
   uint32_t m_currentSampleRate{48000};
   uint32_t m_currentBufferSize{512};
   std::function<void()> m_deviceChangeCallback;
+  std::function<void()> m_endpointChangeCallback;
+  std::atomic<bool> m_endpointMonitorActive{false};
+  std::atomic<bool> m_endpointChangePending{false};
+  std::condition_variable m_endpointChangeCondition;
+  std::thread m_endpointMonitorThread;
   mutable std::mutex m_mutex;
 };
 
@@ -111,6 +130,9 @@ AudioDriverManager::AudioDriverManager(DriverFactory factory)
     : m_driverFactory(std::move(factory)) {}
 
 AudioDriverManager::~AudioDriverManager() {
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+  stopEndpointMonitor();
+#endif
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_activeDriver) {
     m_activeDriver->stop();
@@ -251,6 +273,60 @@ void AudioDriverManager::setDeviceChangeCallback(std::function<void()> callback)
 IAudioDriver* AudioDriverManager::getActiveDriver() {
   std::lock_guard<std::mutex> lock(m_mutex);
   return m_activeDriver.get();
+}
+
+std::vector<AudioEndpointCapabilities> AudioDriverManager::enumerateEndpointCapabilities() {
+  AudioEndpointCapabilities dummy;
+  dummy.device_id = "dummy";
+  dummy.display_name = "Dummy Audio Driver";
+  dummy.availability = AudioEndpointAvailability::Available;
+  dummy.supports_output = true;
+  dummy.output_channels.reserve(32);
+  for (uint16_t channel = 0; channel < 32; ++channel) {
+    dummy.output_channels.push_back(
+        {channel, "dummy:output:" + std::to_string(channel),
+         "Dummy Output " + std::to_string(channel + 1)});
+  }
+  dummy.supported_sample_rates = {44100, 48000, 88200, 96000};
+  dummy.supported_buffer_sizes = {128, 256, 512, 1024, 2048};
+  dummy.nominal_sample_rate = 48000;
+  dummy.current_buffer_size = 512;
+
+  std::vector<AudioEndpointCapabilities> endpoints;
+  endpoints.push_back(std::move(dummy));
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+  auto core_audio_endpoints = enumerateCoreAudioEndpointCapabilities();
+  endpoints.insert(endpoints.end(), core_audio_endpoints.begin(), core_audio_endpoints.end());
+#endif
+  return endpoints;
+}
+
+std::optional<AudioEndpointCapabilities> AudioDriverManager::getEndpointCapabilities(
+    const std::string& deviceId) {
+  for (auto& endpoint : enumerateEndpointCapabilities()) {
+    if (endpoint.device_id == deviceId) {
+      return endpoint;
+    }
+  }
+  return std::nullopt;
+}
+
+void AudioDriverManager::setEndpointChangeCallback(std::function<void()> callback) {
+  bool should_start = false;
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_endpointChangeCallback = std::move(callback);
+    should_start = static_cast<bool>(m_endpointChangeCallback);
+  }
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+  if (should_start) {
+    startEndpointMonitor();
+  } else {
+    stopEndpointMonitor();
+  }
+#else
+  (void)should_start;
+#endif
 }
 
 AudioDeviceInfo AudioDriverManager::getDummyDeviceInfo() {
@@ -395,6 +471,257 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateCoreAudioDevices() {
   }
 
   return devices;
+}
+
+std::vector<AudioEndpointCapabilities>
+AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
+  std::vector<AudioEndpointCapabilities> endpoints;
+  const AudioObjectPropertyAddress devices_address = {
+      kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
+      kAudioObjectPropertyElementMain};
+  UInt32 devices_size = 0;
+  if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &devices_address, 0, nullptr,
+                                     &devices_size) != noErr ||
+      devices_size == 0) {
+    return endpoints;
+  }
+  std::vector<AudioDeviceID> device_ids(devices_size / sizeof(AudioDeviceID));
+  if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &devices_address, 0, nullptr,
+                                 &devices_size, device_ids.data()) != noErr) {
+    return endpoints;
+  }
+
+  const auto read_string = [](AudioDeviceID device_id,
+                              AudioObjectPropertySelector selector) -> std::string {
+    const AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    CFStringRef value = nullptr;
+    UInt32 size = sizeof(value);
+    if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) != noErr ||
+        value == nullptr) {
+      return {};
+    }
+    char buffer[1024] = {};
+    const Boolean converted =
+        CFStringGetCString(value, buffer, sizeof(buffer), kCFStringEncodingUTF8);
+    CFRelease(value);
+    return converted ? std::string(buffer) : std::string{};
+  };
+  const auto read_channel_count = [](AudioDeviceID device_id,
+                                     AudioObjectPropertyScope scope) -> uint32_t {
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyStreamConfiguration, scope,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 size = 0;
+    if (AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &size) != noErr ||
+        size < sizeof(AudioBufferList)) {
+      return 0;
+    }
+    std::vector<uint8_t> storage(size);
+    auto* buffers = reinterpret_cast<AudioBufferList*>(storage.data());
+    if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, buffers) != noErr) {
+      return 0;
+    }
+    uint32_t channels = 0;
+    for (UInt32 index = 0; index < buffers->mNumberBuffers; ++index) {
+      channels += buffers->mBuffers[index].mNumberChannels;
+    }
+    return channels;
+  };
+  const auto read_uint32 = [](AudioDeviceID device_id, AudioObjectPropertySelector selector,
+                              AudioObjectPropertyScope scope) -> uint32_t {
+    const AudioObjectPropertyAddress address = {selector, scope,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 value = 0;
+    UInt32 size = sizeof(value);
+    return AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) == noErr
+               ? value
+               : 0;
+  };
+  const auto read_nominal_rate = [](AudioDeviceID device_id) -> uint32_t {
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyNominalSampleRate,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    Float64 value = 0.0;
+    UInt32 size = sizeof(value);
+    if (AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) != noErr ||
+        value <= 0.0) {
+      return 0;
+    }
+    return static_cast<uint32_t>(value);
+  };
+
+  AudioDeviceID default_input = 0;
+  AudioDeviceID default_output = 0;
+  const AudioObjectPropertyAddress default_input_address = {
+      kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal,
+      kAudioObjectPropertyElementMain};
+  const AudioObjectPropertyAddress default_output_address = {
+      kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal,
+      kAudioObjectPropertyElementMain};
+  UInt32 default_size = sizeof(default_input);
+  AudioObjectGetPropertyData(kAudioObjectSystemObject, &default_input_address, 0, nullptr,
+                             &default_size, &default_input);
+  default_size = sizeof(default_output);
+  AudioObjectGetPropertyData(kAudioObjectSystemObject, &default_output_address, 0, nullptr,
+                             &default_size, &default_output);
+
+  constexpr uint32_t common_rates[] = {44100, 48000, 88200, 96000, 176400, 192000};
+  constexpr uint32_t common_buffers[] = {32,  64,  96,  128,  160,  192,  256,
+                                         384, 512, 768, 1024, 1536, 2048, 4096};
+  for (const AudioDeviceID device_id : device_ids) {
+    const std::string uid = read_string(device_id, kAudioDevicePropertyDeviceUID);
+    if (uid.empty()) {
+      continue;
+    }
+    const std::string name = read_string(device_id, kAudioDevicePropertyDeviceNameCFString);
+    const uint32_t input_count = read_channel_count(device_id, kAudioObjectPropertyScopeInput);
+    const uint32_t output_count = read_channel_count(device_id, kAudioObjectPropertyScopeOutput);
+
+    AudioEndpointCapabilities endpoint;
+    endpoint.device_id = uid;
+    endpoint.display_name = name.empty() ? uid : name;
+    endpoint.availability = input_count != 0 || output_count != 0
+                                ? AudioEndpointAvailability::Available
+                                : AudioEndpointAvailability::FormatUnavailable;
+    endpoint.is_default_input = device_id == default_input;
+    endpoint.is_default_output = device_id == default_output;
+    endpoint.supports_input = input_count != 0;
+    endpoint.supports_output = output_count != 0;
+    endpoint.input_channels.reserve(input_count);
+    endpoint.output_channels.reserve(output_count);
+    for (uint32_t channel = 0; channel < input_count; ++channel) {
+      endpoint.input_channels.push_back(
+          {static_cast<uint16_t>(channel), uid + ":input:" + std::to_string(channel),
+           endpoint.display_name + " Input " + std::to_string(channel + 1)});
+    }
+    for (uint32_t channel = 0; channel < output_count; ++channel) {
+      endpoint.output_channels.push_back(
+          {static_cast<uint16_t>(channel), uid + ":output:" + std::to_string(channel),
+           endpoint.display_name + " Output " + std::to_string(channel + 1)});
+    }
+
+    const AudioObjectPropertyAddress rates_address = {
+        kAudioDevicePropertyAvailableNominalSampleRates, kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain};
+    UInt32 rates_size = 0;
+    if (AudioObjectGetPropertyDataSize(device_id, &rates_address, 0, nullptr, &rates_size) ==
+            noErr &&
+        rates_size >= sizeof(AudioValueRange)) {
+      std::vector<AudioValueRange> ranges(rates_size / sizeof(AudioValueRange));
+      if (AudioObjectGetPropertyData(device_id, &rates_address, 0, nullptr, &rates_size,
+                                     ranges.data()) == noErr) {
+        for (const uint32_t rate : common_rates) {
+          if (std::any_of(ranges.begin(), ranges.end(), [rate](const AudioValueRange& range) {
+                return rate >= range.mMinimum && rate <= range.mMaximum;
+              })) {
+            endpoint.supported_sample_rates.push_back(rate);
+          }
+        }
+      }
+    }
+    endpoint.nominal_sample_rate = read_nominal_rate(device_id);
+    if (endpoint.nominal_sample_rate != 0 &&
+        std::find(endpoint.supported_sample_rates.begin(), endpoint.supported_sample_rates.end(),
+                  endpoint.nominal_sample_rate) == endpoint.supported_sample_rates.end()) {
+      endpoint.supported_sample_rates.push_back(endpoint.nominal_sample_rate);
+    }
+    std::sort(endpoint.supported_sample_rates.begin(), endpoint.supported_sample_rates.end());
+
+    const AudioObjectPropertyAddress buffer_range_address = {
+        kAudioDevicePropertyBufferFrameSizeRange, kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain};
+    AudioValueRange buffer_range{};
+    UInt32 buffer_range_size = sizeof(buffer_range);
+    if (AudioObjectGetPropertyData(device_id, &buffer_range_address, 0, nullptr,
+                                   &buffer_range_size, &buffer_range) == noErr) {
+      for (const uint32_t buffer : common_buffers) {
+        if (buffer >= buffer_range.mMinimum && buffer <= buffer_range.mMaximum) {
+          endpoint.supported_buffer_sizes.push_back(buffer);
+        }
+      }
+    }
+    endpoint.current_buffer_size =
+        read_uint32(device_id, kAudioDevicePropertyBufferFrameSize,
+                    kAudioObjectPropertyScopeGlobal);
+    if (endpoint.current_buffer_size != 0 &&
+        std::find(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end(),
+                  endpoint.current_buffer_size) == endpoint.supported_buffer_sizes.end()) {
+      endpoint.supported_buffer_sizes.push_back(endpoint.current_buffer_size);
+    }
+    std::sort(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end());
+    endpoints.push_back(std::move(endpoint));
+  }
+  return endpoints;
+}
+#endif
+
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+OSStatus AudioDriverManager::endpointPropertyChanged(
+    AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void* context) noexcept {
+  auto* manager = static_cast<AudioDriverManager*>(context);
+  if (manager == nullptr) {
+    return noErr;
+  }
+  manager->m_endpointChangePending.store(true, std::memory_order_release);
+  manager->m_endpointChangeCondition.notify_one();
+  return noErr;
+}
+
+void AudioDriverManager::startEndpointMonitor() {
+  if (m_endpointMonitorActive.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+  const AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
+                                              kAudioObjectPropertyScopeGlobal,
+                                              kAudioObjectPropertyElementMain};
+  if (AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address, &endpointPropertyChanged,
+                                     this) != noErr) {
+    m_endpointMonitorActive.store(false, std::memory_order_release);
+    return;
+  }
+  try {
+    m_endpointMonitorThread = std::thread(&AudioDriverManager::endpointMonitorLoop, this);
+  } catch (...) {
+    AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address,
+                                      &endpointPropertyChanged, this);
+    m_endpointMonitorActive.store(false, std::memory_order_release);
+  }
+}
+
+void AudioDriverManager::stopEndpointMonitor() {
+  if (!m_endpointMonitorActive.exchange(false, std::memory_order_acq_rel) &&
+      !m_endpointMonitorThread.joinable()) {
+    return;
+  }
+  const AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
+                                              kAudioObjectPropertyScopeGlobal,
+                                              kAudioObjectPropertyElementMain};
+  AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address, &endpointPropertyChanged,
+                                    this);
+  m_endpointChangePending.store(true, std::memory_order_release);
+  m_endpointChangeCondition.notify_one();
+  if (m_endpointMonitorThread.joinable()) {
+    m_endpointMonitorThread.join();
+  }
+}
+
+void AudioDriverManager::endpointMonitorLoop() {
+  while (m_endpointMonitorActive.load(std::memory_order_acquire)) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_endpointChangeCondition.wait(lock, [this] {
+      return m_endpointChangePending.load(std::memory_order_acquire) ||
+             !m_endpointMonitorActive.load(std::memory_order_acquire);
+    });
+    m_endpointChangePending.store(false, std::memory_order_release);
+    if (!m_endpointMonitorActive.load(std::memory_order_acquire)) {
+      break;
+    }
+    const auto endpoint_callback = m_endpointChangeCallback;
+    lock.unlock();
+    if (endpoint_callback) {
+      endpoint_callback();
+    }
+  }
 }
 #endif
 

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "coreaudio/coreaudio_endpoint_catalog.h"
+#include "coreaudio/coreaudio_endpoint_monitor.h"
 
 #include <orpheus/audio_driver.h>
 #include <orpheus/audio_driver_manager.h>
@@ -91,8 +92,8 @@ public:
   void setDeviceChangeCallback(std::function<void()> callback) override;
   IAudioDriver* getActiveDriver() override;
   std::vector<AudioEndpointCapabilities> enumerateEndpointCapabilities() override;
-  std::optional<AudioEndpointCapabilities> getEndpointCapabilities(
-      const std::string& deviceId) override;
+  std::optional<AudioEndpointCapabilities>
+  getEndpointCapabilities(const std::string& deviceId) override;
   void setEndpointChangeCallback(std::function<void()> callback) override;
 
 private:
@@ -103,11 +104,7 @@ private:
   AudioDeviceInfo getDummyDeviceInfo();
   std::unique_ptr<IAudioDriver> createDriverForDevice(const std::string& deviceId);
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  static OSStatus endpointPropertyChanged(AudioObjectID, UInt32,
-                                          const AudioObjectPropertyAddress*, void*) noexcept;
-  void startEndpointMonitor();
-  void stopEndpointMonitor();
-  void endpointMonitorLoop();
+  std::unique_ptr<CoreAudioEndpointMonitor> m_endpointMonitor;
 #endif
 
   std::unique_ptr<IAudioDriver> m_activeDriver;
@@ -116,11 +113,6 @@ private:
   uint32_t m_currentSampleRate{48000};
   uint32_t m_currentBufferSize{512};
   std::function<void()> m_deviceChangeCallback;
-  std::function<void()> m_endpointChangeCallback;
-  std::atomic<bool> m_endpointMonitorActive{false};
-  std::atomic<bool> m_endpointChangePending{false};
-  std::condition_variable m_endpointChangeCondition;
-  std::thread m_endpointMonitorThread;
   mutable std::mutex m_mutex;
 };
 
@@ -133,7 +125,7 @@ AudioDriverManager::AudioDriverManager(DriverFactory factory)
 
 AudioDriverManager::~AudioDriverManager() {
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  stopEndpointMonitor();
+  m_endpointMonitor.reset();
 #endif
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_activeDriver) {
@@ -285,9 +277,8 @@ std::vector<AudioEndpointCapabilities> AudioDriverManager::enumerateEndpointCapa
   dummy.supports_output = true;
   dummy.output_channels.reserve(32);
   for (uint16_t channel = 0; channel < 32; ++channel) {
-    dummy.output_channels.push_back(
-        {channel, "dummy:output:" + std::to_string(channel),
-         "Dummy Output " + std::to_string(channel + 1)});
+    dummy.output_channels.push_back({channel, "dummy:output:" + std::to_string(channel),
+                                     "Dummy Output " + std::to_string(channel + 1)});
   }
   dummy.supported_sample_rates = {44100, 48000, 88200, 96000};
   dummy.supported_buffer_sizes = {128, 256, 512, 1024, 2048};
@@ -303,8 +294,8 @@ std::vector<AudioEndpointCapabilities> AudioDriverManager::enumerateEndpointCapa
   return endpoints;
 }
 
-std::optional<AudioEndpointCapabilities> AudioDriverManager::getEndpointCapabilities(
-    const std::string& deviceId) {
+std::optional<AudioEndpointCapabilities>
+AudioDriverManager::getEndpointCapabilities(const std::string& deviceId) {
   for (auto& endpoint : enumerateEndpointCapabilities()) {
     if (endpoint.device_id == deviceId) {
       return endpoint;
@@ -314,20 +305,14 @@ std::optional<AudioEndpointCapabilities> AudioDriverManager::getEndpointCapabili
 }
 
 void AudioDriverManager::setEndpointChangeCallback(std::function<void()> callback) {
-  bool should_start = false;
-  {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_endpointChangeCallback = std::move(callback);
-    should_start = static_cast<bool>(m_endpointChangeCallback);
-  }
 #if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-  if (should_start) {
-    startEndpointMonitor();
-  } else {
-    stopEndpointMonitor();
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (!m_endpointMonitor) {
+    m_endpointMonitor = createCoreAudioEndpointMonitor();
   }
+  m_endpointMonitor->setCallback(std::move(callback));
 #else
-  (void)should_start;
+  (void)callback;
 #endif
 }
 
@@ -478,9 +463,9 @@ std::vector<AudioDeviceInfo> AudioDriverManager::enumerateCoreAudioDevices() {
 std::vector<AudioEndpointCapabilities>
 AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
   std::vector<AudioEndpointCapabilities> endpoints;
-  const AudioObjectPropertyAddress devices_address = {
-      kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
-      kAudioObjectPropertyElementMain};
+  const AudioObjectPropertyAddress devices_address = {kAudioHardwarePropertyDevices,
+                                                      kAudioObjectPropertyScopeGlobal,
+                                                      kAudioObjectPropertyElementMain};
   UInt32 devices_size = 0;
   if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &devices_address, 0, nullptr,
                                      &devices_size) != noErr ||
@@ -531,8 +516,7 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
   };
   const auto read_uint32 = [](AudioDeviceID device_id, AudioObjectPropertySelector selector,
                               AudioObjectPropertyScope scope) -> uint32_t {
-    const AudioObjectPropertyAddress address = {selector, scope,
-                                                kAudioObjectPropertyElementMain};
+    const AudioObjectPropertyAddress address = {selector, scope, kAudioObjectPropertyElementMain};
     UInt32 value = 0;
     UInt32 size = sizeof(value);
     return AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &size, &value) == noErr
@@ -578,10 +562,8 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
     facts.display_name = read_string(device_id, kAudioDevicePropertyDeviceNameCFString);
     facts.is_default_input = device_id == default_input;
     facts.is_default_output = device_id == default_output;
-    facts.input_channel_count =
-        read_channel_count(device_id, kAudioObjectPropertyScopeInput);
-    facts.output_channel_count =
-        read_channel_count(device_id, kAudioObjectPropertyScopeOutput);
+    facts.input_channel_count = read_channel_count(device_id, kAudioObjectPropertyScopeInput);
+    facts.output_channel_count = read_channel_count(device_id, kAudioObjectPropertyScopeOutput);
 
     const AudioObjectPropertyAddress rates_address = {
         kAudioDevicePropertyAvailableNominalSampleRates, kAudioObjectPropertyScopeGlobal,
@@ -607,89 +589,17 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
         kAudioObjectPropertyElementMain};
     AudioValueRange buffer_range{};
     UInt32 buffer_range_size = sizeof(buffer_range);
-    if (AudioObjectGetPropertyData(device_id, &buffer_range_address, 0, nullptr,
-                                   &buffer_range_size, &buffer_range) == noErr) {
+    if (AudioObjectGetPropertyData(device_id, &buffer_range_address, 0, nullptr, &buffer_range_size,
+                                   &buffer_range) == noErr) {
       facts.buffer_size_ranges.push_back(
-          {static_cast<double>(buffer_range.mMinimum),
-           static_cast<double>(buffer_range.mMaximum)});
+          {static_cast<double>(buffer_range.mMinimum), static_cast<double>(buffer_range.mMaximum)});
     }
-    facts.current_buffer_size =
-        read_uint32(device_id, kAudioDevicePropertyBufferFrameSize,
-                    kAudioObjectPropertyScopeGlobal);
+    facts.current_buffer_size = read_uint32(device_id, kAudioDevicePropertyBufferFrameSize,
+                                            kAudioObjectPropertyScopeGlobal);
 
     endpoints.push_back(detail::makeCoreAudioEndpointCapabilities(facts));
   }
   return endpoints;
-}
-#endif
-
-#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
-OSStatus AudioDriverManager::endpointPropertyChanged(
-    AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void* context) noexcept {
-  auto* manager = static_cast<AudioDriverManager*>(context);
-  if (manager == nullptr) {
-    return noErr;
-  }
-  manager->m_endpointChangePending.store(true, std::memory_order_release);
-  manager->m_endpointChangeCondition.notify_one();
-  return noErr;
-}
-
-void AudioDriverManager::startEndpointMonitor() {
-  if (m_endpointMonitorActive.exchange(true, std::memory_order_acq_rel)) {
-    return;
-  }
-  const AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
-                                              kAudioObjectPropertyScopeGlobal,
-                                              kAudioObjectPropertyElementMain};
-  if (AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address, &endpointPropertyChanged,
-                                     this) != noErr) {
-    m_endpointMonitorActive.store(false, std::memory_order_release);
-    return;
-  }
-  try {
-    m_endpointMonitorThread = std::thread(&AudioDriverManager::endpointMonitorLoop, this);
-  } catch (...) {
-    AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address,
-                                      &endpointPropertyChanged, this);
-    m_endpointMonitorActive.store(false, std::memory_order_release);
-  }
-}
-
-void AudioDriverManager::stopEndpointMonitor() {
-  if (!m_endpointMonitorActive.exchange(false, std::memory_order_acq_rel) &&
-      !m_endpointMonitorThread.joinable()) {
-    return;
-  }
-  const AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
-                                              kAudioObjectPropertyScopeGlobal,
-                                              kAudioObjectPropertyElementMain};
-  AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address, &endpointPropertyChanged,
-                                    this);
-  m_endpointChangePending.store(true, std::memory_order_release);
-  m_endpointChangeCondition.notify_one();
-  if (m_endpointMonitorThread.joinable()) {
-    m_endpointMonitorThread.join();
-  }
-}
-
-void AudioDriverManager::endpointMonitorLoop() {
-  while (m_endpointMonitorActive.load(std::memory_order_acquire)) {
-    std::unique_lock<std::mutex> lock(m_mutex);
-    m_endpointChangeCondition.wait(lock, [this] {
-      return m_endpointChangePending.load(std::memory_order_acquire) ||
-             !m_endpointMonitorActive.load(std::memory_order_acquire);
-    });
-    m_endpointChangePending.store(false, std::memory_order_release);
-    if (!m_endpointMonitorActive.load(std::memory_order_acquire)) {
-      break;
-    }
-    const auto endpoint_callback = m_endpointChangeCallback;
-    lock.unlock();
-    if (endpoint_callback) {
-      endpoint_callback();
-    }
-  }
 }
 #endif
 

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include "coreaudio/coreaudio_endpoint_catalog.h"
+
 #include <orpheus/audio_driver.h>
 #include <orpheus/audio_driver_manager.h>
 
@@ -565,40 +567,21 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
   AudioObjectGetPropertyData(kAudioObjectSystemObject, &default_output_address, 0, nullptr,
                              &default_size, &default_output);
 
-  constexpr uint32_t common_rates[] = {44100, 48000, 88200, 96000, 176400, 192000};
-  constexpr uint32_t common_buffers[] = {32,  64,  96,  128,  160,  192,  256,
-                                         384, 512, 768, 1024, 1536, 2048, 4096};
   for (const AudioDeviceID device_id : device_ids) {
     const std::string uid = read_string(device_id, kAudioDevicePropertyDeviceUID);
     if (uid.empty()) {
       continue;
     }
-    const std::string name = read_string(device_id, kAudioDevicePropertyDeviceNameCFString);
-    const uint32_t input_count = read_channel_count(device_id, kAudioObjectPropertyScopeInput);
-    const uint32_t output_count = read_channel_count(device_id, kAudioObjectPropertyScopeOutput);
 
-    AudioEndpointCapabilities endpoint;
-    endpoint.device_id = uid;
-    endpoint.display_name = name.empty() ? uid : name;
-    endpoint.availability = input_count != 0 || output_count != 0
-                                ? AudioEndpointAvailability::Available
-                                : AudioEndpointAvailability::FormatUnavailable;
-    endpoint.is_default_input = device_id == default_input;
-    endpoint.is_default_output = device_id == default_output;
-    endpoint.supports_input = input_count != 0;
-    endpoint.supports_output = output_count != 0;
-    endpoint.input_channels.reserve(input_count);
-    endpoint.output_channels.reserve(output_count);
-    for (uint32_t channel = 0; channel < input_count; ++channel) {
-      endpoint.input_channels.push_back(
-          {static_cast<uint16_t>(channel), uid + ":input:" + std::to_string(channel),
-           endpoint.display_name + " Input " + std::to_string(channel + 1)});
-    }
-    for (uint32_t channel = 0; channel < output_count; ++channel) {
-      endpoint.output_channels.push_back(
-          {static_cast<uint16_t>(channel), uid + ":output:" + std::to_string(channel),
-           endpoint.display_name + " Output " + std::to_string(channel + 1)});
-    }
+    detail::CoreAudioEndpointFacts facts;
+    facts.device_id = uid;
+    facts.display_name = read_string(device_id, kAudioDevicePropertyDeviceNameCFString);
+    facts.is_default_input = device_id == default_input;
+    facts.is_default_output = device_id == default_output;
+    facts.input_channel_count =
+        read_channel_count(device_id, kAudioObjectPropertyScopeInput);
+    facts.output_channel_count =
+        read_channel_count(device_id, kAudioObjectPropertyScopeOutput);
 
     const AudioObjectPropertyAddress rates_address = {
         kAudioDevicePropertyAvailableNominalSampleRates, kAudioObjectPropertyScopeGlobal,
@@ -610,22 +593,14 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
       std::vector<AudioValueRange> ranges(rates_size / sizeof(AudioValueRange));
       if (AudioObjectGetPropertyData(device_id, &rates_address, 0, nullptr, &rates_size,
                                      ranges.data()) == noErr) {
-        for (const uint32_t rate : common_rates) {
-          if (std::any_of(ranges.begin(), ranges.end(), [rate](const AudioValueRange& range) {
-                return rate >= range.mMinimum && rate <= range.mMaximum;
-              })) {
-            endpoint.supported_sample_rates.push_back(rate);
-          }
+        facts.sample_rate_ranges.reserve(ranges.size());
+        for (const auto& range : ranges) {
+          facts.sample_rate_ranges.push_back(
+              {static_cast<double>(range.mMinimum), static_cast<double>(range.mMaximum)});
         }
       }
     }
-    endpoint.nominal_sample_rate = read_nominal_rate(device_id);
-    if (endpoint.nominal_sample_rate != 0 &&
-        std::find(endpoint.supported_sample_rates.begin(), endpoint.supported_sample_rates.end(),
-                  endpoint.nominal_sample_rate) == endpoint.supported_sample_rates.end()) {
-      endpoint.supported_sample_rates.push_back(endpoint.nominal_sample_rate);
-    }
-    std::sort(endpoint.supported_sample_rates.begin(), endpoint.supported_sample_rates.end());
+    facts.nominal_sample_rate = read_nominal_rate(device_id);
 
     const AudioObjectPropertyAddress buffer_range_address = {
         kAudioDevicePropertyBufferFrameSizeRange, kAudioObjectPropertyScopeGlobal,
@@ -634,22 +609,15 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
     UInt32 buffer_range_size = sizeof(buffer_range);
     if (AudioObjectGetPropertyData(device_id, &buffer_range_address, 0, nullptr,
                                    &buffer_range_size, &buffer_range) == noErr) {
-      for (const uint32_t buffer : common_buffers) {
-        if (buffer >= buffer_range.mMinimum && buffer <= buffer_range.mMaximum) {
-          endpoint.supported_buffer_sizes.push_back(buffer);
-        }
-      }
+      facts.buffer_size_ranges.push_back(
+          {static_cast<double>(buffer_range.mMinimum),
+           static_cast<double>(buffer_range.mMaximum)});
     }
-    endpoint.current_buffer_size =
+    facts.current_buffer_size =
         read_uint32(device_id, kAudioDevicePropertyBufferFrameSize,
                     kAudioObjectPropertyScopeGlobal);
-    if (endpoint.current_buffer_size != 0 &&
-        std::find(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end(),
-                  endpoint.current_buffer_size) == endpoint.supported_buffer_sizes.end()) {
-      endpoint.supported_buffer_sizes.push_back(endpoint.current_buffer_size);
-    }
-    std::sort(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end());
-    endpoints.push_back(std::move(endpoint));
+
+    endpoints.push_back(detail::makeCoreAudioEndpointCapabilities(facts));
   }
   return endpoints;
 }

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -284,6 +284,7 @@ endif()
 # Audio Driver Manager tests
 add_executable(driver_manager_test
     driver_manager_test.cpp
+    coreaudio_endpoint_catalog_test.cpp
 )
 
 target_link_libraries(driver_manager_test
@@ -308,6 +309,7 @@ target_include_directories(driver_manager_test
     PRIVATE
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/src/core
+        ${CMAKE_SOURCE_DIR}/src/platform/audio_drivers
 )
 
 add_test(NAME driver_manager_test COMMAND driver_manager_test)

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -284,6 +284,7 @@ endif()
 # Audio Driver Manager tests
 add_executable(driver_manager_test
     driver_manager_test.cpp
+    coreaudio_endpoint_monitor_test.cpp
     coreaudio_endpoint_catalog_test.cpp
 )
 

--- a/tests/audio_io/coreaudio_driver_test.cpp
+++ b/tests/audio_io/coreaudio_driver_test.cpp
@@ -982,6 +982,33 @@ TEST_F(CoreAudioDriverTest, ExplicitOutputUidAndMapAreReflectedInActiveRoute) {
   ASSERT_EQ(m_driver->stop(), SessionGraphError::OK);
 }
 
+TEST_F(CoreAudioDriverTest, OutputRouteRequestPublishesPlaybackState) {
+  const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();
+  if (!endpoints.isValid()) {
+    GTEST_SKIP() << "Distinct default output with a readable UID is unavailable";
+  }
+
+  AudioOutputRouteRequest request;
+  request.output_device_id = endpoints.output_uid;
+  request.output_channel_map = {1, 0};
+  request.requested_sample_rate = 48000;
+  request.requested_buffer_size = 512;
+
+  ASSERT_EQ(m_driver->initializeAudioOutput(request), SessionGraphError::OK);
+  const AudioIoRouteState initialized = m_driver->getAudioIoRouteState();
+  EXPECT_EQ(initialized.state, AudioRouteState::Inactive);
+  EXPECT_EQ(initialized.selected_output_device_id, endpoints.output_uid);
+  EXPECT_EQ(initialized.requested_buffer_size, 512u);
+  EXPECT_EQ(initialized.actual_buffer_size, 512u);
+  EXPECT_EQ(initialized.active_output_channel_map, request.output_channel_map);
+  EXPECT_EQ(initialized.requested_sample_rate, 48000u);
+  EXPECT_EQ(initialized.actual_sample_rate, 48000u);
+
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+  EXPECT_EQ(m_driver->getAudioIoRouteState().state, AudioRouteState::Running);
+  ASSERT_EQ(m_driver->stop(), SessionGraphError::OK);
+}
+
 TEST_F(CoreAudioDriverTest, StopWaitsForAdmittedCallback) {
   const EndpointPair endpoints = getDistinctDefaultEndpointsForTest();
   if (!endpoints.isValid()) {

--- a/tests/audio_io/coreaudio_endpoint_catalog_test.cpp
+++ b/tests/audio_io/coreaudio_endpoint_catalog_test.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio/coreaudio_endpoint_catalog.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+using detail::CoreAudioEndpointFacts;
+using detail::CoreAudioEndpointRange;
+using detail::makeCoreAudioEndpointCapabilities;
+
+TEST(CoreAudioEndpointCatalogTest, PreservesOutputOnlyEndpointsAndDuplicateNames) {
+  const std::vector<CoreAudioEndpointFacts> facts = {
+      {.device_id = "uid-output-a",
+       .display_name = "Duplicate Interface",
+       .is_default_output = true,
+       .output_channel_count = 2,
+       .sample_rate_ranges = {{44100.0, 48000.0}},
+       .buffer_size_ranges = {{64.0, 512.0}},
+       .nominal_sample_rate = 48000,
+       .current_buffer_size = 256},
+      {.device_id = "uid-output-b",
+       .display_name = "Duplicate Interface",
+       .output_channel_count = 1,
+       .sample_rate_ranges = {{96000.0, 192000.0}},
+       .buffer_size_ranges = {{128.0, 1024.0}},
+       .nominal_sample_rate = 96000,
+       .current_buffer_size = 1024},
+  };
+
+  std::vector<AudioEndpointCapabilities> endpoints;
+  endpoints.reserve(facts.size());
+  for (const auto& endpoint : facts) {
+    endpoints.push_back(makeCoreAudioEndpointCapabilities(endpoint));
+  }
+
+  ASSERT_EQ(endpoints.size(), 2u);
+  EXPECT_EQ(endpoints[0].device_id, "uid-output-a");
+  EXPECT_EQ(endpoints[1].device_id, "uid-output-b");
+  EXPECT_EQ(endpoints[0].display_name, endpoints[1].display_name);
+  EXPECT_FALSE(endpoints[0].supports_input);
+  EXPECT_TRUE(endpoints[0].supports_output);
+  EXPECT_TRUE(endpoints[0].is_default_output);
+  ASSERT_EQ(endpoints[0].output_channels.size(), 2u);
+  EXPECT_EQ(endpoints[0].output_channels[0].stable_id, "uid-output-a:output:0");
+  EXPECT_EQ(endpoints[0].output_channels[1].device_index, 1u);
+  EXPECT_EQ(endpoints[0].supported_buffer_sizes,
+            (std::vector<uint32_t>{64, 96, 128, 160, 192, 256, 384, 512}));
+  EXPECT_EQ(endpoints[0].current_buffer_size, 256u);
+  EXPECT_EQ(endpoints[1].output_channels[0].stable_id, "uid-output-b:output:0");
+  EXPECT_EQ(endpoints[1].supported_sample_rates,
+            (std::vector<uint32_t>{96000, 176400, 192000}));
+  EXPECT_EQ(endpoints[1].supported_buffer_sizes,
+            (std::vector<uint32_t>{128, 160, 192, 256, 384, 512, 768, 1024}));
+}
+
+TEST(CoreAudioEndpointCatalogTest, ReportsFormatUnavailableWithoutUsableChannels) {
+  const CoreAudioEndpointFacts facts{
+      .device_id = "uid-no-format",
+      .display_name = "No Format",
+      .sample_rate_ranges = {{48000.0, 48000.0}},
+      .buffer_size_ranges = {{512.0, 512.0}},
+      .nominal_sample_rate = 48000,
+      .current_buffer_size = 512,
+  };
+
+  const auto endpoint = makeCoreAudioEndpointCapabilities(facts);
+  EXPECT_EQ(endpoint.availability, AudioEndpointAvailability::FormatUnavailable);
+  EXPECT_FALSE(endpoint.supports_input);
+  EXPECT_FALSE(endpoint.supports_output);
+  EXPECT_TRUE(endpoint.input_channels.empty());
+  EXPECT_TRUE(endpoint.output_channels.empty());
+  EXPECT_EQ(endpoint.supported_sample_rates, (std::vector<uint32_t>{48000}));
+  EXPECT_EQ(endpoint.supported_buffer_sizes, (std::vector<uint32_t>{512}));
+}
+
+} // namespace
+} // namespace orpheus

--- a/tests/audio_io/coreaudio_endpoint_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_endpoint_monitor_test.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+#include <gtest/gtest.h>
+
+#if defined(__APPLE__) && defined(ORPHEUS_ENABLE_COREAUDIO)
+#include "coreaudio/coreaudio_endpoint_monitor.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+class FakeCoreAudioEndpointPropertyApi final : public ICoreAudioEndpointPropertyApi {
+public:
+  struct Listener {
+    AudioObjectPropertyAddress address;
+    AudioObjectPropertyListenerProc callback;
+    void* context;
+  };
+
+  OSStatus addPropertyListener(AudioObjectID, const AudioObjectPropertyAddress* address,
+                               AudioObjectPropertyListenerProc callback,
+                               void* context) noexcept override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    listeners_.push_back({*address, callback, context});
+    return noErr;
+  }
+
+  OSStatus removePropertyListener(AudioObjectID, const AudioObjectPropertyAddress* address,
+                                  AudioObjectPropertyListenerProc callback,
+                                  void* context) noexcept override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto listener =
+        std::find_if(listeners_.begin(), listeners_.end(), [&](const Listener& candidate) {
+          return candidate.address.mSelector == address->mSelector &&
+                 candidate.callback == callback && candidate.context == context;
+        });
+    if (listener == listeners_.end()) {
+      return -1;
+    }
+    listeners_.erase(listener);
+    return noErr;
+  }
+
+  void notify(AudioObjectPropertySelector selector) {
+    std::vector<Listener> listeners;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      listeners = listeners_;
+    }
+    const AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    for (const Listener& listener : listeners) {
+      if (listener.address.mSelector == selector) {
+        listener.callback(kAudioObjectSystemObject, 1, &address, listener.context);
+      }
+    }
+  }
+
+  size_t listenerCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return listeners_.size();
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<Listener> listeners_;
+};
+
+TEST(CoreAudioEndpointMonitorTest, MonitorsDeviceAndDefaultEndpointChanges) {
+  FakeCoreAudioEndpointPropertyApi api;
+  CoreAudioEndpointMonitor monitor(api);
+  std::promise<void> callback_called;
+  auto callback_complete = callback_called.get_future();
+
+  monitor.setCallback([&callback_called] { callback_called.set_value(); });
+  ASSERT_EQ(api.listenerCount(), 3u);
+
+  api.notify(kAudioHardwarePropertyDefaultOutputDevice);
+  EXPECT_EQ(callback_complete.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+
+  monitor.setCallback({});
+  EXPECT_EQ(api.listenerCount(), 0u);
+}
+
+TEST(CoreAudioEndpointMonitorTest, CallbackMayUnregisterItself) {
+  FakeCoreAudioEndpointPropertyApi api;
+  CoreAudioEndpointMonitor monitor(api);
+  std::promise<void> callback_finished;
+  auto completion = callback_finished.get_future();
+
+  monitor.setCallback([&] {
+    monitor.setCallback({});
+    callback_finished.set_value();
+  });
+  api.notify(kAudioHardwarePropertyDevices);
+
+  EXPECT_EQ(completion.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_EQ(api.listenerCount(), 0u);
+}
+
+TEST(CoreAudioEndpointMonitorTest, CallbackMayDestroyMonitor) {
+  FakeCoreAudioEndpointPropertyApi api;
+  auto monitor = std::make_unique<CoreAudioEndpointMonitor>(api);
+  std::promise<void> callback_finished;
+  auto completion = callback_finished.get_future();
+
+  monitor->setCallback([&] {
+    monitor.reset();
+    callback_finished.set_value();
+  });
+  api.notify(kAudioHardwarePropertyDevices);
+
+  EXPECT_EQ(completion.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_EQ(api.listenerCount(), 0u);
+}
+
+} // namespace
+} // namespace orpheus
+#endif

--- a/tests/audio_io/coreaudio_route_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_route_monitor_test.cpp
@@ -179,7 +179,8 @@ public:
     api.setFormat(stream.stream_id, kAudioStreamPropertyPhysicalFormat,
                   stream.expected_physical_format);
     monitor = std::make_unique<CoreAudioRouteMonitor>(
-        api, 48000, 512, std::vector<AudioDeviceID>{1}, std::vector<CoreAudioRouteStream>{stream});
+        api, 48000, 512, std::vector<CoreAudioRouteDevice>{{1, false, false}},
+        std::vector<CoreAudioRouteStream>{stream});
     initialization_ok = monitor->start();
     if (initialization_ok) {
       monitor->requestCheck();
@@ -273,6 +274,42 @@ TEST(CoreAudioRouteMonitorTest, PropertyReadFailureReportsBackendFailure) {
 
   EXPECT_EQ(fixture.monitor->poll(), CoreAudioRoutePollResult::BackendFailure);
   EXPECT_FALSE(fixture.monitor->permitsRendering());
+}
+TEST(CoreAudioRouteMonitorTest, ReportsUnavailableDirectionForDistinctDuplexEndpoints) {
+  FakeCoreAudioRoutePropertyApi api;
+  for (const AudioDeviceID device_id : {AudioDeviceID{1}, AudioDeviceID{2}, AudioDeviceID{3}}) {
+    api.setAlive(device_id, 1);
+    api.setRate(device_id, 48000.0);
+    api.setBuffer(device_id, 512);
+  }
+
+  {
+    CoreAudioRouteMonitor monitor(
+        api, 48000, 512,
+        std::vector<CoreAudioRouteDevice>{{1, false, false}, {2, true, false}, {3, false, true}},
+        {});
+    ASSERT_TRUE(monitor.start());
+    monitor.requestCheck();
+    ASSERT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+    api.setAlive(2, 0);
+    api.notify(2, kAudioDevicePropertyDeviceIsAlive);
+    EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::InputUnavailable);
+  }
+
+  api.setAlive(2, 1);
+  {
+    CoreAudioRouteMonitor monitor(
+        api, 48000, 512,
+        std::vector<CoreAudioRouteDevice>{{1, false, false}, {2, true, false}, {3, false, true}},
+        {});
+    ASSERT_TRUE(monitor.start());
+    monitor.requestCheck();
+    ASSERT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+    api.setAlive(1, 0);
+    api.setAlive(3, 0);
+    api.notify(3, kAudioDevicePropertyDeviceIsAlive);
+    EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::OutputUnavailable);
+  }
 }
 
 } // namespace

--- a/tests/audio_io/driver_manager_test.cpp
+++ b/tests/audio_io/driver_manager_test.cpp
@@ -37,6 +37,24 @@ TEST_F(AudioDriverManagerTest, EnumerateDevices_IncludesDummyDriver) {
   EXPECT_FALSE(devices[0].isDefaultDevice) << "Dummy driver should not be default";
 }
 
+TEST_F(AudioDriverManagerTest, EndpointCapabilitiesExposeStableDirectionalChannels) {
+  const auto endpoints = manager->enumerateEndpointCapabilities();
+  ASSERT_FALSE(endpoints.empty());
+  ASSERT_EQ(endpoints.front().device_id, "dummy");
+  EXPECT_EQ(endpoints.front().availability, AudioEndpointAvailability::Available);
+  EXPECT_FALSE(endpoints.front().supports_input);
+  EXPECT_TRUE(endpoints.front().supports_output);
+  ASSERT_EQ(endpoints.front().output_channels.size(), 32u);
+  EXPECT_EQ(endpoints.front().output_channels[2].stable_id, "dummy:output:2");
+  EXPECT_EQ(endpoints.front().output_channels[2].device_index, 2u);
+  EXPECT_EQ(endpoints.front().output_channels[2].display_name, "Dummy Output 3");
+
+  const auto dummy = manager->getEndpointCapabilities("dummy");
+  ASSERT_TRUE(dummy.has_value());
+  EXPECT_EQ(dummy->output_channels.size(), 32u);
+  EXPECT_FALSE(manager->getEndpointCapabilities("missing-endpoint").has_value());
+}
+
 /// Test: Device enumeration returns valid device info
 TEST_F(AudioDriverManagerTest, EnumerateDevices_ValidDeviceInfo) {
   auto devices = manager->enumerateDevices();

--- a/tests/audio_io/dummy_driver_test.cpp
+++ b/tests/audio_io/dummy_driver_test.cpp
@@ -148,6 +148,36 @@ TEST_F(DummyDriverTest, RetainsRequestedChannelMapWithoutFabricatingPhysicalRout
   EXPECT_FALSE(active_route.latency.complete);
 }
 
+TEST_F(DummyDriverTest, OutputRouteRequestPreservesMapAndLifecycleState) {
+  AudioOutputRouteRequest request;
+  request.output_device_id = "dummy";
+  request.output_channel_map = {2, 0};
+  request.requested_sample_rate = 48000;
+  request.requested_buffer_size = 256;
+
+  ASSERT_EQ(m_driver->initializeAudioOutput(request), SessionGraphError::OK);
+  auto state = m_driver->getAudioIoRouteState();
+  EXPECT_EQ(state.state, AudioRouteState::Inactive);
+  EXPECT_EQ(state.selected_output_device_id, "dummy");
+  EXPECT_EQ(state.active_output_channel_map, request.output_channel_map);
+  EXPECT_EQ(state.requested_sample_rate, 48000u);
+  EXPECT_EQ(state.actual_sample_rate, 48000u);
+  EXPECT_EQ(state.requested_buffer_size, 256u);
+  EXPECT_EQ(state.actual_buffer_size, 256u);
+
+  ASSERT_EQ(m_driver->start(m_callback.get()), SessionGraphError::OK);
+  state = m_driver->getAudioIoRouteState();
+  EXPECT_EQ(state.state, AudioRouteState::Running);
+  ASSERT_EQ(m_driver->stop(), SessionGraphError::OK);
+  EXPECT_EQ(m_driver->getAudioIoRouteState().state, AudioRouteState::Inactive);
+}
+
+TEST_F(DummyDriverTest, OutputRouteRequestRejectsDuplicateMap) {
+  AudioOutputRouteRequest request;
+  request.output_channel_map = {1, 1};
+  EXPECT_EQ(m_driver->initializeAudioOutput(request), SessionGraphError::InvalidParameter);
+}
+
 TEST_F(DummyDriverTest, InitializeRejectsInvalidConfig) {
   AudioDriverConfig config;
   config.sample_rate = 0; // Invalid

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -39,37 +39,47 @@ int main() {
   if (!outputDriver) {
     return 11;
   }
-  orpheus::AudioDriverConfig outputConfig;
-  outputConfig.sample_rate = kSampleRate;
-  outputConfig.buffer_size = 128;
-  outputConfig.num_inputs = 0;
-  outputConfig.num_outputs = 2;
-  outputConfig.output_device_id = "dummy";
-  outputConfig.channel_map.output_channels = {1, 0};
-  if (outputDriver->initialize(outputConfig) != orpheus::SessionGraphError::OK) {
+  orpheus::AudioOutputRouteRequest outputRequest;
+  outputRequest.output_device_id = "dummy";
+  outputRequest.output_channel_map = {1, 0};
+  outputRequest.requested_sample_rate = kSampleRate;
+  outputRequest.requested_buffer_size = 128;
+  if (outputDriver->initializeAudioOutput(outputRequest) !=
+      orpheus::SessionGraphError::OK) {
     return 12;
   }
   if (outputDriver->getConfig().channel_map.output_channels !=
-      outputConfig.channel_map.output_channels) {
+      outputRequest.output_channel_map) {
     return 13;
+  }
+  const auto routeState = outputDriver->getAudioIoRouteState();
+  if (routeState.state != orpheus::AudioRouteState::Inactive ||
+      routeState.selected_output_device_id != outputRequest.output_device_id ||
+      routeState.active_output_channel_map != outputRequest.output_channel_map ||
+      routeState.requested_sample_rate != kSampleRate ||
+      routeState.actual_sample_rate != kSampleRate ||
+      routeState.requested_buffer_size != outputRequest.requested_buffer_size ||
+      routeState.actual_buffer_size != outputRequest.requested_buffer_size) {
+    return 14;
   }
   const auto activeRoute = outputDriver->getActiveRoute();
   if (!activeRoute.input_device_id.empty() || !activeRoute.output_device_id.empty() ||
       activeRoute.input_alive || activeRoute.output_alive || !activeRoute.input_channels.empty() ||
       !activeRoute.output_channels.empty() || activeRoute.latency.complete) {
-    return 14;
+    return 15;
   }
 
   auto manager = orpheus::createAudioDriverManager();
   if (!manager) {
-    return 15;
+    return 16;
   }
   const auto devices = manager->enumerateDevices();
   const auto dummy = std::find_if(devices.begin(), devices.end(),
                                   [](const auto& device) { return device.deviceId == "dummy"; });
   if (dummy == devices.end() || dummy->maxChannels != 2) {
-    return 16;
+    return 17;
   }
+
 
   auto transport = orpheus::createTransportController(
       nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});


### PR DESCRIPTION
## Summary
- add host-neutral directional endpoint capability discovery with stable channel descriptors
- add strict output-only route requests and control-thread route state snapshots
- wire CoreAudio and Dummy implementations, bounded endpoint-change notification, and deterministic contract tests

## Verification
- `cmake --build build-route --parallel 8` passed
- focused `dummy_driver_test`, `driver_manager_test`, `coreaudio_driver_test`, and `realtime_static_audit` passed
- full CTest: 75 enabled tests passed; pre-existing `docs_path_audit` remains blocked by 10 unrelated stale links
- Windows/WASAPI remains unverified on macOS

The branch is based on merged SDK route-state commit `b3b6287c`.