### PR TITLE
feat(coreaudio): add non-mutating route compatibility probe

### DIFF
--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -21,6 +21,35 @@ struct AudioRouteChannelMap {
   std::vector<uint16_t> input_channels;
   std::vector<uint16_t> output_channels;
 };
+enum class AudioSampleRatePolicy : uint8_t {
+  PreserveDeviceRate,
+  RequestExactRate,
+};
+
+enum class AudioRouteCompatibilityStatus : uint8_t {
+  Compatible,
+  RequiresSampleRateChange,
+  InputUnavailable,
+  OutputUnavailable,
+  SampleRateUnsupported,
+  InvalidChannelMap,
+  PermissionDenied,
+  BackendFailure,
+};
+
+struct AudioRouteCompatibility {
+  AudioRouteCompatibilityStatus status = AudioRouteCompatibilityStatus::BackendFailure;
+  std::string resolved_input_device_id;
+  std::string resolved_output_device_id;
+  uint32_t requested_sample_rate = 0;
+  uint32_t current_input_sample_rate = 0;
+  uint32_t current_output_sample_rate = 0;
+  bool input_rate_change_required = false;
+  bool output_rate_change_required = false;
+  bool input_is_running_somewhere = false;
+  bool output_is_running_somewhere = false;
+  std::string detail;
+};
 
 /// Audio driver configuration.
 ///
@@ -39,6 +68,7 @@ struct AudioDriverConfig {
   /// Physical-to-logical channel selection for each direction.
   /// An empty vector selects consecutive physical channels starting at zero.
   AudioRouteChannelMap channel_map{};
+  AudioSampleRatePolicy sample_rate_policy = AudioSampleRatePolicy::PreserveDeviceRate;
 };
 
 /// Decomposed route latency reported by the backend.
@@ -314,6 +344,11 @@ public:
   /// A terminal state describes the last observed route failure. Hosts must
   /// explicitly reinitialize rather than assuming automatic endpoint fallback.
   virtual AudioIoRouteState getAudioIoRouteState() const {
+    return {};
+  }
+
+  virtual AudioRouteCompatibility probeRoute(const AudioDriverConfig& config) const {
+    (void)config;
     return {};
   }
 };

--- a/include/orpheus/audio_driver_manager.h
+++ b/include/orpheus/audio_driver_manager.h
@@ -54,6 +54,7 @@ struct AudioEndpointCapabilities {
   std::vector<uint32_t> supported_buffer_sizes;
   uint32_t nominal_sample_rate = 0;
   uint32_t current_buffer_size = 0;
+  bool is_running_somewhere = false;
 };
 /// Audio device information
 struct AudioDeviceInfo {
@@ -160,8 +161,8 @@ public:
   }
 
   /// Find one endpoint by stable backend device ID.
-  virtual std::optional<AudioEndpointCapabilities> getEndpointCapabilities(
-      const std::string& deviceId) {
+  virtual std::optional<AudioEndpointCapabilities>
+  getEndpointCapabilities(const std::string& deviceId) {
     (void)deviceId;
     return std::nullopt;
   }

--- a/src/core/audio_io/dummy_audio_driver.cpp
+++ b/src/core/audio_io/dummy_audio_driver.cpp
@@ -42,8 +42,7 @@ SessionGraphError DummyAudioDriver::initialize(const AudioDriverConfig& config) 
   return SessionGraphError::OK;
 }
 
-SessionGraphError DummyAudioDriver::initializeAudioOutput(
-    const AudioOutputRouteRequest& request) {
+SessionGraphError DummyAudioDriver::initializeAudioOutput(const AudioOutputRouteRequest& request) {
   if (request.output_channel_map.empty() || request.requested_sample_rate == 0 ||
       request.requested_buffer_size == 0 || request.requested_buffer_size > 0xffffu ||
       request.output_channel_map.size() > 32 ||
@@ -168,6 +167,91 @@ AudioIoRouteState DummyAudioDriver::getAudioIoRouteState() const {
 AudioIoTelemetry DummyAudioDriver::getTelemetry() const noexcept {
   return {input_render_failures_.load(std::memory_order_acquire),
           AudioDriverRuntimeOutcome::Healthy, AudioRouteRuntimeOutcome::Healthy};
+}
+
+AudioRouteCompatibility DummyAudioDriver::probeRoute(const AudioDriverConfig& config) const {
+  AudioRouteCompatibility compatibility;
+  compatibility.requested_sample_rate = config.sample_rate;
+  if (config.num_outputs == 0) {
+    compatibility.status = AudioRouteCompatibilityStatus::OutputUnavailable;
+    compatibility.detail = "config:output";
+    return compatibility;
+  }
+  if (config.sample_rate == 0 || config.buffer_size == 0) {
+    compatibility.status = AudioRouteCompatibilityStatus::BackendFailure;
+    compatibility.detail = "config:output";
+    return compatibility;
+  }
+
+  const auto resolve_id = [](const std::string& requested, std::string& resolved,
+                             const char* direction, std::string& detail) {
+    if (requested.empty() || requested == "dummy") {
+      resolved = "dummy";
+      return true;
+    }
+    detail = std::string("resolve:") + direction;
+    return false;
+  };
+  if (!resolve_id(config.output_device_id, compatibility.resolved_output_device_id, "output",
+                  compatibility.detail)) {
+    compatibility.status = AudioRouteCompatibilityStatus::OutputUnavailable;
+    return compatibility;
+  }
+  if (config.num_inputs > 0 &&
+      !resolve_id(config.input_device_id, compatibility.resolved_input_device_id, "input",
+                  compatibility.detail)) {
+    compatibility.status = AudioRouteCompatibilityStatus::InputUnavailable;
+    return compatibility;
+  }
+
+  const auto resolve_map = [](const std::vector<uint16_t>& requested, uint16_t logical_count,
+                              std::vector<uint16_t>& resolved) {
+    if (logical_count > 32) {
+      return false;
+    }
+    if (requested.empty()) {
+      resolved.resize(logical_count);
+      for (uint16_t channel = 0; channel < logical_count; ++channel) {
+        resolved[channel] = channel;
+      }
+      return true;
+    }
+    if (requested.size() != logical_count) {
+      return false;
+    }
+    resolved.clear();
+    resolved.reserve(requested.size());
+    for (const uint16_t channel : requested) {
+      if (channel >= 32 || std::find(resolved.begin(), resolved.end(), channel) != resolved.end()) {
+        return false;
+      }
+      resolved.push_back(channel);
+    }
+    return true;
+  };
+
+  std::vector<uint16_t> resolved_output;
+  if (!resolve_map(config.channel_map.output_channels, config.num_outputs, resolved_output)) {
+    compatibility.status = AudioRouteCompatibilityStatus::InvalidChannelMap;
+    compatibility.detail = "map:output";
+    return compatibility;
+  }
+  if (config.num_inputs > 0) {
+    std::vector<uint16_t> resolved_input;
+    if (!resolve_map(config.channel_map.input_channels, config.num_inputs, resolved_input)) {
+      compatibility.status = AudioRouteCompatibilityStatus::InvalidChannelMap;
+      compatibility.detail = "map:input";
+      return compatibility;
+    }
+  }
+
+  compatibility.current_output_sample_rate = config.sample_rate;
+  if (config.num_inputs > 0) {
+    compatibility.current_input_sample_rate = config.sample_rate;
+  }
+  compatibility.status = AudioRouteCompatibilityStatus::Compatible;
+  compatibility.detail.clear();
+  return compatibility;
 }
 
 void DummyAudioDriver::audioThreadMain() {

--- a/src/core/audio_io/dummy_audio_driver.h
+++ b/src/core/audio_io/dummy_audio_driver.h
@@ -28,6 +28,8 @@ public:
   AudioDriverCapabilities getCapabilities() const override;
   ActiveAudioRoute getActiveRoute() const override;
   AudioIoRouteState getAudioIoRouteState() const override;
+  AudioRouteCompatibility probeRoute(const AudioDriverConfig& config) const override;
+
   AudioIoTelemetry getTelemetry() const noexcept override;
 
 private:

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -78,9 +78,11 @@ message(STATUS "Orpheus: Audio Driver Manager enabled")
 if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
     add_library(orpheus_audio_driver_coreaudio STATIC
         coreaudio/coreaudio_driver.cpp
+        coreaudio/coreaudio_route_resolver.cpp
         coreaudio/coreaudio_endpoint_monitor.cpp
         coreaudio/coreaudio_sample_rate_monitor.cpp
         coreaudio/coreaudio_route_monitor.cpp
+
     )
 
     target_include_directories(orpheus_audio_driver_coreaudio

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -165,8 +165,6 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
 
   cleanupAudioUnit();
   config_ = config;
-  input_channel_map_.clear();
-  output_channel_map_.clear();
   active_route_ = {};
   expected_stream_sample_ = 0;
   stream_timeline_initialized_ = false;
@@ -174,13 +172,58 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
   unavailable_route_state_.store(AudioRouteState::Failed, std::memory_order_release);
 
-  device_id_ = resolveInputOutputDevice();
-  if (device_id_ == 0 || !resolveChannelMaps(config)) {
-    route_outcome_.store(device_id_ == 0 ? AudioRouteRuntimeOutcome::RouteUnavailable
-                                         : AudioRouteRuntimeOutcome::ReinitializationRequired,
-                         std::memory_order_release);
+  auto resolved_route = route_resolver_.resolve(config);
+  const auto compatibility_status = resolved_route.compatibility.status;
+  const bool activation_eligible =
+      resolved_route.resolved &&
+      (compatibility_status == AudioRouteCompatibilityStatus::Compatible ||
+       compatibility_status == AudioRouteCompatibilityStatus::RequiresSampleRateChange);
+  if (!activation_eligible) {
+    switch (compatibility_status) {
+    case AudioRouteCompatibilityStatus::InputUnavailable:
+      unavailable_route_state_.store(AudioRouteState::InputUnavailable, std::memory_order_release);
+      route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+      break;
+    case AudioRouteCompatibilityStatus::OutputUnavailable:
+      unavailable_route_state_.store(AudioRouteState::OutputUnavailable, std::memory_order_release);
+      route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+      break;
+    case AudioRouteCompatibilityStatus::PermissionDenied:
+      unavailable_route_state_.store(AudioRouteState::PermissionDenied, std::memory_order_release);
+      route_outcome_.store(AudioRouteRuntimeOutcome::RouteUnavailable, std::memory_order_release);
+      break;
+    case AudioRouteCompatibilityStatus::BackendFailure:
+      route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+      break;
+    case AudioRouteCompatibilityStatus::SampleRateUnsupported:
+    case AudioRouteCompatibilityStatus::InvalidChannelMap:
+    case AudioRouteCompatibilityStatus::Compatible:
+    case AudioRouteCompatibilityStatus::RequiresSampleRateChange:
+      route_outcome_.store(AudioRouteRuntimeOutcome::ReinitializationRequired,
+                           std::memory_order_release);
+      break;
+    }
     cleanupAudioUnit();
     return SessionGraphError::InvalidParameter;
+  }
+
+  input_device_id_ = resolved_route.input_device_id;
+  output_device_id_ = resolved_route.output_device_id;
+  available_input_channels_ = resolved_route.input_channel_count;
+  available_output_channels_ = resolved_route.output_channel_count;
+  input_channel_map_ = std::move(resolved_route.input_channel_map);
+  output_channel_map_ = std::move(resolved_route.output_channel_map);
+  device_id_ = output_device_id_;
+
+  if (resolved_route.requires_private_aggregate) {
+    input_channel_offset_ = getChannelCount(output_device_id_, kAudioObjectPropertyScopeInput);
+    aggregate_device_id_ = createAggregateDevice(input_device_id_, output_device_id_);
+    if (aggregate_device_id_ == 0) {
+      route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+      cleanupAudioUnit();
+      return SessionGraphError::InvalidParameter;
+    }
+    device_id_ = aggregate_device_id_;
   }
 
   try {
@@ -564,69 +607,6 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   return noErr;
 }
 
-std::vector<AudioDeviceID> CoreAudioDriver::enumerateDevices() {
-  std::vector<AudioDeviceID> devices;
-  AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
-                                        kAudioObjectPropertyScopeGlobal,
-                                        kAudioObjectPropertyElementMain};
-  UInt32 data_size = 0;
-  if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &address, 0, nullptr, &data_size) !=
-          noErr ||
-      data_size == 0) {
-    return devices;
-  }
-
-  devices.resize(data_size / sizeof(AudioDeviceID));
-  if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr, &data_size,
-                                 devices.data()) != noErr) {
-    devices.clear();
-  }
-  return devices;
-}
-
-AudioDeviceID CoreAudioDriver::getDefaultDevice(AudioObjectPropertySelector selector) {
-  AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
-                                        kAudioObjectPropertyElementMain};
-  AudioDeviceID device_id = 0;
-  UInt32 data_size = sizeof(device_id);
-  const OSStatus status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr,
-                                                     &data_size, &device_id);
-  return status == noErr && device_id != kAudioObjectUnknown ? device_id : 0;
-}
-
-AudioDeviceID CoreAudioDriver::findDeviceByUID(const std::string& device_uid) {
-  if (device_uid.empty()) {
-    return 0;
-  }
-
-  CFStringRef requested =
-      CFStringCreateWithCString(kCFAllocatorDefault, device_uid.c_str(), kCFStringEncodingUTF8);
-  if (!requested) {
-    return 0;
-  }
-
-  AudioDeviceID matched = 0;
-  for (const AudioDeviceID candidate : enumerateDevices()) {
-    CFStringRef candidate_uid = copyDeviceUID(candidate);
-    if (candidate_uid && CFStringCompare(candidate_uid, requested, 0) == kCFCompareEqualTo) {
-      matched = candidate;
-    }
-    if (candidate_uid) {
-      CFRelease(candidate_uid);
-    }
-    if (matched != 0) {
-      break;
-    }
-  }
-  CFRelease(requested);
-  return matched;
-}
-
-bool CoreAudioDriver::supportsDirection(AudioDeviceID device_id,
-                                        AudioObjectPropertyScope scope) const {
-  return getChannelCount(device_id, scope) > 0;
-}
-
 uint32_t CoreAudioDriver::getChannelCount(AudioDeviceID device_id,
                                           AudioObjectPropertyScope scope) const {
   if (device_id == 0) {
@@ -652,57 +632,6 @@ uint32_t CoreAudioDriver::getChannelCount(AudioDeviceID device_id,
     channels += buffers->mBuffers[index].mNumberChannels;
   }
   return channels;
-}
-
-AudioDeviceID CoreAudioDriver::resolveInputOutputDevice() {
-  input_channel_offset_ = 0;
-  available_input_channels_ = 0;
-  available_output_channels_ = 0;
-
-  const AudioDeviceID output_id = config_.output_device_id.empty()
-                                      ? getDefaultDevice(kAudioHardwarePropertyDefaultOutputDevice)
-                                      : findDeviceByUID(config_.output_device_id);
-  if (output_id == 0 || !supportsDirection(output_id, kAudioObjectPropertyScopeOutput)) {
-    return 0;
-  }
-
-  if (config_.num_inputs == 0) {
-    if (!config_.input_device_id.empty()) {
-      return 0;
-    }
-    input_device_id_ = 0;
-    output_device_id_ = output_id;
-    available_output_channels_ = getChannelCount(output_id, kAudioObjectPropertyScopeOutput);
-    return output_id;
-  }
-
-  const AudioDeviceID input_id = config_.input_device_id.empty()
-                                     ? getDefaultDevice(kAudioHardwarePropertyDefaultInputDevice)
-                                     : findDeviceByUID(config_.input_device_id);
-  if (input_id == 0 || !supportsDirection(input_id, kAudioObjectPropertyScopeInput)) {
-    return 0;
-  }
-
-  input_device_id_ = input_id;
-  output_device_id_ = output_id;
-  available_input_channels_ = getChannelCount(input_id, kAudioObjectPropertyScopeInput);
-  available_output_channels_ = getChannelCount(output_id, kAudioObjectPropertyScopeOutput);
-
-  if (input_id == output_id) {
-    return output_id;
-  }
-
-  input_channel_offset_ = getChannelCount(output_id, kAudioObjectPropertyScopeInput);
-  const AudioDeviceID aggregate_id = createAggregateDevice(input_id, output_id);
-  if (aggregate_id == 0) {
-    input_device_id_ = 0;
-    output_device_id_ = 0;
-    available_input_channels_ = 0;
-    available_output_channels_ = 0;
-    return 0;
-  }
-  aggregate_device_id_ = aggregate_id;
-  return aggregate_id;
 }
 
 AudioDeviceID CoreAudioDriver::createAggregateDevice(AudioDeviceID input_device_id,
@@ -775,41 +704,6 @@ AudioDeviceID CoreAudioDriver::createAggregateDevice(AudioDeviceID input_device_
   CFRelease(output_uid);
 
   return status == noErr ? aggregate_id : 0;
-}
-
-bool CoreAudioDriver::resolveChannelMaps(const AudioDriverConfig& config) {
-  const auto resolve = [](const std::vector<uint16_t>& requested, uint16_t logical_count,
-                          uint32_t physical_count, std::vector<uint16_t>& resolved) {
-    if (logical_count > physical_count) {
-      return false;
-    }
-    if (requested.empty()) {
-      resolved.resize(logical_count);
-      for (uint16_t channel = 0; channel < logical_count; ++channel) {
-        resolved[channel] = channel;
-      }
-      return true;
-    }
-    if (requested.size() != logical_count) {
-      return false;
-    }
-
-    resolved.clear();
-    resolved.reserve(requested.size());
-    for (const uint16_t channel : requested) {
-      if (channel >= physical_count ||
-          std::find(resolved.begin(), resolved.end(), channel) != resolved.end()) {
-        return false;
-      }
-      resolved.push_back(channel);
-    }
-    return true;
-  };
-
-  return resolve(config.channel_map.input_channels, config.num_inputs, available_input_channels_,
-                 input_channel_map_) &&
-         resolve(config.channel_map.output_channels, config.num_outputs, available_output_channels_,
-                 output_channel_map_);
 }
 
 std::vector<AudioStreamID> CoreAudioDriver::enumerateStreams(AudioDeviceID device_id,

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -133,7 +133,10 @@ bool addLatencyTerm(const std::optional<UInt32>& term, uint32_t& total) {
 
 } // namespace
 
-CoreAudioDriver::CoreAudioDriver() = default;
+CoreAudioDriver::CoreAudioDriver() : route_resolver_(detail::makeCoreAudioRouteQuery()) {}
+
+CoreAudioDriver::CoreAudioDriver(std::shared_ptr<const detail::ICoreAudioRouteQuery> query)
+    : route_resolver_(query ? std::move(query) : detail::makeCoreAudioRouteQuery()) {}
 
 CoreAudioDriver::~CoreAudioDriver() {
   stop();
@@ -354,6 +357,10 @@ AudioIoTelemetry CoreAudioDriver::getTelemetry() const noexcept {
   return {input_render_failures_.load(std::memory_order_acquire),
           runtime_outcome_.load(std::memory_order_acquire),
           route_outcome_.load(std::memory_order_acquire)};
+}
+
+AudioRouteCompatibility CoreAudioDriver::probeRoute(const AudioDriverConfig& config) const {
+  return route_resolver_.resolve(config).compatibility;
 }
 
 ActiveAudioRoute CoreAudioDriver::getActiveRoute() const {

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -3,6 +3,8 @@
 
 #include "../../../core/common/realtime_borrowed_target.h"
 #include "coreaudio_route_monitor.h"
+#include "coreaudio_route_resolver.h"
+
 #include <orpheus/audio_driver.h>
 
 #include <AudioToolbox/AudioToolbox.h>
@@ -25,6 +27,8 @@ class IPerformanceMonitor;
 class CoreAudioDriver : public IAudioDriver {
 public:
   CoreAudioDriver();
+  explicit CoreAudioDriver(std::shared_ptr<const detail::ICoreAudioRouteQuery> query);
+
   ~CoreAudioDriver() override;
 
   SessionGraphError initialize(const AudioDriverConfig& config) override;
@@ -39,6 +43,7 @@ public:
   ActiveAudioRoute getActiveRoute() const override;
   SessionGraphError initializeAudioOutput(const AudioOutputRouteRequest& request) override;
   AudioIoRouteState getAudioIoRouteState() const override;
+  AudioRouteCompatibility probeRoute(const AudioDriverConfig& config) const override;
 
   void setPerformanceMonitor(IPerformanceMonitor* monitor) override;
 
@@ -81,6 +86,8 @@ private:
   uint32_t queryDeviceLatency() const;
   void cleanupAudioUnit();
   void stopRenderingLocked();
+
+  detail::CoreAudioRouteResolver route_resolver_;
 
   AudioDriverConfig config_;
   AudioUnit audio_unit_{nullptr};

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -57,18 +57,10 @@ private:
                                  UInt32 inNumberFrames, AudioBufferList* ioData);
 
   void recordInputRenderFailure() noexcept;
-
-  std::vector<AudioDeviceID> enumerateDevices();
-  AudioDeviceID findDeviceByUID(const std::string& device_uid);
-  AudioDeviceID getDefaultDevice(AudioObjectPropertySelector selector);
-  AudioDeviceID resolveInputOutputDevice();
-  AudioDeviceID createAggregateDevice(AudioDeviceID input_device_id,
-                                      AudioDeviceID output_device_id);
-  bool supportsDirection(AudioDeviceID device_id, AudioObjectPropertyScope scope) const;
   uint32_t getChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const;
   std::optional<std::string> getDeviceUID(AudioDeviceID device_id) const;
-
-  bool resolveChannelMaps(const AudioDriverConfig& config);
+  AudioDeviceID createAggregateDevice(AudioDeviceID input_device_id,
+                                      AudioDeviceID output_device_id);
   SessionGraphError setupAudioUnit(AudioDeviceID device_id);
   std::vector<AudioStreamID> enumerateStreams(AudioDeviceID device_id,
                                               AudioObjectPropertyScope scope) const;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.cpp
@@ -9,10 +9,9 @@
 namespace orpheus::detail {
 namespace {
 
-constexpr std::array<uint32_t, 6> kCommonSampleRates = {
-    44100, 48000, 88200, 96000, 176400, 192000};
-constexpr std::array<uint32_t, 14> kCommonBufferSizes = {
-    32, 64, 96, 128, 160, 192, 256, 384, 512, 768, 1024, 1536, 2048, 4096};
+constexpr std::array<uint32_t, 6> kCommonSampleRates = {44100, 48000, 88200, 96000, 176400, 192000};
+constexpr std::array<uint32_t, 14> kCommonBufferSizes = {32,  64,  96,  128,  160,  192,  256,
+                                                         384, 512, 768, 1024, 1536, 2048, 4096};
 
 bool isInRange(double value, const CoreAudioEndpointRange& range) {
   return value >= range.minimum && value <= range.maximum;
@@ -34,15 +33,13 @@ void appendChannels(std::vector<AudioChannelDescriptor>& channels, uint32_t coun
   for (uint32_t channel = 0; channel < count; ++channel) {
     channels.push_back({static_cast<uint16_t>(channel),
                         deviceId + ":" + stableDirection + ":" + std::to_string(channel),
-                        displayName + " " + displayDirection + " " +
-                            std::to_string(channel + 1)});
+                        displayName + " " + displayDirection + " " + std::to_string(channel + 1)});
   }
 }
 
 } // namespace
 
-AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(
-    const CoreAudioEndpointFacts& facts) {
+AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(const CoreAudioEndpointFacts& facts) {
   AudioEndpointCapabilities endpoint;
   endpoint.device_id = facts.device_id;
   endpoint.display_name = facts.display_name.empty() ? facts.device_id : facts.display_name;
@@ -90,6 +87,8 @@ AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(
     }
   }
   endpoint.current_buffer_size = facts.current_buffer_size;
+  endpoint.is_running_somewhere = facts.is_running_somewhere;
+
   appendUnique(endpoint.supported_buffer_sizes, endpoint.current_buffer_size);
   std::sort(endpoint.supported_buffer_sizes.begin(), endpoint.supported_buffer_sizes.end());
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_endpoint_catalog.h
@@ -27,6 +27,7 @@ struct CoreAudioEndpointFacts {
   std::vector<CoreAudioEndpointRange> buffer_size_ranges;
   uint32_t nominal_sample_rate = 0;
   uint32_t current_buffer_size = 0;
+  bool is_running_somewhere = false;
 };
 
 AudioEndpointCapabilities makeCoreAudioEndpointCapabilities(const CoreAudioEndpointFacts& facts);

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
@@ -286,14 +286,14 @@ void setFailure(ResolvedCoreAudioRoute& route, AudioRouteCompatibilityStatus sta
 }
 
 bool setQueryFailure(ResolvedCoreAudioRoute& route, CoreAudioRouteQueryStatus status,
-                     const char* operation, bool output) {
+                     const char* operation, bool output, bool missing_is_unavailable = true) {
   if (status == CoreAudioRouteQueryStatus::Success) {
     return false;
   }
   const AudioRouteCompatibilityStatus compatibility_status =
       status == CoreAudioRouteQueryStatus::PermissionDenied
           ? AudioRouteCompatibilityStatus::PermissionDenied
-      : status == CoreAudioRouteQueryStatus::Missing
+      : status == CoreAudioRouteQueryStatus::Missing && missing_is_unavailable
           ? unavailableStatus(output)
           : AudioRouteCompatibilityStatus::BackendFailure;
   setFailure(route, compatibility_status, operation, output);
@@ -442,7 +442,7 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
 
   bool output_rate_supported = false;
   const auto output_ranges = query_->advertisedSampleRateRanges(route.output_device_id);
-  if (setQueryFailure(route, output_ranges.status, "ranges", true)) {
+  if (setQueryFailure(route, output_ranges.status, "ranges", true, false)) {
     return route;
   }
   output_rate_supported = supportsRequestedRate(output_ranges.value, config.sample_rate);
@@ -454,7 +454,7 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
   bool input_rate_supported = true;
   if (config.num_inputs > 0 && route.input_device_id != route.output_device_id) {
     const auto input_ranges = query_->advertisedSampleRateRanges(route.input_device_id);
-    if (setQueryFailure(route, input_ranges.status, "ranges", false)) {
+    if (setQueryFailure(route, input_ranges.status, "ranges", false, false)) {
       return route;
     }
     input_rate_supported = supportsRequestedRate(input_ranges.value, config.sample_rate);
@@ -467,7 +467,7 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
   const auto query_global_facts = [&](AudioDeviceID device_id, bool output, uint32_t& rate,
                                       bool& running) -> bool {
     const auto current = query_->currentSampleRate(device_id);
-    if (setQueryFailure(route, current.status, "current_rate", output)) {
+    if (setQueryFailure(route, current.status, "current_rate", output, false)) {
       return false;
     }
     if (!normalizeCurrentSampleRate(current.value, rate)) {
@@ -475,7 +475,7 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
       return false;
     }
     const auto is_running = query_->isRunningSomewhere(device_id);
-    if (setQueryFailure(route, is_running.status, "running", output)) {
+    if (setQueryFailure(route, is_running.status, "running", output, false)) {
       return false;
     }
     running = is_running.value;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio_route_resolver.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace orpheus::detail {
+namespace {
+
+constexpr double kSampleRateEpsilonHz = 0.001;
+
+bool isPermissionDenied(OSStatus status) {
+  return status == kAudioDevicePermissionsError;
+}
+
+template <typename T> CoreAudioRouteQueryResult<T> queryResultForStatus(OSStatus status) {
+  CoreAudioRouteQueryResult<T> result;
+  if (status == noErr) {
+    result.status = CoreAudioRouteQueryStatus::Success;
+  } else if (isPermissionDenied(status)) {
+    result.status = CoreAudioRouteQueryStatus::PermissionDenied;
+  } else {
+    result.status = CoreAudioRouteQueryStatus::Failure;
+  }
+  return result;
+}
+
+template <typename T> CoreAudioRouteQueryResult<T> missingQueryResult() {
+  CoreAudioRouteQueryResult<T> result;
+  result.status = CoreAudioRouteQueryStatus::Missing;
+  return result;
+}
+
+template <typename T> CoreAudioRouteQueryResult<T> successQueryResult(T value) {
+  CoreAudioRouteQueryResult<T> result;
+  result.status = CoreAudioRouteQueryStatus::Success;
+  result.value = std::move(value);
+  return result;
+}
+
+class ProductionCoreAudioRouteQuery final : public ICoreAudioRouteQuery {
+public:
+  CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> resolveDefault(bool output) const override {
+    const AudioObjectPropertySelector selector = output ? kAudioHardwarePropertyDefaultOutputDevice
+                                                        : kAudioHardwarePropertyDefaultInputDevice;
+    const AudioObjectPropertyAddress address = {selector, kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    AudioDeviceID device_id = 0;
+    UInt32 data_size = sizeof(device_id);
+    const OSStatus status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0,
+                                                       nullptr, &data_size, &device_id);
+    if (status != noErr) {
+      return queryResultForStatus<ResolvedCoreAudioEndpoint>(status);
+    }
+    if (device_id == 0 || device_id == kAudioObjectUnknown) {
+      return missingQueryResult<ResolvedCoreAudioEndpoint>();
+    }
+
+    const auto uid = readDeviceUID(device_id);
+    if (uid.status != CoreAudioRouteQueryStatus::Success) {
+      CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> result;
+      result.status = uid.status;
+      return result;
+    }
+    return successQueryResult(ResolvedCoreAudioEndpoint{device_id, uid.value});
+  }
+
+  CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint>
+  resolveDeviceUID(std::string_view device_uid) const override {
+    if (device_uid.empty()) {
+      return missingQueryResult<ResolvedCoreAudioEndpoint>();
+    }
+
+    CFStringRef requested = CFStringCreateWithBytes(
+        kCFAllocatorDefault, reinterpret_cast<const UInt8*>(device_uid.data()),
+        static_cast<CFIndex>(device_uid.size()), kCFStringEncodingUTF8, false);
+    if (requested == nullptr) {
+      CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> result;
+      result.status = CoreAudioRouteQueryStatus::Failure;
+      return result;
+    }
+
+    const AudioObjectPropertyAddress address = {kAudioHardwarePropertyDevices,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 data_size = 0;
+    OSStatus status =
+        AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &address, 0, nullptr, &data_size);
+    if (status != noErr) {
+      CFRelease(requested);
+      return queryResultForStatus<ResolvedCoreAudioEndpoint>(status);
+    }
+    if (data_size == 0 || data_size % sizeof(AudioDeviceID) != 0) {
+      CFRelease(requested);
+      return data_size == 0 ? missingQueryResult<ResolvedCoreAudioEndpoint>()
+                            : queryResultForStatus<ResolvedCoreAudioEndpoint>(
+                                  kAudioHardwareBadPropertySizeError);
+    }
+
+    std::vector<AudioDeviceID> devices(data_size / sizeof(AudioDeviceID));
+    status = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr, &data_size,
+                                        devices.data());
+    if (status != noErr) {
+      CFRelease(requested);
+      return queryResultForStatus<ResolvedCoreAudioEndpoint>(status);
+    }
+
+    for (const AudioDeviceID device_id : devices) {
+      const auto uid = readDeviceUID(device_id);
+      if (uid.status != CoreAudioRouteQueryStatus::Success) {
+        CFRelease(requested);
+        CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> result;
+        result.status = uid.status;
+        return result;
+      }
+      CFStringRef candidate = CFStringCreateWithBytes(
+          kCFAllocatorDefault, reinterpret_cast<const UInt8*>(uid.value.data()),
+          static_cast<CFIndex>(uid.value.size()), kCFStringEncodingUTF8, false);
+      if (candidate == nullptr) {
+        CFRelease(requested);
+        CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> result;
+        result.status = CoreAudioRouteQueryStatus::Failure;
+        return result;
+      }
+      const bool equal = CFStringCompare(candidate, requested, 0) == kCFCompareEqualTo;
+      CFRelease(candidate);
+      if (equal) {
+        CFRelease(requested);
+        return successQueryResult(ResolvedCoreAudioEndpoint{device_id, uid.value});
+      }
+    }
+
+    CFRelease(requested);
+    return missingQueryResult<ResolvedCoreAudioEndpoint>();
+  }
+
+  CoreAudioRouteQueryResult<uint32_t> channelCount(AudioDeviceID device_id,
+                                                   AudioObjectPropertyScope scope) const override {
+    if (device_id == 0) {
+      return missingQueryResult<uint32_t>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyStreamConfiguration, scope,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 data_size = 0;
+    OSStatus status = AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &data_size);
+    if (status != noErr) {
+      return queryResultForStatus<uint32_t>(status);
+    }
+    if (data_size < sizeof(AudioBufferList)) {
+      return queryResultForStatus<uint32_t>(kAudioHardwareBadPropertySizeError);
+    }
+
+    std::vector<uint8_t> storage(data_size);
+    auto* buffers = reinterpret_cast<AudioBufferList*>(storage.data());
+    status = AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, buffers);
+    if (status != noErr) {
+      return queryResultForStatus<uint32_t>(status);
+    }
+
+    uint64_t channels = 0;
+    for (UInt32 index = 0; index < buffers->mNumberBuffers; ++index) {
+      channels += buffers->mBuffers[index].mNumberChannels;
+    }
+    if (channels > std::numeric_limits<uint32_t>::max()) {
+      return queryResultForStatus<uint32_t>(kAudioHardwareBadPropertySizeError);
+    }
+    return successQueryResult(static_cast<uint32_t>(channels));
+  }
+
+  CoreAudioRouteQueryResult<std::vector<CoreAudioEndpointRange>>
+  advertisedSampleRateRanges(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<std::vector<CoreAudioEndpointRange>>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyAvailableNominalSampleRates,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 data_size = 0;
+    OSStatus status = AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &data_size);
+    if (status != noErr) {
+      return queryResultForStatus<std::vector<CoreAudioEndpointRange>>(status);
+    }
+    if (data_size == 0) {
+      return successQueryResult(std::vector<CoreAudioEndpointRange>{});
+    }
+    if (data_size % sizeof(AudioValueRange) != 0) {
+      return queryResultForStatus<std::vector<CoreAudioEndpointRange>>(
+          kAudioHardwareBadPropertySizeError);
+    }
+
+    std::vector<AudioValueRange> ranges(data_size / sizeof(AudioValueRange));
+    status = AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, ranges.data());
+    if (status != noErr) {
+      return queryResultForStatus<std::vector<CoreAudioEndpointRange>>(status);
+    }
+
+    std::vector<CoreAudioEndpointRange> normalized;
+    normalized.reserve(ranges.size());
+    for (const AudioValueRange& range : ranges) {
+      normalized.push_back(
+          {static_cast<double>(range.mMinimum), static_cast<double>(range.mMaximum)});
+    }
+    return successQueryResult(std::move(normalized));
+  }
+
+  CoreAudioRouteQueryResult<double> currentSampleRate(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<double>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyNominalSampleRate,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    Float64 value = 0.0;
+    UInt32 data_size = sizeof(value);
+    const OSStatus status =
+        AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, &value);
+    if (status != noErr) {
+      return queryResultForStatus<double>(status);
+    }
+    return successQueryResult(static_cast<double>(value));
+  }
+
+  CoreAudioRouteQueryResult<bool> isRunningSomewhere(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<bool>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyDeviceIsRunningSomewhere,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 value = 0;
+    UInt32 data_size = sizeof(value);
+    const OSStatus status =
+        AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, &value);
+    if (status != noErr) {
+      return queryResultForStatus<bool>(status);
+    }
+    return successQueryResult(value != 0);
+  }
+
+private:
+  CoreAudioRouteQueryResult<std::string> readDeviceUID(AudioDeviceID device_id) const {
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyDeviceUID,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    CFStringRef uid = nullptr;
+    UInt32 data_size = sizeof(uid);
+    const OSStatus status =
+        AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, &uid);
+    if (status != noErr) {
+      return queryResultForStatus<std::string>(status);
+    }
+    if (uid == nullptr) {
+      CoreAudioRouteQueryResult<std::string> result;
+      result.status = CoreAudioRouteQueryStatus::Failure;
+      return result;
+    }
+    char buffer[1024] = {};
+    const Boolean converted =
+        CFStringGetCString(uid, buffer, sizeof(buffer), kCFStringEncodingUTF8);
+    CFRelease(uid);
+    if (!converted) {
+      CoreAudioRouteQueryResult<std::string> result;
+      result.status = CoreAudioRouteQueryStatus::Failure;
+      return result;
+    }
+    return successQueryResult(std::string(buffer));
+  }
+};
+
+AudioRouteCompatibilityStatus unavailableStatus(bool output) {
+  return output ? AudioRouteCompatibilityStatus::OutputUnavailable
+                : AudioRouteCompatibilityStatus::InputUnavailable;
+}
+
+void setFailure(ResolvedCoreAudioRoute& route, AudioRouteCompatibilityStatus status,
+                const char* operation, bool output) {
+  route.resolved = false;
+  route.compatibility.status = status;
+  route.compatibility.detail = operation;
+  route.compatibility.detail += output ? ":output" : ":input";
+  if (route.compatibility.detail.size() > 96) {
+    route.compatibility.detail.resize(96);
+  }
+}
+
+bool setQueryFailure(ResolvedCoreAudioRoute& route, CoreAudioRouteQueryStatus status,
+                     const char* operation, bool output) {
+  if (status == CoreAudioRouteQueryStatus::Success) {
+    return false;
+  }
+  const AudioRouteCompatibilityStatus compatibility_status =
+      status == CoreAudioRouteQueryStatus::PermissionDenied
+          ? AudioRouteCompatibilityStatus::PermissionDenied
+      : status == CoreAudioRouteQueryStatus::Missing
+          ? unavailableStatus(output)
+          : AudioRouteCompatibilityStatus::BackendFailure;
+  setFailure(route, compatibility_status, operation, output);
+  return true;
+}
+
+bool normalizeCurrentSampleRate(double value, uint32_t& normalized) {
+  if (!std::isfinite(value) || value <= 0.0 ||
+      value > static_cast<double>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+  const double rounded = std::round(value);
+  if (std::abs(value - rounded) > kSampleRateEpsilonHz ||
+      rounded > static_cast<double>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+  normalized = static_cast<uint32_t>(rounded);
+  return true;
+}
+
+bool supportsRequestedRate(const std::vector<CoreAudioEndpointRange>& ranges, uint32_t requested) {
+  const double requested_rate = static_cast<double>(requested);
+  return std::any_of(ranges.begin(), ranges.end(), [requested_rate](const auto& range) {
+    if (!std::isfinite(range.minimum) || !std::isfinite(range.maximum) || range.minimum <= 0.0 ||
+        range.maximum <= 0.0 || range.minimum > range.maximum) {
+      return false;
+    }
+    return requested_rate + kSampleRateEpsilonHz >= range.minimum &&
+           requested_rate <= range.maximum + kSampleRateEpsilonHz;
+  });
+}
+
+} // namespace
+
+bool resolveCoreAudioChannelMap(const std::vector<uint16_t>& requested, uint16_t logical_count,
+                                uint32_t physical_count, std::vector<uint16_t>& resolved) {
+  resolved.clear();
+  if (logical_count > physical_count) {
+    return false;
+  }
+  if (requested.empty()) {
+    resolved.resize(logical_count);
+    for (uint16_t channel = 0; channel < logical_count; ++channel) {
+      resolved[channel] = channel;
+    }
+    return true;
+  }
+  if (requested.size() != logical_count) {
+    return false;
+  }
+
+  resolved.reserve(requested.size());
+  for (const uint16_t channel : requested) {
+    if (channel >= physical_count ||
+        std::find(resolved.begin(), resolved.end(), channel) != resolved.end()) {
+      resolved.clear();
+      return false;
+    }
+    resolved.push_back(channel);
+  }
+  return true;
+}
+
+CoreAudioRouteResolver::CoreAudioRouteResolver(std::shared_ptr<const ICoreAudioRouteQuery> query)
+    : query_(std::move(query)) {}
+
+ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& config) const {
+  ResolvedCoreAudioRoute route;
+  route.compatibility.requested_sample_rate = config.sample_rate;
+
+  if (config.num_outputs == 0) {
+    setFailure(route, AudioRouteCompatibilityStatus::OutputUnavailable, "config", true);
+    return route;
+  }
+  if (config.sample_rate == 0 || config.buffer_size == 0) {
+    setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "config", true);
+    return route;
+  }
+  if (!query_) {
+    setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "query", true);
+    return route;
+  }
+
+  const auto resolve_endpoint = [&](bool output, const std::string& requested,
+                                    ResolvedCoreAudioEndpoint& endpoint) -> bool {
+    const auto resolved =
+        requested.empty() ? query_->resolveDefault(output) : query_->resolveDeviceUID(requested);
+    if (setQueryFailure(route, resolved.status, "resolve", output)) {
+      return false;
+    }
+    endpoint = resolved.value;
+    if (endpoint.device_id == 0) {
+      setFailure(route, unavailableStatus(output), "resolve", output);
+      return false;
+    }
+    if (endpoint.device_uid.empty()) {
+      if (requested.empty()) {
+        setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "resolve", output);
+        return false;
+      }
+      endpoint.device_uid = requested;
+    }
+    const auto channels =
+        query_->channelCount(endpoint.device_id, output ? kAudioObjectPropertyScopeOutput
+                                                        : kAudioObjectPropertyScopeInput);
+    if (setQueryFailure(route, channels.status, "channels", output)) {
+      return false;
+    }
+    if (channels.value == 0) {
+      setFailure(route, unavailableStatus(output), "channels", output);
+      return false;
+    }
+    if (output) {
+      route.output_device_id = endpoint.device_id;
+      route.output_channel_count = channels.value;
+      route.compatibility.resolved_output_device_id = endpoint.device_uid;
+    } else {
+      route.input_device_id = endpoint.device_id;
+      route.input_channel_count = channels.value;
+      route.compatibility.resolved_input_device_id = endpoint.device_uid;
+    }
+    return true;
+  };
+
+  ResolvedCoreAudioEndpoint output_endpoint;
+  if (!resolve_endpoint(true, config.output_device_id, output_endpoint)) {
+    return route;
+  }
+
+  ResolvedCoreAudioEndpoint input_endpoint;
+  if (config.num_inputs > 0 && !resolve_endpoint(false, config.input_device_id, input_endpoint)) {
+    return route;
+  }
+
+  if (!resolveCoreAudioChannelMap(config.channel_map.output_channels, config.num_outputs,
+                                  route.output_channel_count, route.output_channel_map)) {
+    setFailure(route, AudioRouteCompatibilityStatus::InvalidChannelMap, "map", true);
+    return route;
+  }
+  if (config.num_inputs > 0 &&
+      !resolveCoreAudioChannelMap(config.channel_map.input_channels, config.num_inputs,
+                                  route.input_channel_count, route.input_channel_map)) {
+    setFailure(route, AudioRouteCompatibilityStatus::InvalidChannelMap, "map", false);
+    return route;
+  }
+
+  bool output_rate_supported = false;
+  const auto output_ranges = query_->advertisedSampleRateRanges(route.output_device_id);
+  if (setQueryFailure(route, output_ranges.status, "ranges", true)) {
+    return route;
+  }
+  output_rate_supported = supportsRequestedRate(output_ranges.value, config.sample_rate);
+  if (!output_rate_supported) {
+    setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", true);
+    return route;
+  }
+
+  bool input_rate_supported = true;
+  if (config.num_inputs > 0 && route.input_device_id != route.output_device_id) {
+    const auto input_ranges = query_->advertisedSampleRateRanges(route.input_device_id);
+    if (setQueryFailure(route, input_ranges.status, "ranges", false)) {
+      return route;
+    }
+    input_rate_supported = supportsRequestedRate(input_ranges.value, config.sample_rate);
+    if (!input_rate_supported) {
+      setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", false);
+      return route;
+    }
+  }
+
+  const auto query_global_facts = [&](AudioDeviceID device_id, bool output, uint32_t& rate,
+                                      bool& running) -> bool {
+    const auto current = query_->currentSampleRate(device_id);
+    if (setQueryFailure(route, current.status, "current_rate", output)) {
+      return false;
+    }
+    if (!normalizeCurrentSampleRate(current.value, rate)) {
+      setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "current_rate", output);
+      return false;
+    }
+    const auto is_running = query_->isRunningSomewhere(device_id);
+    if (setQueryFailure(route, is_running.status, "running", output)) {
+      return false;
+    }
+    running = is_running.value;
+    return true;
+  };
+
+  uint32_t output_current_rate = 0;
+  bool output_running = false;
+  if (!query_global_facts(route.output_device_id, true, output_current_rate, output_running)) {
+    return route;
+  }
+
+  uint32_t input_current_rate = 0;
+  bool input_running = false;
+  if (config.num_inputs > 0) {
+    if (route.input_device_id == route.output_device_id) {
+      input_current_rate = output_current_rate;
+      input_running = output_running;
+    } else if (!query_global_facts(route.input_device_id, false, input_current_rate,
+                                   input_running)) {
+      return route;
+    }
+  }
+
+  route.compatibility.current_output_sample_rate = output_current_rate;
+  route.compatibility.output_is_running_somewhere = output_running;
+  route.compatibility.output_rate_change_required = output_current_rate != config.sample_rate;
+  if (config.num_inputs > 0) {
+    route.compatibility.current_input_sample_rate = input_current_rate;
+    route.compatibility.input_is_running_somewhere = input_running;
+    route.compatibility.input_rate_change_required = input_current_rate != config.sample_rate;
+  }
+
+  const bool rate_change_required = route.compatibility.output_rate_change_required ||
+                                    route.compatibility.input_rate_change_required;
+  route.compatibility.status =
+      rate_change_required && config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate
+          ? AudioRouteCompatibilityStatus::RequiresSampleRateChange
+          : AudioRouteCompatibilityStatus::Compatible;
+  route.compatibility.detail.clear();
+  route.resolved = true;
+  route.requires_private_aggregate =
+      config.num_inputs > 0 && route.input_device_id != route.output_device_id;
+  (void)input_rate_supported;
+  return route;
+}
+
+std::shared_ptr<const ICoreAudioRouteQuery> makeCoreAudioRouteQuery() {
+  return std::make_shared<ProductionCoreAudioRouteQuery>();
+}
+
+} // namespace orpheus::detail

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "coreaudio_endpoint_catalog.h"
+#include <orpheus/audio_driver.h>
+
+#include <CoreAudio/CoreAudio.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace orpheus::detail {
+
+enum class CoreAudioRouteQueryStatus : uint8_t {
+  Success,
+  Missing,
+  PermissionDenied,
+  Failure,
+};
+
+template <typename T> struct CoreAudioRouteQueryResult {
+  CoreAudioRouteQueryStatus status = CoreAudioRouteQueryStatus::Failure;
+  T value{};
+};
+
+struct ResolvedCoreAudioEndpoint {
+  AudioDeviceID device_id = 0;
+  std::string device_uid;
+};
+
+class ICoreAudioRouteQuery {
+public:
+  virtual ~ICoreAudioRouteQuery() = default;
+
+  virtual CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint>
+  resolveDefault(bool output) const = 0;
+  virtual CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint>
+  resolveDeviceUID(std::string_view device_uid) const = 0;
+  virtual CoreAudioRouteQueryResult<uint32_t>
+  channelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const = 0;
+  virtual CoreAudioRouteQueryResult<std::vector<CoreAudioEndpointRange>>
+  advertisedSampleRateRanges(AudioDeviceID device_id) const = 0;
+  virtual CoreAudioRouteQueryResult<double> currentSampleRate(AudioDeviceID device_id) const = 0;
+  virtual CoreAudioRouteQueryResult<bool> isRunningSomewhere(AudioDeviceID device_id) const = 0;
+};
+
+struct ResolvedCoreAudioRoute {
+  bool resolved = false;
+  AudioRouteCompatibility compatibility;
+  AudioDeviceID input_device_id = 0;
+  AudioDeviceID output_device_id = 0;
+  uint32_t input_channel_count = 0;
+  uint32_t output_channel_count = 0;
+  std::vector<uint16_t> input_channel_map;
+  std::vector<uint16_t> output_channel_map;
+  bool requires_private_aggregate = false;
+};
+
+bool resolveCoreAudioChannelMap(const std::vector<uint16_t>& requested, uint16_t logical_count,
+                                uint32_t physical_count, std::vector<uint16_t>& resolved);
+
+class CoreAudioRouteResolver {
+public:
+  explicit CoreAudioRouteResolver(std::shared_ptr<const ICoreAudioRouteQuery> query);
+  ResolvedCoreAudioRoute resolve(const AudioDriverConfig& config) const;
+
+private:
+  std::shared_ptr<const ICoreAudioRouteQuery> query_;
+};
+
+std::shared_ptr<const ICoreAudioRouteQuery> makeCoreAudioRouteQuery();
+
+} // namespace orpheus::detail

--- a/src/platform/audio_drivers/driver_manager.cpp
+++ b/src/platform/audio_drivers/driver_manager.cpp
@@ -596,6 +596,9 @@ AudioDriverManager::enumerateCoreAudioEndpointCapabilities() {
     }
     facts.current_buffer_size = read_uint32(device_id, kAudioDevicePropertyBufferFrameSize,
                                             kAudioObjectPropertyScopeGlobal);
+    facts.is_running_somewhere =
+        read_uint32(device_id, kAudioDevicePropertyDeviceIsRunningSomewhere,
+                    kAudioObjectPropertyScopeGlobal) != 0;
 
     endpoints.push_back(detail::makeCoreAudioEndpointCapabilities(facts));
   }

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -241,6 +241,31 @@ target_include_directories(dummy_driver_test
 
 add_test(NAME dummy_driver_test COMMAND dummy_driver_test)
 
+# FTR077: deterministic, non-mutating CoreAudio route compatibility probe.
+if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
+    add_executable(coreaudio_route_probe_test
+        coreaudio_route_probe_test.cpp
+    )
+
+    target_link_libraries(coreaudio_route_probe_test
+        PRIVATE
+            orpheus_audio_driver_coreaudio
+            orpheus_session
+            GTest::gtest
+            GTest::gtest_main
+            "-framework CoreFoundation"
+    )
+
+    target_include_directories(coreaudio_route_probe_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/src/core
+            ${CMAKE_SOURCE_DIR}/src/platform/audio_drivers
+    )
+
+    add_test(NAME coreaudio_route_probe_test COMMAND coreaudio_route_probe_test)
+    set_tests_properties(coreaudio_route_probe_test PROPERTIES LABELS "unit")
+endif()
+
 # CoreAudio driver tests (macOS only)
 if(ORPHEUS_ENABLE_COREAUDIO AND ORPHEUS_ENABLE_EXTENDED_TESTS)
     add_executable(coreaudio_driver_test

--- a/tests/audio_io/coreaudio_endpoint_catalog_test.cpp
+++ b/tests/audio_io/coreaudio_endpoint_catalog_test.cpp
@@ -51,8 +51,7 @@ TEST(CoreAudioEndpointCatalogTest, PreservesOutputOnlyEndpointsAndDuplicateNames
             (std::vector<uint32_t>{64, 96, 128, 160, 192, 256, 384, 512}));
   EXPECT_EQ(endpoints[0].current_buffer_size, 256u);
   EXPECT_EQ(endpoints[1].output_channels[0].stable_id, "uid-output-b:output:0");
-  EXPECT_EQ(endpoints[1].supported_sample_rates,
-            (std::vector<uint32_t>{96000, 176400, 192000}));
+  EXPECT_EQ(endpoints[1].supported_sample_rates, (std::vector<uint32_t>{96000, 176400, 192000}));
   EXPECT_EQ(endpoints[1].supported_buffer_sizes,
             (std::vector<uint32_t>{128, 160, 192, 256, 384, 512, 768, 1024}));
 }
@@ -75,6 +74,25 @@ TEST(CoreAudioEndpointCatalogTest, ReportsFormatUnavailableWithoutUsableChannels
   EXPECT_TRUE(endpoint.output_channels.empty());
   EXPECT_EQ(endpoint.supported_sample_rates, (std::vector<uint32_t>{48000}));
   EXPECT_EQ(endpoint.supported_buffer_sizes, (std::vector<uint32_t>{512}));
+}
+TEST(CoreAudioEndpointCatalogTest, ProjectsRunningSomewhereWithoutChangingAvailability) {
+  CoreAudioEndpointFacts running;
+  running.device_id = "running";
+  running.display_name = "Running";
+  running.output_channel_count = 2;
+  running.is_running_somewhere = true;
+
+  CoreAudioEndpointFacts stopped = running;
+  stopped.device_id = "stopped";
+  stopped.is_running_somewhere = false;
+
+  const auto running_endpoint = makeCoreAudioEndpointCapabilities(running);
+  const auto stopped_endpoint = makeCoreAudioEndpointCapabilities(stopped);
+
+  EXPECT_TRUE(running_endpoint.is_running_somewhere);
+  EXPECT_FALSE(stopped_endpoint.is_running_somewhere);
+  EXPECT_EQ(running_endpoint.availability, AudioEndpointAvailability::Available);
+  EXPECT_EQ(stopped_endpoint.availability, AudioEndpointAvailability::Available);
 }
 
 } // namespace

--- a/tests/audio_io/coreaudio_route_probe_test.cpp
+++ b/tests/audio_io/coreaudio_route_probe_test.cpp
@@ -383,6 +383,35 @@ TEST(CoreAudioRouteProbeTest, UnsupportedRateSkipsCurrentAndRunningQueries) {
   expectFailureDetail(compatibility);
 }
 
+TEST(CoreAudioRouteProbeTest, PassiveFactQueryFailuresAreBackendFailures) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->endpoints.at(11).sample_rate_status = CoreAudioRouteQueryStatus::Missing;
+  CoreAudioDriver driver(fake);
+
+  auto compatibility = driver.probeRoute(duplexConfig());
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(compatibility.detail, "ranges:output");
+  EXPECT_EQ(fake->ledger.current_rate_reads, 0);
+  expectFailureDetail(compatibility);
+
+  fake->endpoints.at(11).sample_rate_status = CoreAudioRouteQueryStatus::Success;
+  fake->endpoints.at(11).current_rate_status = CoreAudioRouteQueryStatus::Missing;
+  fake->resetLedger();
+  compatibility = driver.probeRoute(duplexConfig());
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(compatibility.detail, "current_rate:output");
+  EXPECT_EQ(fake->ledger.running_reads, 0);
+
+  fake->endpoints.at(11).current_rate_status = CoreAudioRouteQueryStatus::Success;
+  fake->endpoints.at(11).running_status = CoreAudioRouteQueryStatus::Missing;
+  fake->resetLedger();
+  compatibility = driver.probeRoute(duplexConfig());
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(compatibility.detail, "running:output");
+  expectFailureDetail(compatibility);
+}
+
 TEST(CoreAudioRouteProbeTest, PermissionDeniedInputStopsBeforeInputFacts) {
   auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
   installSameDevice(*fake);

--- a/tests/audio_io/coreaudio_route_probe_test.cpp
+++ b/tests/audio_io/coreaudio_route_probe_test.cpp
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: MIT
+#include "coreaudio/coreaudio_driver.h"
+#include "coreaudio/coreaudio_route_resolver.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace orpheus {
+namespace {
+
+using detail::CoreAudioEndpointRange;
+using detail::CoreAudioRouteQueryResult;
+using detail::CoreAudioRouteQueryStatus;
+using detail::ICoreAudioRouteQuery;
+using detail::ResolvedCoreAudioEndpoint;
+
+struct FakeLedger {
+  int default_input_reads = 0;
+  int default_output_reads = 0;
+  int uid_reads = 0;
+  int input_channel_reads = 0;
+  int output_channel_reads = 0;
+  int sample_rate_range_reads = 0;
+  int current_rate_reads = 0;
+  int running_reads = 0;
+  int property_writes = 0;
+  int aggregate_requests = 0;
+  int auhal_actions = 0;
+  int listener_registrations = 0;
+  int io_starts = 0;
+  int tcc_requests = 0;
+  int driver_state_mutations = 0;
+};
+
+struct FakeEndpoint {
+  AudioDeviceID device_id = 0;
+  std::string device_uid;
+  uint32_t input_channels = 0;
+  uint32_t output_channels = 0;
+  CoreAudioRouteQueryStatus input_channel_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus output_channel_status = CoreAudioRouteQueryStatus::Success;
+  std::vector<CoreAudioEndpointRange> sample_rate_ranges;
+  CoreAudioRouteQueryStatus sample_rate_status = CoreAudioRouteQueryStatus::Success;
+  double current_sample_rate = 48000.0;
+  CoreAudioRouteQueryStatus current_rate_status = CoreAudioRouteQueryStatus::Success;
+  bool is_running_somewhere = false;
+  CoreAudioRouteQueryStatus running_status = CoreAudioRouteQueryStatus::Success;
+};
+
+template <typename T>
+CoreAudioRouteQueryResult<T> fakeResult(CoreAudioRouteQueryStatus status, T value = {}) {
+  return {status, std::move(value)};
+}
+
+class FakeCoreAudioRouteQuery final : public ICoreAudioRouteQuery {
+public:
+  CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> resolveDefault(bool output) const override {
+    if (output) {
+      ++ledger.default_output_reads;
+      if (default_output_status != CoreAudioRouteQueryStatus::Success) {
+        return fakeResult<ResolvedCoreAudioEndpoint>(default_output_status);
+      }
+      return endpointFor(default_output);
+    }
+    ++ledger.default_input_reads;
+    if (default_input_status != CoreAudioRouteQueryStatus::Success) {
+      return fakeResult<ResolvedCoreAudioEndpoint>(default_input_status);
+    }
+    return endpointFor(default_input);
+  }
+
+  CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint>
+  resolveDeviceUID(std::string_view device_uid) const override {
+    ++ledger.uid_reads;
+    const auto status = uid_status.find(std::string(device_uid));
+    if (status != uid_status.end() && status->second != CoreAudioRouteQueryStatus::Success) {
+      return fakeResult<ResolvedCoreAudioEndpoint>(status->second);
+    }
+    for (const auto& [id, endpoint] : endpoints) {
+      if (endpoint.device_uid == device_uid) {
+        return fakeResult(CoreAudioRouteQueryStatus::Success,
+                          ResolvedCoreAudioEndpoint{id, endpoint.device_uid});
+      }
+    }
+    return fakeResult<ResolvedCoreAudioEndpoint>(CoreAudioRouteQueryStatus::Missing);
+  }
+
+  CoreAudioRouteQueryResult<uint32_t> channelCount(AudioDeviceID device_id,
+                                                   AudioObjectPropertyScope scope) const override {
+    const auto endpoint = endpoints.find(device_id);
+    if (scope == kAudioObjectPropertyScopeOutput) {
+      ++ledger.output_channel_reads;
+    } else {
+      ++ledger.input_channel_reads;
+    }
+    if (endpoint == endpoints.end()) {
+      return fakeResult<uint32_t>(CoreAudioRouteQueryStatus::Missing);
+    }
+    if (scope == kAudioObjectPropertyScopeOutput) {
+      return fakeResult(endpoint->second.output_channel_status, endpoint->second.output_channels);
+    }
+    return fakeResult(endpoint->second.input_channel_status, endpoint->second.input_channels);
+  }
+
+  CoreAudioRouteQueryResult<std::vector<CoreAudioEndpointRange>>
+  advertisedSampleRateRanges(AudioDeviceID device_id) const override {
+    ++ledger.sample_rate_range_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<std::vector<CoreAudioEndpointRange>>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.sample_rate_status, endpoint->second.sample_rate_ranges);
+  }
+
+  CoreAudioRouteQueryResult<double> currentSampleRate(AudioDeviceID device_id) const override {
+    ++ledger.current_rate_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<double>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.current_rate_status, endpoint->second.current_sample_rate);
+  }
+
+  CoreAudioRouteQueryResult<bool> isRunningSomewhere(AudioDeviceID device_id) const override {
+    ++ledger.running_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<bool>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.running_status, endpoint->second.is_running_somewhere);
+  }
+
+  void resetLedger() const {
+    ledger = {};
+  }
+
+  mutable FakeLedger ledger;
+  std::map<AudioDeviceID, FakeEndpoint> endpoints;
+  std::map<std::string, CoreAudioRouteQueryStatus> uid_status;
+  AudioDeviceID default_input = 0;
+  AudioDeviceID default_output = 0;
+  CoreAudioRouteQueryStatus default_input_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus default_output_status = CoreAudioRouteQueryStatus::Success;
+
+private:
+  CoreAudioRouteQueryResult<ResolvedCoreAudioEndpoint> endpointFor(AudioDeviceID device_id) const {
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<ResolvedCoreAudioEndpoint>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(CoreAudioRouteQueryStatus::Success,
+                      ResolvedCoreAudioEndpoint{device_id, endpoint->second.device_uid});
+  }
+};
+
+AudioDriverConfig duplexConfig() {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 512;
+  config.num_inputs = 2;
+  config.num_outputs = 2;
+  return config;
+}
+
+void installSameDevice(FakeCoreAudioRouteQuery& fake) {
+  FakeEndpoint endpoint;
+  endpoint.device_id = 11;
+  endpoint.device_uid = "shared";
+  endpoint.input_channels = 2;
+  endpoint.output_channels = 2;
+  endpoint.sample_rate_ranges = {{44100.0, 96000.0}};
+  endpoint.current_sample_rate = 48000.0;
+  endpoint.is_running_somewhere = true;
+  fake.endpoints.emplace(endpoint.device_id, endpoint);
+  fake.default_input = endpoint.device_id;
+  fake.default_output = endpoint.device_id;
+}
+
+void expectNoProhibitedActions(const FakeLedger& ledger) {
+  EXPECT_EQ(ledger.property_writes, 0);
+  EXPECT_EQ(ledger.aggregate_requests, 0);
+  EXPECT_EQ(ledger.auhal_actions, 0);
+  EXPECT_EQ(ledger.listener_registrations, 0);
+  EXPECT_EQ(ledger.io_starts, 0);
+  EXPECT_EQ(ledger.tcc_requests, 0);
+  EXPECT_EQ(ledger.driver_state_mutations, 0);
+}
+
+void expectFailureDetail(const AudioRouteCompatibility& compatibility) {
+  EXPECT_LE(compatibility.detail.size(), 96u);
+  for (const unsigned char character : compatibility.detail) {
+    EXPECT_LT(character, 128u);
+  }
+  EXPECT_TRUE(compatibility.detail.find(':') != std::string::npos);
+}
+
+TEST(CoreAudioRouteProbeTest, SameDeviceDefaultsAreCompatibleAndGlobalReadsAreDeduplicated) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  CoreAudioDriver driver(fake);
+
+  const AudioRouteCompatibility compatibility = driver.probeRoute(duplexConfig());
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_EQ(compatibility.resolved_input_device_id, "shared");
+  EXPECT_EQ(compatibility.resolved_output_device_id, "shared");
+  EXPECT_EQ(compatibility.current_input_sample_rate, 48000u);
+  EXPECT_EQ(compatibility.current_output_sample_rate, 48000u);
+  EXPECT_FALSE(compatibility.input_rate_change_required);
+  EXPECT_FALSE(compatibility.output_rate_change_required);
+  EXPECT_TRUE(compatibility.input_is_running_somewhere);
+  EXPECT_TRUE(compatibility.output_is_running_somewhere);
+  EXPECT_TRUE(compatibility.detail.empty());
+
+  EXPECT_EQ(fake->ledger.default_input_reads, 1);
+  EXPECT_EQ(fake->ledger.default_output_reads, 1);
+  EXPECT_EQ(fake->ledger.uid_reads, 0);
+  EXPECT_EQ(fake->ledger.input_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 1);
+  EXPECT_EQ(fake->ledger.current_rate_reads, 1);
+  EXPECT_EQ(fake->ledger.running_reads, 1);
+  expectNoProhibitedActions(fake->ledger);
+}
+
+TEST(CoreAudioRouteProbeTest, RatePolicyClassifiesSupportedMismatchWithoutMutatingRate) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->endpoints.at(11).current_sample_rate = 44100.0;
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig preserve = duplexConfig();
+  const auto preserved = driver.probeRoute(preserve);
+  EXPECT_EQ(preserved.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_EQ(preserved.current_input_sample_rate, 44100u);
+  EXPECT_EQ(preserved.current_output_sample_rate, 44100u);
+  EXPECT_TRUE(preserved.input_rate_change_required);
+  EXPECT_TRUE(preserved.output_rate_change_required);
+  EXPECT_TRUE(preserved.detail.empty());
+
+  fake->resetLedger();
+  AudioDriverConfig exact = duplexConfig();
+  exact.sample_rate_policy = AudioSampleRatePolicy::RequestExactRate;
+  const auto requested = driver.probeRoute(exact);
+  EXPECT_EQ(requested.status, AudioRouteCompatibilityStatus::RequiresSampleRateChange);
+  EXPECT_EQ(requested.current_input_sample_rate, 44100u);
+  EXPECT_EQ(requested.current_output_sample_rate, 44100u);
+  EXPECT_TRUE(requested.input_rate_change_required);
+  EXPECT_TRUE(requested.output_rate_change_required);
+  EXPECT_TRUE(requested.detail.empty());
+  expectNoProhibitedActions(fake->ledger);
+}
+
+TEST(CoreAudioRouteProbeTest, ExplicitUidDoesNotFallBackAndDirectionMismatchIsUnavailable) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig missing = duplexConfig();
+  missing.num_inputs = 0;
+  missing.output_device_id = "missing-output";
+  auto compatibility = driver.probeRoute(missing);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::OutputUnavailable);
+  EXPECT_EQ(fake->ledger.default_output_reads, 0);
+  EXPECT_EQ(fake->ledger.uid_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 0);
+
+  fake->resetLedger();
+  FakeEndpoint input_only = fake->endpoints.at(11);
+  input_only.device_id = 12;
+  input_only.device_uid = "input-only";
+  input_only.output_channels = 0;
+  fake->endpoints.emplace(input_only.device_id, input_only);
+  AudioDriverConfig incompatible = duplexConfig();
+  incompatible.num_inputs = 0;
+  incompatible.output_device_id = "input-only";
+  compatibility = driver.probeRoute(incompatible);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::OutputUnavailable);
+  EXPECT_EQ(fake->ledger.default_output_reads, 0);
+  EXPECT_EQ(fake->ledger.uid_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 1);
+  expectFailureDetail(compatibility);
+}
+
+TEST(CoreAudioRouteProbeTest, OutputOnlyIgnoresStaleInputUidMapAndPermissionState) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->default_input_status = CoreAudioRouteQueryStatus::PermissionDenied;
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig config = duplexConfig();
+  config.num_inputs = 0;
+  config.input_device_id = "stale-input";
+  config.channel_map.input_channels = {99, 99};
+  const auto compatibility = driver.probeRoute(config);
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_EQ(compatibility.resolved_input_device_id, "");
+  EXPECT_EQ(compatibility.current_input_sample_rate, 0u);
+  EXPECT_FALSE(compatibility.input_rate_change_required);
+  EXPECT_FALSE(compatibility.input_is_running_somewhere);
+  EXPECT_EQ(fake->ledger.default_input_reads, 0);
+  EXPECT_EQ(fake->ledger.input_channel_reads, 0);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 1);
+  EXPECT_EQ(fake->ledger.current_rate_reads, 1);
+  EXPECT_EQ(fake->ledger.running_reads, 1);
+  expectNoProhibitedActions(fake->ledger);
+}
+
+TEST(CoreAudioRouteProbeTest, InvalidStaticConfigurationPrecedesEveryEndpointQuery) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig no_output = duplexConfig();
+  no_output.num_outputs = 0;
+  no_output.sample_rate = 0;
+  no_output.buffer_size = 0;
+  auto compatibility = driver.probeRoute(no_output);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::OutputUnavailable);
+  expectFailureDetail(compatibility);
+  EXPECT_EQ(fake->ledger.default_input_reads, 0);
+  EXPECT_EQ(fake->ledger.default_output_reads, 0);
+  EXPECT_EQ(fake->ledger.uid_reads, 0);
+
+  fake->resetLedger();
+  AudioDriverConfig invalid_rate = duplexConfig();
+  invalid_rate.sample_rate = 0;
+  compatibility = driver.probeRoute(invalid_rate);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(fake->ledger.default_input_reads, 0);
+  EXPECT_EQ(fake->ledger.default_output_reads, 0);
+  EXPECT_EQ(fake->ledger.uid_reads, 0);
+  expectFailureDetail(compatibility);
+}
+
+TEST(CoreAudioRouteProbeTest, InvalidMapsAreClassifiedAfterBothEndpointsResolve) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig output_map = duplexConfig();
+  output_map.channel_map.output_channels = {0, 0};
+  auto compatibility = driver.probeRoute(output_map);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::InvalidChannelMap);
+  EXPECT_EQ(compatibility.detail, "map:output");
+  EXPECT_EQ(fake->ledger.input_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 0);
+
+  fake->resetLedger();
+  AudioDriverConfig input_map = duplexConfig();
+  input_map.channel_map.input_channels = {2, 0};
+  compatibility = driver.probeRoute(input_map);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::InvalidChannelMap);
+  EXPECT_EQ(compatibility.detail, "map:input");
+  EXPECT_EQ(fake->ledger.input_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 0);
+}
+
+TEST(CoreAudioRouteProbeTest, UnsupportedRateSkipsCurrentAndRunningQueries) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->endpoints.at(11).sample_rate_ranges = {{44100.0, 44100.0}};
+  CoreAudioDriver driver(fake);
+
+  AudioDriverConfig config = duplexConfig();
+  config.sample_rate = 48000;
+  const auto compatibility = driver.probeRoute(config);
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::SampleRateUnsupported);
+  EXPECT_EQ(compatibility.current_input_sample_rate, 0u);
+  EXPECT_EQ(compatibility.current_output_sample_rate, 0u);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 1);
+  EXPECT_EQ(fake->ledger.current_rate_reads, 0);
+  EXPECT_EQ(fake->ledger.running_reads, 0);
+  expectFailureDetail(compatibility);
+}
+
+TEST(CoreAudioRouteProbeTest, PermissionDeniedInputStopsBeforeInputFacts) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->default_input_status = CoreAudioRouteQueryStatus::PermissionDenied;
+  CoreAudioDriver driver(fake);
+
+  const auto compatibility = driver.probeRoute(duplexConfig());
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::PermissionDenied);
+  EXPECT_EQ(compatibility.detail, "resolve:input");
+  EXPECT_EQ(fake->ledger.default_output_reads, 1);
+  EXPECT_EQ(fake->ledger.default_input_reads, 1);
+  EXPECT_EQ(fake->ledger.output_channel_reads, 1);
+  EXPECT_EQ(fake->ledger.input_channel_reads, 0);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 0);
+  expectFailureDetail(compatibility);
+}
+
+TEST(CoreAudioRouteProbeTest, RejectsMalformedCurrentRateWithBoundedDetail) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  fake->endpoints.at(11).current_sample_rate = 48000.002;
+  CoreAudioDriver driver(fake);
+
+  const auto compatibility = driver.probeRoute(duplexConfig());
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(compatibility.detail, "current_rate:output");
+  EXPECT_EQ(fake->ledger.current_rate_reads, 1);
+  EXPECT_EQ(fake->ledger.running_reads, 0);
+  expectFailureDetail(compatibility);
+}
+
+TEST(CoreAudioRouteProbeTest,
+     ResolverMarksSupportedRoutesAsResolvedAndAggregatesOnlyDistinctDevices) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  detail::CoreAudioRouteResolver resolver(fake);
+
+  auto same_device = resolver.resolve(duplexConfig());
+  EXPECT_TRUE(same_device.resolved);
+  EXPECT_FALSE(same_device.requires_private_aggregate);
+  EXPECT_EQ(same_device.input_device_id, 11u);
+  EXPECT_EQ(same_device.output_device_id, 11u);
+  EXPECT_EQ(same_device.input_channel_map, (std::vector<uint16_t>{0, 1}));
+  EXPECT_EQ(same_device.output_channel_map, (std::vector<uint16_t>{0, 1}));
+
+  fake->resetLedger();
+  FakeEndpoint distinct_input = fake->endpoints.at(11);
+  distinct_input.device_id = 12;
+  distinct_input.device_uid = "input";
+  distinct_input.output_channels = 0;
+  fake->endpoints.emplace(12, distinct_input);
+  fake->default_input = 12;
+  auto distinct = resolver.resolve(duplexConfig());
+  EXPECT_TRUE(distinct.resolved);
+  EXPECT_TRUE(distinct.requires_private_aggregate);
+  EXPECT_EQ(distinct.input_device_id, 12u);
+  EXPECT_EQ(distinct.output_device_id, 11u);
+  EXPECT_EQ(fake->ledger.sample_rate_range_reads, 2);
+  EXPECT_EQ(fake->ledger.current_rate_reads, 2);
+  EXPECT_EQ(fake->ledger.running_reads, 2);
+}
+
+TEST(CoreAudioRouteProbeTest, ProbeDoesNotMutateCoreAudioDriverState) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  installSameDevice(*fake);
+  CoreAudioDriver driver(fake);
+  const AudioDriverConfig before_config = driver.getConfig();
+  const ActiveAudioRoute before_route = driver.getActiveRoute();
+  const AudioIoRouteState before_state = driver.getAudioIoRouteState();
+
+  AudioDriverConfig request = duplexConfig();
+  request.output_device_id = "shared";
+  request.input_device_id = "shared";
+  request.channel_map.output_channels = {1, 0};
+  const auto compatibility = driver.probeRoute(request);
+  ASSERT_EQ(compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+
+  const auto& after_config = driver.getConfig();
+  EXPECT_EQ(after_config.sample_rate, before_config.sample_rate);
+  EXPECT_EQ(after_config.buffer_size, before_config.buffer_size);
+  EXPECT_EQ(after_config.num_inputs, before_config.num_inputs);
+  EXPECT_EQ(after_config.num_outputs, before_config.num_outputs);
+  EXPECT_EQ(after_config.input_device_id, before_config.input_device_id);
+  EXPECT_EQ(after_config.output_device_id, before_config.output_device_id);
+  EXPECT_EQ(after_config.channel_map.input_channels, before_config.channel_map.input_channels);
+  EXPECT_EQ(after_config.channel_map.output_channels, before_config.channel_map.output_channels);
+  EXPECT_EQ(after_config.sample_rate_policy, before_config.sample_rate_policy);
+
+  const auto after_route = driver.getActiveRoute();
+  EXPECT_EQ(after_route.input_device_id, before_route.input_device_id);
+  EXPECT_EQ(after_route.output_device_id, before_route.output_device_id);
+  EXPECT_EQ(after_route.input_channels, before_route.input_channels);
+  EXPECT_EQ(after_route.output_channels, before_route.output_channels);
+  EXPECT_EQ(after_route.requested_sample_rate, before_route.requested_sample_rate);
+  EXPECT_EQ(after_route.actual_sample_rate, before_route.actual_sample_rate);
+
+  const auto after_state = driver.getAudioIoRouteState();
+  EXPECT_EQ(after_state.state, before_state.state);
+  EXPECT_EQ(after_state.selected_input_device_id, before_state.selected_input_device_id);
+  EXPECT_EQ(after_state.selected_output_device_id, before_state.selected_output_device_id);
+  EXPECT_EQ(after_state.active_input_device_id, before_state.active_input_device_id);
+  EXPECT_EQ(after_state.active_output_device_id, before_state.active_output_device_id);
+  EXPECT_EQ(after_state.requested_sample_rate, before_state.requested_sample_rate);
+  EXPECT_EQ(after_state.actual_sample_rate, before_state.actual_sample_rate);
+  expectNoProhibitedActions(fake->ledger);
+}
+
+} // namespace
+} // namespace orpheus

--- a/tests/audio_io/dummy_driver_test.cpp
+++ b/tests/audio_io/dummy_driver_test.cpp
@@ -317,3 +317,107 @@ TEST_F(DummyDriverTest, StopWhenNotRunning) {
   auto error = m_driver->stop();
   EXPECT_EQ(error, SessionGraphError::OK);
 }
+
+TEST_F(DummyDriverTest, ProbeValidConfigUsesProbeOnlyDummyIdentity) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 256;
+  config.num_inputs = 1;
+  config.num_outputs = 2;
+  config.input_device_id = "dummy";
+  config.output_device_id = "dummy";
+
+  const auto compatibility = m_driver->probeRoute(config);
+
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_EQ(compatibility.resolved_input_device_id, "dummy");
+  EXPECT_EQ(compatibility.resolved_output_device_id, "dummy");
+  EXPECT_EQ(compatibility.current_input_sample_rate, 48000u);
+  EXPECT_EQ(compatibility.current_output_sample_rate, 48000u);
+  EXPECT_FALSE(compatibility.input_rate_change_required);
+  EXPECT_FALSE(compatibility.output_rate_change_required);
+  EXPECT_FALSE(compatibility.input_is_running_somewhere);
+  EXPECT_FALSE(compatibility.output_is_running_somewhere);
+  EXPECT_TRUE(compatibility.detail.empty());
+}
+
+TEST_F(DummyDriverTest, ProbeReportsUnavailableExplicitIdsWithoutFallback) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 256;
+  config.num_inputs = 1;
+  config.num_outputs = 2;
+  config.output_device_id = "not-dummy";
+  auto compatibility = m_driver->probeRoute(config);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::OutputUnavailable);
+  EXPECT_EQ(compatibility.detail, "resolve:output");
+
+  config.output_device_id.clear();
+  config.input_device_id = "not-dummy";
+  compatibility = m_driver->probeRoute(config);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::InputUnavailable);
+  EXPECT_EQ(compatibility.detail, "resolve:input");
+}
+
+TEST_F(DummyDriverTest, ProbeReportsInvalidMapsAndStaticPrecedence) {
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 256;
+  config.num_outputs = 2;
+  config.channel_map.output_channels = {0, 0};
+  auto compatibility = m_driver->probeRoute(config);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::InvalidChannelMap);
+  EXPECT_EQ(compatibility.detail, "map:output");
+
+  config.channel_map.output_channels.clear();
+  config.num_outputs = 0;
+  config.sample_rate = 0;
+  config.buffer_size = 0;
+  compatibility = m_driver->probeRoute(config);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::OutputUnavailable);
+
+  config.num_outputs = 2;
+  compatibility = m_driver->probeRoute(config);
+  EXPECT_EQ(compatibility.status, AudioRouteCompatibilityStatus::BackendFailure);
+  EXPECT_EQ(compatibility.detail, "config:output");
+}
+
+TEST_F(DummyDriverTest, ProbeDoesNotChangeDriverState) {
+  AudioDriverConfig initialized;
+  initialized.sample_rate = 48000;
+  initialized.buffer_size = 128;
+  initialized.num_inputs = 1;
+  initialized.num_outputs = 2;
+  initialized.channel_map.output_channels = {1, 0};
+  ASSERT_EQ(m_driver->initialize(initialized), SessionGraphError::OK);
+
+  const auto before_config = m_driver->getConfig();
+  const auto before_route = m_driver->getActiveRoute();
+  const auto before_state = m_driver->getAudioIoRouteState();
+
+  AudioDriverConfig request = initialized;
+  request.sample_rate = 96000;
+  request.output_device_id = "dummy";
+  request.input_device_id = "dummy";
+  request.channel_map.output_channels = {0, 1};
+  ASSERT_EQ(m_driver->probeRoute(request).status, AudioRouteCompatibilityStatus::Compatible);
+
+  const auto& after_config = m_driver->getConfig();
+  EXPECT_EQ(after_config.sample_rate, before_config.sample_rate);
+  EXPECT_EQ(after_config.buffer_size, before_config.buffer_size);
+  EXPECT_EQ(after_config.num_inputs, before_config.num_inputs);
+  EXPECT_EQ(after_config.num_outputs, before_config.num_outputs);
+  EXPECT_EQ(after_config.channel_map.output_channels, before_config.channel_map.output_channels);
+  const auto after_route = m_driver->getActiveRoute();
+  EXPECT_EQ(after_route.input_device_id, before_route.input_device_id);
+  EXPECT_EQ(after_route.output_device_id, before_route.output_device_id);
+  EXPECT_EQ(after_route.input_channels, before_route.input_channels);
+  EXPECT_EQ(after_route.output_channels, before_route.output_channels);
+  const auto after_state = m_driver->getAudioIoRouteState();
+  EXPECT_EQ(after_state.state, before_state.state);
+  EXPECT_EQ(after_state.selected_input_device_id, before_state.selected_input_device_id);
+  EXPECT_EQ(after_state.selected_output_device_id, before_state.selected_output_device_id);
+  EXPECT_EQ(after_state.active_input_channel_map, before_state.active_input_channel_map);
+  EXPECT_EQ(after_state.active_output_channel_map, before_state.active_output_channel_map);
+  EXPECT_EQ(after_state.actual_sample_rate, before_state.actual_sample_rate);
+}

--- a/tests/cmake/add_subdirectory/CMakeLists.txt
+++ b/tests/cmake/add_subdirectory/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(orpheus_add_subdirectory_smoke
   PRIVATE
     Orpheus::transport
     Orpheus::routing
-    Orpheus::audio_utils)
+    Orpheus::audio_utils
+    Orpheus::audio_io)

--- a/tests/cmake/add_subdirectory/main.cpp
+++ b/tests/cmake/add_subdirectory/main.cpp
@@ -5,6 +5,8 @@
 // enough to prove the headers compile and link cleanly from an external
 // consumer that pulled the SDK in via add_subdirectory. No JUCE, no host glue.
 
+#include <orpheus/audio_driver.h>
+
 #include <orpheus/polyphase_resampler.h>
 #include <orpheus/transport_controller.h>
 
@@ -15,11 +17,22 @@
 using namespace orpheus;
 
 int main() {
+  orpheus::AudioDriverConfig legacy{48000, 512, 0, {}, 2, {}, {}, {{}, {0, 1}}};
+  if (legacy.sample_rate != 48000 || legacy.buffer_size != 512 || legacy.num_inputs != 0 ||
+      !legacy.input_device_id.empty() || legacy.num_outputs != 2 ||
+      !legacy.output_device_id.empty() || !legacy.device_name.empty() ||
+      !legacy.channel_map.input_channels.empty() ||
+      legacy.channel_map.output_channels != std::vector<uint16_t>{0, 1} ||
+      legacy.sample_rate_policy != orpheus::AudioSampleRatePolicy::PreserveDeviceRate) {
+    return 1;
+  }
+
   // Transport is host-neutral: a null SessionGraph is fine for a link/compile
   // smoke test (we never register real audio here).
-  auto transport = createTransportController(nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
+  auto transport = createTransportController(
+      nullptr, TransportConfig{.sampleRate = static_cast<uint32_t>(48000)});
   if (!transport) {
-    return 1;
+    return 2;
   }
 
   // ORP127 G5: voice-mode API is reachable and typed as expected.
@@ -30,7 +43,7 @@ int main() {
   // ORP127 G7: choke + voice-cap primitives are reachable.
   transport->setMaxVoicesPerClip(4);
   if (transport->getMaxVoicesPerClip() != 4) {
-    return 2;
+    return 3;
   }
   transport->stopOtherClips(0);
 

--- a/tests/cmake/find_package/audio_io_telemetry.cpp
+++ b/tests/cmake/find_package/audio_io_telemetry.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <orpheus/audio_driver.h>
 
+#include <vector>
+
 namespace {
 
 class TelemetryDriver final : public orpheus::IAudioDriver {
@@ -41,10 +43,23 @@ private:
 } // namespace
 
 int main() {
+  orpheus::AudioDriverConfig legacy{48000, 512, 0, {}, 2, {}, {}, {{}, {0, 1}}};
   TelemetryDriver driver;
+  if (driver.initialize(legacy) != orpheus::SessionGraphError::OK) {
+    return 1;
+  }
+  const auto& observed = driver.getConfig();
+  if (observed.sample_rate != 48000 || observed.buffer_size != 512 || observed.num_inputs != 0 ||
+      !observed.input_device_id.empty() || observed.num_outputs != 2 ||
+      !observed.output_device_id.empty() || !observed.device_name.empty() ||
+      !observed.channel_map.input_channels.empty() ||
+      observed.channel_map.output_channels != std::vector<uint16_t>{0, 1} ||
+      observed.sample_rate_policy != orpheus::AudioSampleRatePolicy::PreserveDeviceRate) {
+    return 2;
+  }
   const orpheus::AudioIoTelemetry telemetry = driver.getTelemetry();
   return telemetry.input_render_failures != 0 ||
                  telemetry.runtime_outcome != orpheus::AudioDriverRuntimeOutcome::Healthy
-             ? 1
+             ? 3
              : 0;
 }

--- a/tests/package_runtime_consumer/main.cpp
+++ b/tests/package_runtime_consumer/main.cpp
@@ -8,6 +8,8 @@
 #include <cstddef>
 #include <vector>
 
+#include <cstdint>
+
 namespace {
 
 class RecordingCallback final : public orpheus::ITransportCallback {
@@ -30,7 +32,20 @@ public:
 
 } // namespace
 
+bool validLegacyAudioDriverConfig(const orpheus::AudioDriverConfig& config) {
+  return config.sample_rate == 48000 && config.buffer_size == 512 && config.num_inputs == 0 &&
+         config.input_device_id.empty() && config.num_outputs == 2 &&
+         config.output_device_id.empty() && config.device_name.empty() &&
+         config.channel_map.input_channels.empty() &&
+         config.channel_map.output_channels == std::vector<uint16_t>{0, 1} &&
+         config.sample_rate_policy == orpheus::AudioSampleRatePolicy::PreserveDeviceRate;
+}
+
 int main() {
+  orpheus::AudioDriverConfig legacy{48000, 512, 0, {}, 2, {}, {}, {{}, {0, 1}}};
+  if (!validLegacyAudioDriverConfig(legacy)) {
+    return 18;
+  }
   constexpr uint32_t kSampleRate = 48000;
   constexpr orpheus::ClipHandle kHandle = 17;
   constexpr size_t kFrames = 64;
@@ -44,12 +59,10 @@ int main() {
   outputRequest.output_channel_map = {1, 0};
   outputRequest.requested_sample_rate = kSampleRate;
   outputRequest.requested_buffer_size = 128;
-  if (outputDriver->initializeAudioOutput(outputRequest) !=
-      orpheus::SessionGraphError::OK) {
+  if (outputDriver->initializeAudioOutput(outputRequest) != orpheus::SessionGraphError::OK) {
     return 12;
   }
-  if (outputDriver->getConfig().channel_map.output_channels !=
-      outputRequest.output_channel_map) {
+  if (outputDriver->getConfig().channel_map.output_channels != outputRequest.output_channel_map) {
     return 13;
   }
   const auto routeState = outputDriver->getAudioIoRouteState();
@@ -79,7 +92,6 @@ int main() {
   if (dummy == devices.end() || dummy->maxChannels != 2) {
     return 17;
   }
-
 
   auto transport = orpheus::createTransportController(
       nullptr, orpheus::TransportConfig{.sampleRate = static_cast<uint32_t>(kSampleRate)});


### PR DESCRIPTION
## Summary
- Adds the additive AudioSampleRatePolicy and AudioRouteCompatibility public contract with a default probe virtual.
- Adds a private read-only CoreAudio route resolver with fixed precedence, endpoint/channel-map/range/current-rate/running-state classification, shared-device fact deduplication, and bounded failure details.
- Keeps probe side-effect free; activation consumes the resolved route and remains the only path that may create an aggregate or configure AUHAL.
- Projects the informational DeviceIsRunningSomewhere catalog fact and implements dummy-driver behavior.
- Recompiles and exercises find-package, add-subdirectory, and package-runtime consumers with the exact legacy aggregate and default PreserveDeviceRate tail.

## Verification
- cmake --build --preset sdk-debug --target coreaudio_route_probe_test coreaudio_driver_test driver_manager_test dummy_driver_test
- ctest --test-dir build-sdk-fast -R '^(coreaudio_route_probe_test|driver_manager_test|dummy_driver_test)$' --output-on-failure — 3/3 passed.
- ctest --test-dir build-sdk-fast --output-on-failure -VV — 63/63 tests passed.
- Installed find-package fixture — 13/13 passed.
- Installed package-runtime consumer — 1/1 passed.
- Add-subdirectory consumer configured, built, and executable returned success.
- ctest --test-dir build-sdk-fast -R '^realtime_static_audit$' --output-on-failure — passed.
- build-sdk-debug compiled successfully and its realtime_static_audit passed. The complete Debug CTest invocation was attempted but every ASan/UBSan executable stalled at startup in this macOS environment; no Debug test result is claimed.

FourTrack was not modified and its SDK gitlink was not changed. FTR078 owns runtime-taxonomy cleanup, rate writes/rollback, passive monitoring, and adoption.