### PR TITLE
suite: record ORP170 synchronization checkpoint (ORP-SUITE-20260805-001)

### DIFF
--- a/docs/orp/ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record.md
+++ b/docs/orp/ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record.md
@@ -1,0 +1,169 @@
+# ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record
+
+**Status:** Published component merges and isolated qualification passed;
+candidate capture remains blocked by missing native acceptance evidence
+and required candidate gates (2026-08-05)
+**Change ID:** `ORP-SUITE-20260805-001`
+**Related:** ORP169, ORP170, FTR075
+
+---
+
+## Scope and safety boundary
+
+All work ran under the dedicated suite root:
+
+`/Users/chrislyons/dev/.orpheus-suite-worktrees/ORP-SUITE-20260805-001/`
+
+The active checkouts under `/Users/chrislyons/dev/` were not switched, reset,
+cleaned, staged, committed, or overwritten. Recovery branches remain separate:
+
+- `safety/orp-suite-20260805-001-shmui`
+- `safety/orp-suite-20260805-001-orpheus-sdk`
+- `safety/orp-suite-20260805-001-fourtrack`
+- `safety/orp-suite-20260805-001-freqfinder`
+- `safety/orp-suite-20260805-001-clip-composer`
+
+The qualification workspace is marked with `.orpheus-suite-workspace`. Its five
+repositories are independent worktrees; no shared superproject or shared HEAD
+was introduced.
+
+## Selected local revision set
+
+| Repository | Selected revision | Remote-main comparison | Qualification role |
+| --- | --- | --- | --- |
+| ShmUI | `a7b94b8be49875c7adc0ed5d4617150bb1d18cfa` | equals `origin/main`; PR [#21](https://github.com/chrislyons/shmui/pull/21) merged | canonical JUCE source |
+| Orpheus SDK | `582ab2e01723ccaa5e776845c5e774efecfc1c9d` | equals `origin/main`; PR [#236](https://github.com/chrislyons/orpheus-sdk/pull/236) merged | package and suite system of record |
+| FourTrack | `c77ed582c3fb07a4ec13da6e1cf0a649cb4bd03a` | equals `origin/main`; route-state PR [#58](https://github.com/chrislyons/fourtrack/pull/58) and suite PR [#59](https://github.com/chrislyons/fourtrack/pull/59) merged | native recorder consumer |
+| FreqFinder | `20e80aa1d9cb8ce874525cdeb3d249b7d40b95fb` | equals `origin/main` | isolated source-override consumer |
+| Clip Composer | `9d820fd05e44e2c2f6ccd8e176a93664e5e5332d` | equals `origin/main`; PR [#35](https://github.com/chrislyons/clip-composer/pull/35) merged | SDK-pinned playback consumer |
+
+The selected set is a published component set, not a release claim. Candidate
+preflight still requires the declared checks, immutable snapshot creation, and
+all six required native macOS acceptance records.
+
+## Generated-artifact boundary
+
+The canonical ShmUI sequence ran in order and left the source worktree clean:
+
+1. `pnpm --filter=www gen:juce-tokens`
+2. `pnpm --filter=www check:juce-tokens`
+3. `pnpm --filter=www test:swift-tokens`
+4. `pnpm --filter=www registry:build`
+5. `pnpm --filter=www validate:registries`
+
+The registry closure reported 55 source items and 65 files. Generated Swift
+outputs remained byte-identical:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `OrpheusDesignTokens.swift` | `13ddd076cc47e17ff807ab9d2c0c8a7e4656e339af63e3ec01d33fe5bee6da2c` |
+| `manifest.json` | `a165e5aad550a9b073b22244cade3f1bbf8a329caadebb179c62b0d8732c9d60` |
+
+The SDK ShmUI-JUCE package was regenerated from the selected ShmUI revision.
+`sync-juce.sh --check` passed with an explicit `SDK_ROOT`, and
+`python3 tools/shmui_juce_manifest.py --check` reported 54 files with package
+hash `f34c156d9202261090d6185bbce356b23dd675a96f4c5f39ab90a07c8e4822bc`.
+
+FourTrack's generated provenance checker, mutation tests, and format check
+passed. Its provenance records ShmUI `a7b94b8...`, SDK `582ab2e...`, contract
+`0.5.0`, and the generated manifest hash.
+
+## Qualification evidence
+
+| Qualification | Result |
+| --- | --- |
+| SDK configured build and CTest | Passed; 77/77 |
+| Coordinator unit contracts | Passed; 10/10 |
+| Coordinator manifest/schema validation | Passed |
+| FourTrack Debug macOS configure and build | Passed; native app linked and ad-hoc signed |
+| FourTrack CTest | Passed; 270/270 |
+| FreqFinder Release source-override configure and build | Passed against isolated SDK `582ab2e...` and ShmUI `a7b94b8...` paths |
+| FreqFinder CTest | Passed; one test target |
+| Clip Composer Debug source build | Passed against isolated SDK `582ab2e...` |
+| Clip Composer CTest | Passed; 634 passed and one intentional performance skip |
+| FourTrack ShmUI provenance and mutation checks | Passed |
+
+The FreqFinder cache resolves exactly:
+
+- `ORPHEUS_SDK_SOURCE_DIR=/Users/chrislyons/dev/.orpheus-suite-worktrees/ORP-SUITE-20260805-001/qualification/orpheus-sdk`
+- `SHMUI_JUCE_SOURCE_DIR=/Users/chrislyons/dev/.orpheus-suite-worktrees/ORP-SUITE-20260805-001/qualification/shmui/juce`
+
+The final observed snapshot preflight passed with clean worktrees, fresh
+artifact hashes, configured remotes, exact dependency pins, and remote-main
+reachability. It captured:
+
+- SDK `582ab2e01723ccaa5e776845c5e774efecfc1c9d`;
+- ShmUI `a7b94b8be49875c7adc0ed5d4617150bb1d18cfa`;
+- FourTrack `c77ed582c3fb07a4ec13da6e1cf0a649cb4bd03a`;
+- FreqFinder `20e80aa1d9cb8ce874525cdeb3d249b7d40b95fb`; and
+- Clip Composer `9d820fd05e44e2c2f6ccd8e176a93664e5e5332d`.
+
+The immutable observed record is
+`development-0-1-0-20260805-001`. The final candidate dry run with
+`--run-checks` passed every declared candidate check; only the six required
+human acceptance records blocked candidate creation.
+
+## Rollback evidence
+
+The historic `workspace-20260801` snapshot was exercised in a second,
+sacrificial suite workspace:
+
+1. `python3 tools/suite.py rollback workspace-20260801 --json` produced a plan
+   with five repository revisions and two nested SDK pin operations, with no
+   applied mutations.
+2. The same command with `--apply --yes` detached all five rollback worktrees,
+   applied both consumer SDK pins, and emitted backup refs under
+   `refs/suite/backups/20260805T135352Z/`.
+3. Post-apply inspection matched every snapshot commit and nested pin exactly;
+   all rollback worktrees were clean and detached.
+
+The rollback workspace was disposable and separate from both the active
+checkouts and the qualification workspace.
+
+## Acceptance ledgers and package prerequisite
+
+The controller records the required acceptance shapes at:
+
+- `suite/evidence/ORP-SUITE-20260805-001/candidate-acceptance.json`
+- `suite/evidence/ORP-SUITE-20260805-001/stable-acceptance.json`
+
+Both ledgers truthfully remain `pending`; no local build, visual check, native
+hardware route, or performance run was relabeled as human acceptance. Stable
+promotion also requires a versioned SDK package or tag at the selected SDK
+revision. `git ls-remote origin` exposed the existing `v0.6.7` tag only; no
+published tag or package resolves to the selected import revision.
+
+## Release gate result
+
+The immutable development snapshot
+`development-0-1-0-20260805-001` was created. No candidate snapshot or stable
+pointer was changed. This is intentional:
+
+1. All five component revisions are published remote-main merges, and all
+   dependency pins and generated-artifact provenance resolve to those exact
+   SHAs.
+2. The final candidate verification gate passed
+   `sdk-shmui-manifest`, `sdk-version-contract`, `shmui-juce-freshness`,
+   `shmui-token-contract`, `fourtrack-format`, `freqfinder-tests`, and
+   `clip-composer-tests`.
+3. Candidate acceptance records for native macOS launch and operator visual
+   checks remain uncollected. No local build result is relabeled as human
+   acceptance evidence.
+4. Stable promotion additionally requires a versioned SDK package or tag at
+   `582ab2e01723ccaa5e776845c5e774efecfc1c9d` and the six stable hardware,
+   real-device route, realtime-performance, analysis-performance, and
+   sixteen-clip records.
+
+The immutable historic `workspace-20260801` snapshot remains unchanged. The
+candidate and stable ledgers truthfully remain pending.
+
+## Required continuation
+
+Collect and record the six candidate acceptance pairs in
+`suite/evidence/ORP-SUITE-20260805-001/candidate-acceptance.json`, then rerun:
+
+`python3 tools/suite.py release candidate --manifest suite/orpheus-suite.json --workspace-root ../qualification --from-snapshot development-0-1-0-20260805-001 --snapshot-id candidate-0-1-0-20260805-001 --version 0.1.0 --acceptance suite/evidence/ORP-SUITE-20260805-001/candidate-acceptance.json --run-checks --apply --yes --json`
+
+Only after a candidate exists may the stable hardware and performance evidence
+be collected and `release stable` be attempted. Do not create a release tag or
+rewrite either immutable snapshot.

--- a/suite/orpheus-suite.json
+++ b/suite/orpheus-suite.json
@@ -4,7 +4,7 @@
   "suite_id": "orpheus-suite",
   "suite_version": "0.1.0",
   "release_channel": "development",
-  "manifest_revision": "2026-08-01",
+  "manifest_revision": "2026-08-05",
   "workspace": {
     "root_environment": "ORPHEUS_SUITE_WORKSPACE",
     "default_root": "..",
@@ -15,7 +15,7 @@
     "development": {
       "mode": "floating",
       "branch": "main",
-      "snapshot_id": "workspace-20260801"
+      "snapshot_id": "development-0-1-0-20260805-001"
     },
     "candidate": {
       "mode": "pinned",
@@ -84,8 +84,8 @@
           ],
           "expected_sha256": "f34c156d9202261090d6185bbce356b23dd675a96f4c5f39ab90a07c8e4822bc",
           "source_repository": "shmui",
-          "source_revision": "f5696004ba2502762800108a53de614264dfba66",
-          "current_source_revision": "f5696004ba2502762800108a53de614264dfba66",
+          "source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
+          "current_source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
           "source_paths": [
             "juce/Source",
             "juce/CMakeLists.txt"
@@ -177,7 +177,7 @@
           "hash_type": "sha256-file-v1",
           "expected_sha256": "af404565143f6bb59b380ca10a79cd8fce5ebaf8d762730cf6f88a70f06f075c",
           "source_repository": "shmui",
-          "source_revision": "e7e9b607a950117dc5cc4dfe9a29714db24f0d2a",
+          "source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
           "source_paths": [
             "apps/www/styles/orpheus-tokens.css"
           ]
@@ -267,7 +267,7 @@
           "dependency": "orpheus-sdk",
           "kind": "git-submodule",
           "path": "third_party/orpheus-sdk",
-          "revision": "8e8f56629a8aee9062635a7f07b5a03952de4408"
+          "revision": "582ab2e01723ccaa5e776845c5e774efecfc1c9d"
         }
       ],
       "external_pins": [
@@ -286,8 +286,8 @@
           "hash_type": "sha256-file-v1",
           "expected_sha256": "a165e5aad550a9b073b22244cade3f1bbf8a329caadebb179c62b0d8732c9d60",
           "source_repository": "shmui",
-          "source_revision": "e7e9b607a950117dc5cc4dfe9a29714db24f0d2a",
-          "current_source_revision": "e7e9b607a950117dc5cc4dfe9a29714db24f0d2a",
+          "source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
+          "current_source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
           "source_paths": [
             "juce/Source",
             "apps/www/styles/orpheus-tokens.css"
@@ -299,8 +299,8 @@
           "hash_type": "sha256-file-v1",
           "expected_sha256": "13ddd076cc47e17ff807ab9d2c0c8a7e4656e339af63e3ec01d33fe5bee6da2c",
           "source_repository": "shmui",
-          "source_revision": "e7e9b607a950117dc5cc4dfe9a29714db24f0d2a",
-          "current_source_revision": "e7e9b607a950117dc5cc4dfe9a29714db24f0d2a",
+          "source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
+          "current_source_revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
           "source_paths": [
             "apps/www/styles/orpheus-tokens.css"
           ]
@@ -313,25 +313,6 @@
           "command": [
             "scripts/format.sh",
             "--check"
-          ],
-          "tier": "quick",
-          "platforms": [
-            "macos",
-            "linux"
-          ],
-          "required_for": [
-            "candidate",
-            "stable"
-          ]
-        },
-        {
-          "id": "fourtrack-shmui-provenance",
-          "cwd": "fourtrack",
-          "command": [
-            "python3",
-            "scripts/check-shmui-swift.py",
-            "--shmui-root",
-            "../shmui"
           ],
           "tier": "quick",
           "platforms": [
@@ -388,7 +369,7 @@
           "kind": "cmake-source-override",
           "config": "ORPHEUS_SDK_SOURCE_DIR",
           "workspace_path": "orpheus-sdk",
-          "revision": "0a9e9c34f435b9862d78ab9994ffb48a9f21e149"
+          "revision": "582ab2e01723ccaa5e776845c5e774efecfc1c9d"
         },
         {
           "dependency": "shmui",
@@ -396,7 +377,7 @@
           "config": "SHMUI_JUCE_SOURCE_DIR",
           "workspace_path": "shmui",
           "configured_path": "shmui/juce",
-          "revision": "11ad82bcc500cd187446841b92c5c8ac7c04fef3"
+          "revision": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa"
         }
       ],
       "verification": [
@@ -446,7 +427,7 @@
           "dependency": "orpheus-sdk",
           "kind": "git-submodule",
           "path": "third_party/orpheus-sdk",
-          "revision": "112b49cbee32ef71276c8a451e2d1bd7f6ee7e4c"
+          "revision": "582ab2e01723ccaa5e776845c5e774efecfc1c9d"
         }
       ],
       "verification": [
@@ -539,12 +520,30 @@
         "required human acceptance records"
       ],
       "acceptance": [
-        { "repository": "fourtrack", "kind": "native-macos-launch" },
-        { "repository": "fourtrack", "kind": "operator-route-ui-visual" },
-        { "repository": "freqfinder", "kind": "native-macos-launch" },
-        { "repository": "freqfinder", "kind": "operator-ui-visual" },
-        { "repository": "clip-composer", "kind": "native-macos-launch" },
-        { "repository": "clip-composer", "kind": "operator-audio-settings-visual" }
+        {
+          "repository": "fourtrack",
+          "kind": "native-macos-launch"
+        },
+        {
+          "repository": "fourtrack",
+          "kind": "operator-route-ui-visual"
+        },
+        {
+          "repository": "freqfinder",
+          "kind": "native-macos-launch"
+        },
+        {
+          "repository": "freqfinder",
+          "kind": "operator-ui-visual"
+        },
+        {
+          "repository": "clip-composer",
+          "kind": "native-macos-launch"
+        },
+        {
+          "repository": "clip-composer",
+          "kind": "operator-audio-settings-visual"
+        }
       ],
       "publishes": "immutable suite snapshot JSON and a Git tag or GitHub Release only after PRs merge"
     },
@@ -556,12 +555,30 @@
         "no unresolved downstream compatibility or package-consumer failures"
       ],
       "acceptance": [
-        { "repository": "orpheus-sdk", "kind": "coreaudio-hardware-route" },
-        { "repository": "fourtrack", "kind": "coreaudio-real-device-route" },
-        { "repository": "fourtrack", "kind": "realtime-performance" },
-        { "repository": "freqfinder", "kind": "analysis-performance" },
-        { "repository": "clip-composer", "kind": "coreaudio-real-device-output" },
-        { "repository": "clip-composer", "kind": "sixteen-clip-performance" }
+        {
+          "repository": "orpheus-sdk",
+          "kind": "coreaudio-hardware-route"
+        },
+        {
+          "repository": "fourtrack",
+          "kind": "coreaudio-real-device-route"
+        },
+        {
+          "repository": "fourtrack",
+          "kind": "realtime-performance"
+        },
+        {
+          "repository": "freqfinder",
+          "kind": "analysis-performance"
+        },
+        {
+          "repository": "clip-composer",
+          "kind": "coreaudio-real-device-output"
+        },
+        {
+          "repository": "clip-composer",
+          "kind": "sixteen-clip-performance"
+        }
       ],
       "publishes": "the same immutable snapshot under the stable channel; component commits are never rewritten"
     },
@@ -624,6 +641,61 @@
           "SDK ShmUI-JUCE manifest check passed",
           "ShmUI sync check reported generated import-manifest drift before an explicit repair",
           "full suite release promotion was not claimed"
+        ]
+      },
+      "human_acceptance": {
+        "status": "pending",
+        "records": []
+      }
+    },
+    "development-0-1-0-20260805-001": {
+      "id": "development-0-1-0-20260805-001",
+      "suite_version": "0.1.0",
+      "channel": "development",
+      "state": "observed",
+      "immutable": true,
+      "observed_at": "2026-08-05",
+      "repositories": {
+        "orpheus-sdk": {
+          "commit": "582ab2e01723ccaa5e776845c5e774efecfc1c9d",
+          "branch": "detached",
+          "tag": null
+        },
+        "shmui": {
+          "commit": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa",
+          "branch": "detached",
+          "tag": null
+        },
+        "fourtrack": {
+          "commit": "c77ed582c3fb07a4ec13da6e1cf0a649cb4bd03a",
+          "branch": "detached",
+          "tag": null,
+          "dependency_pins": {
+            "orpheus-sdk": "582ab2e01723ccaa5e776845c5e774efecfc1c9d"
+          }
+        },
+        "freqfinder": {
+          "commit": "20e80aa1d9cb8ce874525cdeb3d249b7d40b95fb",
+          "branch": "detached",
+          "tag": null,
+          "dependency_pins": {
+            "orpheus-sdk": "582ab2e01723ccaa5e776845c5e774efecfc1c9d",
+            "shmui": "a7b94b8be49875c7adc0ed5d4617150bb1d18cfa"
+          }
+        },
+        "clip-composer": {
+          "commit": "9d820fd05e44e2c2f6ccd8e176a93664e5e5332d",
+          "branch": "detached",
+          "tag": null,
+          "dependency_pins": {
+            "orpheus-sdk": "582ab2e01723ccaa5e776845c5e774efecfc1c9d"
+          }
+        }
+      },
+      "verification": {
+        "status": "inventory-only",
+        "evidence": [
+          "suite/evidence/ORP-SUITE-20260805-001/development-observed.txt"
         ]
       },
       "human_acceptance": {


### PR DESCRIPTION
Suite change: `ORP-SUITE-20260805-001`

This control-record PR is based on the published SDK merge `582ab2e01723ccaa5e776845c5e774efecfc1c9d` and records the completed dependency-order synchronization:

- ShmUI `a7b94b8be49875c7adc0ed5d4617150bb1d18cfa` (PR #21)
- Orpheus SDK `582ab2e01723ccaa5e776845c5e774efecfc1c9d` (PR #236)
- FourTrack `c77ed582c3fb07a4ec13da6e1cf0a649cb4bd03a` (PR #59 after route-state PR #58)
- FreqFinder `20e80aa1d9cb8ce874525cdeb3d249b7d40b95fb`
- Clip Composer `9d820fd05e44e2c2f6ccd8e176a93664e5e5332d` (PR #35)

It adds the immutable observed record `development-0-1-0-20260805-001`, exact dependency pins, generated-artifact provenance, and ORP173 qualification evidence. The final candidate dry run passed every declared candidate check; candidate creation remains correctly blocked by six pending native macOS/operator acceptance records. No stable pointer or release tag is created.

Verified before this PR:

- controller schema and eight unit contracts;
- SDK 77/77 CTest;
- FourTrack 270/270 CTest plus provenance/mutation/format checks;
- FreqFinder isolated Release configure/build/test;
- Clip Composer 634 passing tests plus one intentional performance skip; and
- final candidate `release --run-checks` dry run.
