### PR TITLE
ORP174: record cooperative CoreAudio handoff

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,5 +1,42 @@
 # Progress
 
+
+## ORP174 — Cooperative CoreAudio rate negotiation
+
+**Date:** 2026-08-08
+**Status:** Implemented and merged as [PR #242](https://github.com/chrislyons/orpheus-sdk/pull/242) at
+`498c02222f11a81f3dcc3e726d0355bdb20866ae`; downstream adoption deferred to FTR079.
+**Pre-sprint SDK baseline:** `8333a04a47cd9c5f8a2dcd78fb185f6984b2069e`
+
+### Delivered
+
+- The public C++ runtime taxonomy is `AudioRouteRuntimeOutcome`; telemetry has
+  only cumulative input-render failures and that outcome. The package is
+  version `0.7.0`; the stable C ABI remains `1.0`.
+- CoreAudio uses an injectable complete property API, a bounded listener-driven
+  rate transaction with reverse rollback, scoped automatic hog-mode lifecycle,
+  passive directional route monitoring, and a terminal admission latch.
+- Render facts publish atomically before start. A callback validates complete
+  hardware buffers, renders the full input span once, delivers contiguous
+  client chunks without clamping, and copies all output frames.
+
+### Evidence and boundary
+
+- The configured `sdk-debug` tree built successfully and its 80-test CTest
+  configuration passed, including installed package consumers and CoreAudio
+  hardware-tagged coverage.
+- Installed consumers passed current-minor acceptance, previous-minor
+  rejection, exact telemetry assertions, retired enum rejection, and retired
+  telemetry-field rejection.
+- `PYTHONDONTWRITEBYTECODE=1 python3 tools/realtime_audit.py` passed with zero
+  hard failures and zero tracked debt findings.
+- No Windows WASAPI compile or hardware evidence is claimed. FTR079 retains
+  FourTrack manual validation for built-in/USB routes, same-device duplex,
+  distinct private aggregates, default-device changes, unsupported rates,
+  external 44.1/48 kHz rate and buffer changes, permission denial, and
+  disconnect/reconnect.
+- Full details: [`ORP174 Cooperative CoreAudio Rate Negotiation Handoff`](docs/orp/ORP174%20Cooperative%20CoreAudio%20Rate%20Negotiation%20Handoff.md).
+
 ## ORP172 — Non-mutating CoreAudio route compatibility
 
 **Date:** 2026-08-08  

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -9,6 +9,10 @@ Project documentation index for orpheus-sdk.
 
 ## Current Records
 
+- [[ORP174 Cooperative CoreAudio Rate Negotiation Handoff]] — bounded CoreAudio
+  activation, passive route monitoring, and complete callback handoff (2026-08-08)
+- [[ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record]] —
+  qualification and release-gate record (2026-08-08)
 - [[ORP172 Non-Mutating CoreAudio Route Compatibility Handoff]] — non-mutating CoreAudio route compatibility probe and downstream handoff (2026-08-08)
 - [[ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff]] — directional route-state contract and downstream handoff (2026-08-04)
 - [[ORP169 Orpheus Suite Remote Synchronization and PR Merge]] — repository
@@ -26,11 +30,11 @@ Project documentation index for orpheus-sdk.
 
 - [ORP128 CoreAudio Runtime Sample-Rate Resilience](ORP128%20CoreAudio%20Runtime%20Sample-Rate%20Resilience.md)
 - [ORP162 CoreAudio Capture Channel Mapping and Downstream Pin Handoff](ORP162%20CoreAudio%20Capture%20Channel%20Mapping%20and%20Downstream%20Pin%20Handoff.md)
-- [ORP166 Orpheus Suite Application Launch and Icon Checkpoint](ORP166%20Orpheus%20Suite%20Application%20Launch%20and%20Icon%20Checkpoint.md)
-- [ORP168 Streaming Seek Priming and Underrun Classification](ORP168%20Streaming%20Seek%20Priming%20and%20Underrun%20Classification.md)
-- [ORP169 Orpheus Suite Remote Synchronization and PR Merge](ORP169%20Orpheus%20Suite%20Remote%20Synchronization%20and%20PR%20Merge.md)
-- [ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff](ORP171%20FourTrack%20Multi-Device%20CoreAudio%20Route-State%20Contract%20Handoff.md)
+- [ORP174 Cooperative CoreAudio Rate Negotiation Handoff](ORP174%20Cooperative%20CoreAudio%20Rate%20Negotiation%20Handoff.md)
+- [ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record](ORP173%20Orpheus%20Suite%20v0.1.0%20Qualification%20and%20Release%20Gate%20Record.md)
 - [ORP172 Non-Mutating CoreAudio Route Compatibility Handoff](ORP172%20Non-Mutating%20CoreAudio%20Route%20Compatibility%20Handoff.md)
+- [ORP171 FourTrack Multi-Device CoreAudio Route-State Contract Handoff](ORP171%20FourTrack%20Multi-Device%20CoreAudio%20Route-State%20Contract%20Handoff.md)
+- [ORP169 Orpheus Suite Remote Synchronization and PR Merge](ORP169%20Orpheus%20Suite%20Remote%20Synchronization%20and%20PR%20Merge.md)
 - [ORP documentation conventions](ORP.md)
 
 ## Navigation

--- a/docs/orp/ORP174 Cooperative CoreAudio Rate Negotiation Handoff.md
+++ b/docs/orp/ORP174 Cooperative CoreAudio Rate Negotiation Handoff.md
@@ -1,0 +1,100 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP174 — Cooperative CoreAudio Rate Negotiation Handoff
+
+**Document type:** SDK implementation and downstream handoff  
+**Status:** Implemented and merged; downstream adoption deferred to FTR079  
+**Date:** 2026-08-08  
+**Consumer:** FourTrack / EightTrack, FTR079  
+**Implementation PR:** [orpheus-sdk#242](https://github.com/chrislyons/orpheus-sdk/pull/242)  
+**Merged SDK revision:** `498c02222f11a81f3dcc3e726d0355bdb20866ae`  
+**Pre-sprint SDK baseline:** `8333a04a47cd9c5f8a2dcd78fb185f6984b2069e`  
+**Related:** ORP172, ORP173; FourTrack FTR078 and FTR079
+
+---
+
+## 1. Decision and adoption boundary
+
+ORP174 replaces active CoreAudio rate reassertion with a bounded activation
+transaction. The merged SDK now negotiates a requested rate only after the
+ORP172 compatibility resolver accepts the route, monitors active physical
+directions passively, and closes callback admission on terminal route or
+callback-capacity failures.
+
+FourTrack was not changed by PR #242. Its SDK gitlink, bridge, model, and UI
+remain outside this implementation. FTR079 owns adoption from the exact merged
+revision above and the application-level hardware matrix.
+
+## 2. Delivered SDK contracts
+
+- `AudioRouteRuntimeOutcome` is the sole public runtime-outcome taxonomy.
+  `AudioIoTelemetry` contains only cumulative input-render failures and that
+  route outcome. The C++ package version is `0.7.0`; `ORPHEUS_ABI_VERSION`
+  remains `1.0`.
+- The installed package fixtures accept the current minor and reject the
+  previous minor. Separate expected-failure consumers reject the retired enum
+  and retired telemetry field.
+- CoreAudio property access is supplied through the injectable
+  `ICoreAudioPropertyApi` read/write/listener/settable seam. The rate-only
+  property monitor and its retired poll taxonomy are removed.
+- `CoreAudioSampleRateTransaction` rereads nominal rate and settable state,
+  registers listeners before writes, writes output before a distinct input,
+  waits for listener-confirmed readback, and rolls back in reverse order only
+  when fresh readback still equals the requested rate. Same-rate activation
+  performs no rate write or listener registration.
+- Automatic hog-mode permission is scoped to activation. A value changed by the
+  driver is restored on pre-publication failure and normal stop; restoration
+  failure publishes `BackendFailure`. Nominal rate is never restored by hog
+  cleanup.
+- Route monitoring preserves physical output, optional physical input, and
+  private aggregate order, reports directional loss before aggregate loss, and
+  uses passive atomic generation/state waiting. Terminal admission is latched
+  once and later healthy observations cannot reopen it.
+- Render facts publish sample rate, maximum hardware callback frames, client
+  chunk size, and channel counts atomically before start. The callback validates
+  the complete AudioBufferList, renders the full hardware span once, invokes
+  the client in contiguous chunks, and copies every internal output frame once.
+
+## 3. Implementation record
+
+The implementation branch was based on `8333a04a47cd9c5f8a2dcd78fb185f6984b2069e`
+and merged at `498c02222f11a81f3dcc3e726d0355bdb20866ae` with these three
+commits:
+
+- `4f1f804836bdab0600e20957573bbece7b704ea9` —
+  `refactor(audio-io): unify route runtime outcomes`
+- `7b1e45cb` — `refactor(coreaudio): negotiate sample rate cooperatively`
+- `4ee8f2ad40357f7400a90ed342bcf7a8e902cc18` —
+  `fix(coreaudio): deliver complete hardware callbacks`
+
+## 4. Verification evidence
+
+Observed on the macOS arm64 SDK checkout at the merged implementation tip:
+
+- `cmake --build --preset sdk-debug --parallel` completed successfully.
+- `ctest --test-dir build-sdk-debug --output-on-failure` completed successfully
+  for the configured 80-test tree.
+- Installed package and consumer checks passed, including current-minor
+  acceptance, previous-minor rejection, telemetry contract assertions, retired
+  enum rejection, and retired telemetry-field rejection.
+- `PYTHONDONTWRITEBYTECODE=1 python3 tools/realtime_audit.py` passed with zero
+  hard failures and zero tracked debt findings.
+- CoreAudio deterministic coverage passed transaction ordering, same-rate and
+  same-device cases, settable/write/timeout failure handling, reverse rollback,
+  third-party rate preservation, delayed listener delivery, passive route loss,
+  output-only stale-input auditing, hog-mode restoration, and complete callback
+  chunk delivery.
+
+## 5. Deferred hardware evidence
+
+The following evidence is not claimed by this SDK-only handoff:
+
+- Windows WASAPI compilation, execution, and real-device acceptance; no local
+  Windows runner is available.
+- FourTrack application-level manual validation after FTR079 adoption for
+  built-in and USB routes, same-device duplex, distinct-device/private
+  aggregate routes, directional default-device changes, unsupported-rate
+  selection, external 44.1/48 kHz rate changes, buffer-size changes, permission
+  denial, and disconnect/reconnect.
+
+No FourTrack adoption result is inferred from this record.


### PR DESCRIPTION
## Scope

Documentation-only post-merge handoff for the already merged SDK implementation.

- Source implementation PR: [#242](https://github.com/chrislyons/orpheus-sdk/pull/242)
- Source merge revision: `498c02222f11a81f3dcc3e726d0355bdb20866ae`
- Pre-sprint SDK baseline: `8333a04a47cd9c5f8a2dcd78fb185f6984b2069e`
- Documentation commit: `96ae2e96`

## Changes

- Adds `docs/orp/ORP174 Cooperative CoreAudio Rate Negotiation Handoff.md`.
- Updates `docs/orp/INDEX.md`.
- Updates `PROGRESS.md`.

The record contains only observed implementation, merge, baseline, test, and named hardware-deferral facts. No FourTrack source or gitlink changes are included.
