### PR TITLE
feat(coreaudio): add directional Bluetooth SRC routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output endpoint loss. Endpoint-change notifications include default input and
   output changes, run on a control worker, and are safe to replace, unregister,
   or destroy from their own callback.
+- Added directional CoreAudio sample-rate conversion for `RequestExactRateOrConvert`.
+  Endpoint resolution now publishes settled physical/client rates and widths,
+  converter latency, Bluetooth/related-endpoint facts, a deliberate mono-output
+  fallback, and saturating conversion/FIFO/capture health counters. CoreAudio
+  activates only the required device-rate plan and terminates stale routes after
+  a monitored profile change.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.22)
 
-project(orpheus VERSION 0.7.0 LANGUAGES CXX)
+project(orpheus VERSION 0.8.0 LANGUAGES CXX)
 
 set(ORPHEUS_ABI_MAJOR 1)
 set(ORPHEUS_ABI_MINOR 0)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,30 @@
 # Progress
 
 
+## ORP176 — CoreAudio Bluetooth duplex and directional SRC
+
+**Date:** 2026-08-11
+**Status:** Deterministic and package qualification complete; physical CLbuds acceptance remains blocked.
+
+### Delivered
+
+- CoreAudio now plans physical endpoint rates independently, applies only safe
+  device-global writes, and performs bounded directional conversion at the I/O boundary.
+- Route state reports physical/AUHAL client rates, virtual and callback widths,
+  conversion latency, Bluetooth relationship, mono fallback, and callback health.
+- Converted callback chunks use one session-frame base and advance the timeline only after
+  the full callback, so multi-chunk delivery is contiguous.
+
+### Evidence and boundary
+
+- `polyphase_resampler_test`, `coreaudio_route_probe_test`, and `coreaudio_driver_test`
+  passed after the callback-timeline review correction; `realtime_static_audit` and its
+  unit contract also passed.
+- The repository's complete configured debug suite (80/80) and three release/package
+  contracts passed before review. No CLbuds endpoint is present locally, so no Bluetooth
+  hardware acceptance, release tag, or downstream production pin is claimed.
+- Full record: [`ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion`](docs/orp/ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md).
+
 ## ORP174 — Cooperative CoreAudio rate negotiation
 
 **Date:** 2026-08-08

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Orpheus is a host-neutral C++20 SDK that provides deterministic session/transport control, sample-accurate clip playback, and real-time audio infrastructure. Built for 24/7 broadcast reliability with zero-allocation audio threads and lock-free command processing.
 
-**Current version:** 0.7.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
+**Current version:** 0.8.0 (pre-1.0 SDK; stable C ABI 1.0). The authoritative
 value is `project(orpheus VERSION ...)` in [`CMakeLists.txt`](CMakeLists.txt);
 `tools/version_contract.py` synchronizes public claims and CI rejects drift.
 

--- a/docs/orp/INDEX.md
+++ b/docs/orp/INDEX.md
@@ -8,6 +8,10 @@ Project documentation index for orpheus-sdk.
 
 
 ## Current Records
+- [[ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion]] —
+  directional Bluetooth conversion, settled-route telemetry, and qualification
+  record; physical CLbuds acceptance remains blocked (2026-08-11)
+
 - [[ORP175 ShmUI Operational State Contract Handoff]] — governed v0.6.0
   generated-contract mirror and downstream pin decisions (2026-08-10)
 
@@ -33,6 +37,7 @@ Project documentation index for orpheus-sdk.
 - [ORP128 CoreAudio Runtime Sample-Rate Resilience](ORP128%20CoreAudio%20Runtime%20Sample-Rate%20Resilience.md)
 - [ORP162 CoreAudio Capture Channel Mapping and Downstream Pin Handoff](ORP162%20CoreAudio%20Capture%20Channel%20Mapping%20and%20Downstream%20Pin%20Handoff.md)
 - [ORP175 ShmUI Operational State Contract Handoff](ORP175%20ShmUI%20Operational%20State%20Contract%20Handoff.md)
+- [ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion](ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md)
 - [ORP174 Cooperative CoreAudio Rate Negotiation Handoff](ORP174%20Cooperative%20CoreAudio%20Rate%20Negotiation%20Handoff.md)
 - [ORP173 Orpheus Suite v0.1.0 Qualification and Release Gate Record](ORP173%20Orpheus%20Suite%20v0.1.0%20Qualification%20and%20Release%20Gate%20Record.md)
 - [ORP172 Non-Mutating CoreAudio Route Compatibility Handoff](ORP172%20Non-Mutating%20CoreAudio%20Route%20Compatibility%20Handoff.md)
@@ -52,4 +57,4 @@ Project documentation index for orpheus-sdk.
 
 ---
 
-**Last Generated:** 2026-08-10
+**Last Generated:** 2026-08-11

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -1,0 +1,124 @@
+<!-- SPDX-License-Identifier: MIT -->
+
+# ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion
+
+**Document type:** SDK implementation and qualification record  
+**Status:** Source and deterministic/package qualification complete; physical Bluetooth acceptance blocked  
+**Date:** 2026-08-11  
+**Consumer:** FourTrack / EightTrack, FTR085  
+**Implementation baseline:** `main` worktree at the FTR085 implementation checkpoint  
+**SDK version:** 0.8.0
+
+## Decision
+
+Orpheus SDK 0.8.0 implements the CoreAudio side of FTR085. It preserves a host-selected
+44.1/48 kHz session clock while a CoreAudio input endpoint may run at its own physical
+rate, including a 16 kHz Bluetooth microphone. Conversion occurs only at the SDK I/O
+boundary. The host receives settled physical/client rate and width facts, converter
+latencies, and callback-health counters; it does not probe, resample, or infer a route.
+
+The scope is deliberately bounded. Existing same-rate routes retain their prior behavior.
+The only width exception is same-headset Bluetooth duplex where an explicitly requested
+logical stereo output cannot be physically prepared: strict policy rejects the route;
+`AllowMonoFallback` accepts a single physical output channel and exposes callback width
+one. FourTrack retains its stereo program path and folds the final monitor to
+`0.5f * (L + R)`.
+
+## Implemented public contract
+
+`include/orpheus/audio_driver.h` extends append-only route contracts:
+
+- `AudioSampleRatePolicy::RequestExactRateOrConvert` requests the session client rate
+  while allowing direction-specific conversion when a supported physical rate differs.
+- `AudioOutputChannelPolicy::AllowMonoFallback` authorizes only the documented
+  same-headset physical-width fallback.
+- `AudioRouteCompatibility` reports conversion requirements, planned client rates,
+  settled route width, Bluetooth/endpoint relation, and the rate-plan decision.
+- `ActiveAudioRoute`, `AudioRouteLatency`, and `AudioIoTelemetry` report physical and
+  client rates, virtual/client widths, converter activity/latency, mono fallback, and
+  saturating conversion/FIFO/capture failure counters.
+- `IAudioDriver::getAudioIoRouteState()` is the authoritative detailed route/latency
+  snapshot. Existing telemetry fields retain their order and semantics.
+
+The 0.8.0 bump follows the existing single-source `project(orpheus VERSION ...)` contract;
+C ABI remains 1.0 because the C-facing ABI contract is unchanged.
+
+## CoreAudio activation model
+
+1. Endpoint discovery resolves persistent DeviceUIDs independently and validates input
+   and output direction before activation. Empty IDs select only that direction's default.
+2. Resolver facts include transport, physical nominal rate/ranges, channel-map capacity,
+   related-device identity, and a deduplicated per-device global-rate plan.
+3. Cooperative sample-rate transactions write only plan entries requiring a write, wait
+   for listener-confirmed settlement, and roll back only a write owned by that transaction.
+   Related Bluetooth endpoints retain their observed native rate instead of receiving an
+   unsafe device-global write.
+4. CoreAudio configures independent input/output AUHAL paths. The bounded
+   `DirectionalSampleRateConverter` transfers capture from physical to session rate and
+   render from session to physical rate without allocation, locks, or I/O in the callback.
+5. The route monitor treats property changes as terminal, publishes one structured outcome,
+   closes callback admission, and prevents stale route facts or repeated writes.
+
+## Deterministic evidence
+
+Source and deterministic evidence recorded in this session:
+
+| Gate | Result |
+|---|---|
+| Directional SRC: canonical supported rate pairs, tone/frequency preservation, exact frame accounting, limits, reset, bounded FIFO and callback-path safety | Passed in `polyphase_resampler_test` |
+| Resolver: output-only isolation, distinct endpoints, 16 kHz Bluetooth input conversion, strict mono conflict/fallback, related Bluetooth protection, rate-plan decisions | Passed in `coreaudio_route_probe_test` |
+| Driver: dual-AUHAL flow, active physical/client facts, converter latency and counters, terminal monitor outcomes, rollback/lifecycle behavior | Passed in `coreaudio_driver_test` |
+| Static callback audit | `realtime_static_audit` and `realtime_static_audit_unit` passed |
+| Complete configured SDK tree | 80/80 CTest contracts passed in `build-sdk-debug` |
+| Installed package and public version contract | `version_contract`, `cmake_find_package`, and `cmake_package_runtime_consumer` passed against 0.8.0 |
+
+The physical hardware baseline captured before implementation found no CLbuds endpoint.
+A deterministic output-only CoreAudio acceptance run against `BuiltInSpeakerDevice` at
+48 kHz passed; its JSON reported two settled physical output channels, matching active
+map `{0,1}`, no input route, no conversion, and zero callback health failures. A
+negative expected-tone invocation failed as intended when no input callback existed.
+
+## FourTrack adoption boundary
+
+FourTrack must request `RequestExactRateOrConvert` for the fixed session clock and use
+`AllowMonoFallback` only for its existing Bluetooth same-headset policy. It must use the
+SDK's active output map and callback width verbatim; no Swift-side duplicated mono
+channel or UI/control-path SRC is permitted. Take placement remains latched at record
+start using:
+
+```text
+round_trip_frames = capture_frames + playback_frames + processing_frames
+```
+
+`processing_frames` includes active input/output converter latency from the settled SDK
+route state. Output-only sessions must leave input selection empty: no input capability
+query, listener, device write, capture failure, or permission request is allowed.
+
+## Remaining physical gate
+
+Physical Bluetooth acceptance is not claimed. The 2026-08-11 machine inventory had no
+CLbuds endpoint, so the required Bluetooth-input-plus-speakers, same-headset stereo,
+same-headset mono strict/fallback, and unrelated Bluetooth endpoint measurements remain
+unexecuted. Do not tag a release, mark FTR085 complete, or advance FourTrack's production
+SDK pin until a CLbuds run records the settled endpoint UIDs, physical/client rates,
+physical callback width, converter latency, counters, and tone/frame evidence.
+
+## References
+
+[1] FourTrack, “FTR085 CoreAudio Bluetooth Duplex and Directional SRC SDK Handoff,”
+Aug. 11, 2026, §§ Acceptance matrix and Handoff deliverables.
+
+[2] Apple Inc., “Device input using the HAL Output Audio Unit,” *Technical Note
+TN2091*, Jan. 21, 2014. [Online]. Available:
+https://developer.apple.com/library/archive/technotes/tn2091/_index.html.
+[Accessed: Aug. 11, 2026].
+
+[3] Apple Inc., “kAudioDevicePropertyNominalSampleRate,” *Core Audio
+Documentation*. [Online]. Available:
+https://developer.apple.com/documentation/coreaudio/kaudiodevicepropertynominalsamplerate.
+[Accessed: Aug. 11, 2026].
+
+[4] Apple Inc., “kAudioDevicePropertyLatency,” *Core Audio Documentation*.
+[Online]. Available:
+https://developer.apple.com/documentation/coreaudio/kaudiodevicepropertylatency.
+[Accessed: Aug. 11, 2026].

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -56,6 +56,8 @@ C ABI remains 1.0 because the C-facing ABI contract is unchanged.
 4. CoreAudio configures independent input/output AUHAL paths. The bounded
    `DirectionalSampleRateConverter` transfers capture from physical to session rate and
    render from session to physical rate without allocation, locks, or I/O in the callback.
+   Converted callbacks derive every chunk position from one session-frame base and advance
+   the timeline only after the full callback, preserving contiguous sample positions.
 5. The route monitor treats property changes as terminal, publishes one structured outcome,
    closes callback admission, and prevents stale route facts or repeated writes.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -387,5 +387,5 @@ All examples built in < 15 seconds on modern hardware (M1 Pro, SSD).
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.7.0
+**SDK Version:** 0.8.0
 **Maintained By:** SDK Core Team

--- a/examples/multi_clip_trigger/README.md
+++ b/examples/multi_clip_trigger/README.md
@@ -261,4 +261,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.7.0
+**SDK Version:** 0.8.0

--- a/examples/offline_renderer/README.md
+++ b/examples/offline_renderer/README.md
@@ -355,4 +355,4 @@ The example follows this pattern:
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.7.0
+**SDK Version:** 0.8.0

--- a/examples/simple_player/README.md
+++ b/examples/simple_player/README.md
@@ -174,4 +174,4 @@ See `multi_clip_trigger` example for multi-clip playback and `offline_renderer` 
 ---
 
 **Last Updated:** October 26, 2025
-**SDK Version:** 0.7.0
+**SDK Version:** 0.8.0

--- a/include/orpheus/audio_driver.h
+++ b/include/orpheus/audio_driver.h
@@ -22,19 +22,26 @@ struct AudioRouteChannelMap {
   std::vector<uint16_t> output_channels;
 };
 enum class AudioSampleRatePolicy : uint8_t {
-  PreserveDeviceRate,
-  RequestExactRate,
+  PreserveDeviceRate = 0,
+  RequestExactRate = 1,
+  RequestExactRateOrConvert = 2,
+};
+
+enum class AudioOutputChannelPolicy : uint8_t {
+  RequireRequestedChannels = 0,
+  AllowMonoFallback = 1,
 };
 
 enum class AudioRouteCompatibilityStatus : uint8_t {
-  Compatible,
-  RequiresSampleRateChange,
-  InputUnavailable,
-  OutputUnavailable,
-  SampleRateUnsupported,
-  InvalidChannelMap,
-  PermissionDenied,
-  BackendFailure,
+  Compatible = 0,
+  RequiresSampleRateChange = 1,
+  InputUnavailable = 2,
+  OutputUnavailable = 3,
+  SampleRateUnsupported = 4,
+  InvalidChannelMap = 5,
+  PermissionDenied = 6,
+  BackendFailure = 7,
+  ProfileConflict = 8,
 };
 
 struct AudioRouteCompatibility {
@@ -48,6 +55,19 @@ struct AudioRouteCompatibility {
   bool output_rate_change_required = false;
   bool input_is_running_somewhere = false;
   bool output_is_running_somewhere = false;
+  uint32_t planned_input_client_rate = 0;
+  uint32_t planned_output_client_rate = 0;
+  uint16_t requested_output_channels = 0;
+  uint16_t resolved_output_channels = 0;
+  uint16_t input_virtual_format_channels = 0;
+  uint16_t output_virtual_format_channels = 0;
+  bool input_conversion_required = false;
+  bool output_conversion_required = false;
+  bool input_is_bluetooth = false;
+  bool output_is_bluetooth = false;
+  bool endpoints_related = false;
+  bool requires_post_bind_reprobe = false;
+  bool output_mono_fallback_planned = false;
   std::string detail;
 };
 
@@ -69,6 +89,8 @@ struct AudioDriverConfig {
   /// An empty vector selects consecutive physical channels starting at zero.
   AudioRouteChannelMap channel_map{};
   AudioSampleRatePolicy sample_rate_policy = AudioSampleRatePolicy::PreserveDeviceRate;
+  AudioOutputChannelPolicy output_channel_policy =
+      AudioOutputChannelPolicy::RequireRequestedChannels;
 };
 
 /// Decomposed route latency reported by the backend.
@@ -84,17 +106,20 @@ struct AudioRouteLatency {
 
 /// Runtime outcome that can invalidate active audio I/O.
 enum class AudioRouteRuntimeOutcome : uint8_t {
-  Healthy,
-  SampleRateUnsupported,
-  SampleRateChangeFailed,
-  SampleRateChanged,
-  BufferSizeChanged,
-  FormatChanged,
-  ChannelMapInvalid,
-  InputRouteUnavailable,
-  OutputRouteUnavailable,
-  PermissionDenied,
-  BackendFailure,
+  Healthy = 0,
+  SampleRateUnsupported = 1,
+  SampleRateChangeFailed = 2,
+  SampleRateChanged = 3,
+  BufferSizeChanged = 4,
+  FormatChanged = 5,
+  ChannelMapInvalid = 6,
+  InputRouteUnavailable = 7,
+  OutputRouteUnavailable = 8,
+  PermissionDenied = 9,
+  BackendFailure = 10,
+  ProfileConflict = 11,
+  InputConversionFailed = 12,
+  OutputConversionFailed = 13,
 };
 
 /// Control-thread snapshot of the physical route negotiated by a backend.
@@ -115,6 +140,22 @@ struct ActiveAudioRoute {
   AudioRouteLatency latency;
   bool input_alive = false;
   bool output_alive = false;
+  uint32_t input_physical_sample_rate = 0;
+  uint32_t output_physical_sample_rate = 0;
+  uint32_t input_client_sample_rate = 0;
+  uint32_t output_client_sample_rate = 0;
+  uint16_t requested_output_channels = 0;
+  uint16_t resolved_output_channels = 0;
+  uint16_t input_virtual_format_channels = 0;
+  uint16_t output_virtual_format_channels = 0;
+  uint16_t input_client_format_channels = 0;
+  uint16_t output_client_format_channels = 0;
+  bool input_conversion_active = false;
+  bool output_conversion_active = false;
+  bool input_is_bluetooth = false;
+  bool output_is_bluetooth = false;
+  bool endpoints_related = false;
+  bool output_mono_fallback = false;
 };
 
 /// Playback route lifecycle as observed by a backend.
@@ -147,6 +188,8 @@ struct AudioLatencyBreakdown {
   std::optional<uint32_t> output_converter_frames;
   std::optional<uint32_t> callback_buffer_frames;
   std::optional<uint32_t> aggregate_or_audio_unit_frames;
+  std::optional<uint32_t> input_audio_unit_frames;
+  std::optional<uint32_t> output_audio_unit_frames;
   bool complete = false;
 };
 
@@ -177,6 +220,22 @@ struct AudioIoRouteState {
   uint32_t actual_buffer_size = 0;
   AudioLatencyBreakdown latency;
   std::string detail;
+  uint32_t input_physical_sample_rate = 0;
+  uint32_t output_physical_sample_rate = 0;
+  uint32_t input_client_sample_rate = 0;
+  uint32_t output_client_sample_rate = 0;
+  uint16_t requested_output_channels = 0;
+  uint16_t resolved_output_channels = 0;
+  uint16_t input_virtual_format_channels = 0;
+  uint16_t output_virtual_format_channels = 0;
+  uint16_t input_client_format_channels = 0;
+  uint16_t output_client_format_channels = 0;
+  bool input_conversion_active = false;
+  bool output_conversion_active = false;
+  bool input_is_bluetooth = false;
+  bool output_is_bluetooth = false;
+  bool endpoints_related = false;
+  bool output_mono_fallback = false;
 };
 /// Outcome of a backend runtime condition that can invalidate active audio I/O.
 /// A terminal outcome means the driver has stopped rendering and requires an
@@ -186,6 +245,10 @@ struct AudioIoRouteState {
 struct AudioIoTelemetry {
   uint64_t input_render_failures = 0; ///< Cumulative failed capture renders
   AudioRouteRuntimeOutcome route_outcome = AudioRouteRuntimeOutcome::Healthy;
+  uint64_t input_fifo_overruns = 0;
+  uint64_t input_fifo_underruns = 0;
+  uint64_t input_conversion_failures = 0;
+  uint64_t output_conversion_failures = 0;
 };
 
 /// Audio backend family.

--- a/include/orpheus/directional_sample_rate_converter.h
+++ b/include/orpheus/directional_sample_rate_converter.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <orpheus/errors.h>
+#include <orpheus/export.h>
+
+#include <cstdint>
+#include <memory>
+
+namespace orpheus::audio_utils {
+
+/// Failure and transfer status for the bounded directional realtime converter.
+enum class DirectionalSrcStatus : uint8_t {
+  Ok = 0,
+  NotPrepared = 1,
+  InvalidArgument = 2,
+  InputOverflow = 3,
+  InputUnderflow = 4,
+};
+
+/// Fixed-resource configuration for one directional sample-rate boundary.
+struct DirectionalSrcConfig {
+  uint32_t input_rate = 0;
+  uint32_t output_rate = 0;
+  uint16_t channels = 0;
+  uint32_t max_input_frames = 0;
+  uint32_t max_output_frames = 0;
+  uint32_t fifo_capacity_frames = 0;
+  uint32_t prime_input_frames = 0;
+  bool allow_input_rate_correction = false;
+};
+
+/// Result of one producer or consumer transfer.
+struct DirectionalSrcTransfer {
+  DirectionalSrcStatus status = DirectionalSrcStatus::NotPrepared;
+  uint32_t input_frames_consumed = 0;
+  uint32_t output_frames_produced = 0;
+};
+
+/// Bounded, planar, directional sample-rate conversion for continuous devices.
+///
+/// prepare() owns all allocation and coefficient generation. After preparation,
+/// one producer may call pushInput() while one consumer calls
+/// requiredInputFrames() and renderOutput(); those callback-facing operations
+/// perform no allocation, locking, waiting, or I/O.
+class ORPHEUS_API DirectionalSampleRateConverter final {
+public:
+  DirectionalSampleRateConverter() noexcept;
+  ~DirectionalSampleRateConverter();
+  DirectionalSampleRateConverter(const DirectionalSampleRateConverter&) = delete;
+  DirectionalSampleRateConverter& operator=(const DirectionalSampleRateConverter&) = delete;
+  DirectionalSampleRateConverter(DirectionalSampleRateConverter&&) noexcept;
+  DirectionalSampleRateConverter& operator=(DirectionalSampleRateConverter&&) noexcept;
+
+  SessionGraphError prepare(const DirectionalSrcConfig&) noexcept;
+  DirectionalSrcStatus requiredInputFrames(uint32_t output_frames,
+                                           uint32_t& input_frames) const noexcept;
+  DirectionalSrcTransfer pushInput(const float* const* input, uint16_t channels,
+                                   uint32_t frames) noexcept;
+  DirectionalSrcTransfer renderOutput(float* const* output, uint16_t channels,
+                                      uint32_t frames) noexcept;
+  bool setInputRateCorrectionPpm(int32_t ppm) noexcept;
+  bool isPrimed() const noexcept;
+  uint32_t bufferedInputFrames() const noexcept;
+  uint32_t latencyOutputFrames() const noexcept;
+  void reset() noexcept;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace orpheus::audio_utils

--- a/src/core/audio_io/CMakeLists.txt
+++ b/src/core/audio_io/CMakeLists.txt
@@ -54,6 +54,7 @@ set(ORPHEUS_AUDIO_UTILS_SOURCES)
 
 # ORP127 G6: host-neutral, dependency-free sample-rate conversion. Always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES polyphase_resampler.cpp)
+list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES directional_sample_rate_converter.cpp)
 
 # FTR041: host-neutral, real-time-safe one-shot voice pool. Always built.
 list(APPEND ORPHEUS_AUDIO_UTILS_SOURCES trigger_voice.cpp)

--- a/src/core/audio_io/directional_sample_rate_converter.cpp
+++ b/src/core/audio_io/directional_sample_rate_converter.cpp
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: MIT
+#include <orpheus/directional_sample_rate_converter.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace orpheus::audio_utils {
+namespace {
+
+constexpr uint32_t kTaps = 255;
+constexpr uint32_t kPhaseIntervals = 1024;
+constexpr uint32_t kHistoryFrames = (kTaps - 1) / 2;
+constexpr uint64_t kPpmScale = 1'000'000;
+constexpr int32_t kMaximumCorrectionPpm = 1'000;
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+bool isCanonicalRate(uint32_t rate) noexcept {
+  return rate == 16'000 || rate == 24'000 || rate == 44'100 || rate == 48'000;
+}
+
+bool isSessionRate(uint32_t rate) noexcept {
+  return rate == 44'100 || rate == 48'000;
+}
+
+bool isPowerOfTwo(uint32_t value) noexcept {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+uint64_t ceilDivide(uint64_t numerator, uint64_t denominator) noexcept {
+  const uint64_t quotient = numerator / denominator;
+  return quotient + (numerator % denominator != 0 ? 1 : 0);
+}
+
+bool checkedMultiply(uint64_t lhs, uint64_t rhs, uint64_t& result) noexcept {
+  if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+    return false;
+  }
+  result = lhs * rhs;
+  return true;
+}
+
+bool checkedAdd(uint64_t lhs, uint64_t rhs, uint64_t& result) noexcept {
+  if (rhs > std::numeric_limits<uint64_t>::max() - lhs) {
+    return false;
+  }
+  result = lhs + rhs;
+  return true;
+}
+
+bool checkedPhaseAdvance(uint64_t phase_remainder, uint64_t phase_increment, uint32_t output_frames,
+                         uint64_t denominator, uint64_t& input_frames) noexcept {
+  uint64_t product = 0;
+  uint64_t phase = 0;
+  if (!checkedMultiply(phase_increment, output_frames, product) ||
+      !checkedAdd(phase_remainder, product, phase)) {
+    return false;
+  }
+  input_frames = ceilDivide(phase, denominator);
+  return true;
+}
+
+bool checkedRequiredInput(uint64_t phase_remainder, uint64_t phase_increment,
+                          uint32_t output_frames, uint64_t denominator,
+                          uint64_t& required_frames) noexcept {
+  uint64_t input_advance = 0;
+  if (!checkedPhaseAdvance(phase_remainder, phase_increment, output_frames, denominator,
+                           input_advance) ||
+      !checkedAdd(input_advance, kHistoryFrames, required_frames)) {
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+struct DirectionalSampleRateConverter::Impl {
+  explicit Impl(const DirectionalSrcConfig& source_config)
+      : config(source_config),
+        denominator(static_cast<uint64_t>(source_config.output_rate) * kPpmScale),
+        nominal_phase_increment(static_cast<uint64_t>(source_config.input_rate) * kPpmScale),
+        phase_increment(nominal_phase_increment),
+        phase_kernels(static_cast<size_t>(kPhaseIntervals + 1) * kTaps),
+        fifo(static_cast<size_t>(source_config.fifo_capacity_frames) * source_config.channels),
+        history(static_cast<size_t>(kHistoryFrames) * source_config.channels) {
+    buildKernels();
+  }
+
+  void buildKernels() {
+    const double rate_ratio =
+        static_cast<double>(config.output_rate) / static_cast<double>(config.input_rate);
+    const double cutoff = 0.45 * std::min(1.0, rate_ratio);
+
+    for (uint32_t phase = 0; phase <= kPhaseIntervals; ++phase) {
+      const double fraction = static_cast<double>(phase) / static_cast<double>(kPhaseIntervals);
+      double sum = 0.0;
+      const size_t base = static_cast<size_t>(phase) * kTaps;
+      for (uint32_t tap = 0; tap < kTaps; ++tap) {
+        const double x = static_cast<double>(tap) - static_cast<double>(kHistoryFrames) - fraction;
+        const double sinc_argument = 2.0 * cutoff * x;
+        const double sinc =
+            sinc_argument == 0.0 ? 1.0 : std::sin(kPi * sinc_argument) / (kPi * sinc_argument);
+        const double window = 0.42 - 0.5 * std::cos(2.0 * kPi * static_cast<double>(tap) / 254.0) +
+                              0.08 * std::cos(4.0 * kPi * static_cast<double>(tap) / 254.0);
+        const double coefficient = 2.0 * cutoff * sinc * window;
+        phase_kernels[base + tap] = coefficient;
+        sum += coefficient;
+      }
+      if (sum != 0.0 && std::isfinite(sum)) {
+        for (uint32_t tap = 0; tap < kTaps; ++tap) {
+          phase_kernels[base + tap] /= sum;
+        }
+      }
+    }
+  }
+
+  uint64_t correctedPhaseIncrement(int32_t ppm) const noexcept {
+    const int64_t scaled = static_cast<int64_t>(kPpmScale) + ppm;
+    return static_cast<uint64_t>(static_cast<uint64_t>(config.input_rate) *
+                                 static_cast<uint64_t>(scaled));
+  }
+
+  uint32_t bufferedFrames() const noexcept {
+    const uint64_t write = write_index.load(std::memory_order_acquire);
+    const uint64_t read = read_index.load(std::memory_order_acquire);
+    const uint64_t available = write - read;
+    return static_cast<uint32_t>(std::min<uint64_t>(available, config.fifo_capacity_frames));
+  }
+
+  float fifoSample(uint64_t read, uint32_t offset, uint16_t channel) const noexcept {
+    const uint32_t frame = static_cast<uint32_t>(read + offset) & (config.fifo_capacity_frames - 1);
+    return fifo[static_cast<size_t>(frame) * config.channels + channel];
+  }
+
+  float historySample(int32_t offset, uint16_t channel) const noexcept {
+    const uint32_t distance = static_cast<uint32_t>(-offset);
+    const uint32_t frame = (history_head + kHistoryFrames - distance) % kHistoryFrames;
+    return history[static_cast<size_t>(frame) * config.channels + channel];
+  }
+
+  float sampleAt(uint64_t read, int32_t offset, uint16_t channel) const noexcept {
+    if (offset < 0) {
+      return historySample(offset, channel);
+    }
+    return fifoSample(read, static_cast<uint32_t>(offset), channel);
+  }
+
+  void rememberConsumedFrame(uint64_t read) noexcept {
+    const uint32_t source_frame = static_cast<uint32_t>(read) & (config.fifo_capacity_frames - 1);
+    const size_t source_base = static_cast<size_t>(source_frame) * config.channels;
+    const size_t history_base = static_cast<size_t>(history_head) * config.channels;
+    for (uint16_t channel = 0; channel < config.channels; ++channel) {
+      history[history_base + channel] = fifo[source_base + channel];
+    }
+    history_head = (history_head + 1) % kHistoryFrames;
+  }
+
+  DirectionalSrcConfig config;
+  uint64_t denominator = 0;
+  uint64_t nominal_phase_increment = 0;
+  uint64_t phase_increment = 0;
+  int32_t correction_ppm = 0;
+  uint64_t phase_remainder = 0;
+  uint64_t output_frames_produced = 0;
+  uint32_t history_head = 0;
+  std::vector<double> phase_kernels;
+  std::vector<float> fifo;
+  std::vector<float> history;
+  std::atomic<uint64_t> write_index{0};
+  std::atomic<uint64_t> read_index{0};
+  std::atomic<bool> primed{false};
+};
+
+DirectionalSampleRateConverter::DirectionalSampleRateConverter() noexcept = default;
+
+DirectionalSampleRateConverter::~DirectionalSampleRateConverter() = default;
+
+DirectionalSampleRateConverter::DirectionalSampleRateConverter(
+    DirectionalSampleRateConverter&& other) noexcept = default;
+
+DirectionalSampleRateConverter& DirectionalSampleRateConverter::operator=(
+    DirectionalSampleRateConverter&& other) noexcept = default;
+
+SessionGraphError
+DirectionalSampleRateConverter::prepare(const DirectionalSrcConfig& config) noexcept {
+  if (!isCanonicalRate(config.input_rate) || !isCanonicalRate(config.output_rate) ||
+      (!isSessionRate(config.input_rate) && !isSessionRate(config.output_rate))) {
+    return SessionGraphError::NotSupported;
+  }
+  if (config.channels < 1 || config.channels > 2 || config.max_input_frames < 1 ||
+      config.max_input_frames > 4096 || config.max_output_frames < 1 ||
+      config.max_output_frames > 4096 || config.fifo_capacity_frames < 1024 ||
+      config.fifo_capacity_frames > 32768 || !isPowerOfTwo(config.fifo_capacity_frames)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  const uint64_t denominator = static_cast<uint64_t>(config.output_rate) * kPpmScale;
+  const uint64_t correction_scale = kPpmScale + kMaximumCorrectionPpm;
+  const uint64_t worst_phase_increment =
+      static_cast<uint64_t>(config.input_rate) * correction_scale;
+  uint64_t worst_required = 0;
+  if (!checkedRequiredInput(denominator - 1, worst_phase_increment, config.max_output_frames,
+                            denominator, worst_required)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  if (!checkedAdd(worst_required, kTaps, worst_required)) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  uint64_t callback_storage = 0;
+  if (!checkedMultiply(config.max_input_frames, 8, callback_storage)) {
+    return SessionGraphError::InvalidParameter;
+  }
+  if (config.fifo_capacity_frames < callback_storage ||
+      config.fifo_capacity_frames < worst_required ||
+      config.prime_input_frames > config.fifo_capacity_frames / 2) {
+    return SessionGraphError::InvalidParameter;
+  }
+  uint64_t prime_with_history = 0;
+  if (!checkedAdd(config.prime_input_frames, kHistoryFrames + 1, prime_with_history) ||
+      prime_with_history > config.fifo_capacity_frames) {
+    return SessionGraphError::InvalidParameter;
+  }
+
+  try {
+    auto replacement = std::make_unique<Impl>(config);
+    impl_ = std::move(replacement);
+  } catch (const std::bad_alloc&) {
+    return SessionGraphError::InternalError;
+  }
+  return SessionGraphError::OK;
+}
+
+DirectionalSrcStatus
+DirectionalSampleRateConverter::requiredInputFrames(uint32_t output_frames,
+                                                    uint32_t& input_frames) const noexcept {
+  input_frames = 0;
+  if (!impl_) {
+    return DirectionalSrcStatus::NotPrepared;
+  }
+  if (output_frames > impl_->config.max_output_frames) {
+    return DirectionalSrcStatus::InvalidArgument;
+  }
+  if (output_frames == 0) {
+    return DirectionalSrcStatus::Ok;
+  }
+
+  uint64_t required = 0;
+  if (!checkedRequiredInput(impl_->phase_remainder, impl_->phase_increment, output_frames,
+                            impl_->denominator, required)) {
+    return DirectionalSrcStatus::InvalidArgument;
+  }
+  const uint64_t buffered = impl_->bufferedFrames();
+  if (required <= buffered) {
+    return DirectionalSrcStatus::Ok;
+  }
+  const uint64_t additional = required - buffered;
+  if (additional > std::numeric_limits<uint32_t>::max()) {
+    return DirectionalSrcStatus::InvalidArgument;
+  }
+  input_frames = static_cast<uint32_t>(additional);
+  return DirectionalSrcStatus::Ok;
+}
+
+DirectionalSrcTransfer DirectionalSampleRateConverter::pushInput(const float* const* input,
+                                                                 uint16_t channels,
+                                                                 uint32_t frames) noexcept {
+  DirectionalSrcTransfer result;
+  if (!impl_) {
+    return result;
+  }
+  if (frames == 0) {
+    result.status = DirectionalSrcStatus::Ok;
+    return result;
+  }
+  if (input == nullptr || channels != impl_->config.channels ||
+      frames > impl_->config.max_input_frames) {
+    result.status = DirectionalSrcStatus::InvalidArgument;
+    return result;
+  }
+  for (uint16_t channel = 0; channel < channels; ++channel) {
+    if (input[channel] == nullptr) {
+      result.status = DirectionalSrcStatus::InvalidArgument;
+      return result;
+    }
+  }
+
+  const uint64_t read = impl_->read_index.load(std::memory_order_acquire);
+  const uint64_t write = impl_->write_index.load(std::memory_order_relaxed);
+  const uint64_t buffered = write - read;
+  if (buffered > impl_->config.fifo_capacity_frames ||
+      frames > impl_->config.fifo_capacity_frames - buffered) {
+    result.status = DirectionalSrcStatus::InputOverflow;
+    return result;
+  }
+
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    const uint32_t destination_frame =
+        static_cast<uint32_t>(write + frame) & (impl_->config.fifo_capacity_frames - 1);
+    const size_t destination_base = static_cast<size_t>(destination_frame) * impl_->config.channels;
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      impl_->fifo[destination_base + channel] = input[channel][frame];
+    }
+  }
+  impl_->write_index.store(write + frames, std::memory_order_release);
+  if (write + frames - read >=
+      static_cast<uint64_t>(kHistoryFrames + 1 + impl_->config.prime_input_frames)) {
+    impl_->primed.store(true, std::memory_order_release);
+  }
+  result.status = DirectionalSrcStatus::Ok;
+  result.input_frames_consumed = frames;
+  return result;
+}
+
+DirectionalSrcTransfer DirectionalSampleRateConverter::renderOutput(float* const* output,
+                                                                    uint16_t channels,
+                                                                    uint32_t frames) noexcept {
+  DirectionalSrcTransfer result;
+  if (!impl_) {
+    return result;
+  }
+  if (frames > impl_->config.max_output_frames || output == nullptr ||
+      channels != impl_->config.channels) {
+    result.status = DirectionalSrcStatus::InvalidArgument;
+    return result;
+  }
+  if (frames == 0) {
+    result.status = DirectionalSrcStatus::Ok;
+    return result;
+  }
+  if (!impl_->primed.load(std::memory_order_acquire)) {
+    result.status = DirectionalSrcStatus::InputUnderflow;
+    return result;
+  }
+
+  uint64_t required = 0;
+  if (!checkedRequiredInput(impl_->phase_remainder, impl_->phase_increment, frames,
+                            impl_->denominator, required)) {
+    result.status = DirectionalSrcStatus::InvalidArgument;
+    return result;
+  }
+  const uint64_t read = impl_->read_index.load(std::memory_order_relaxed);
+  const uint64_t write = impl_->write_index.load(std::memory_order_acquire);
+  const uint64_t buffered = write - read;
+  if (buffered < required) {
+    result.status = DirectionalSrcStatus::InputUnderflow;
+    return result;
+  }
+
+  uint64_t cursor = read;
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    const uint64_t scaled_phase = impl_->phase_remainder * kPhaseIntervals;
+    const uint32_t phase_index = static_cast<uint32_t>(scaled_phase / impl_->denominator);
+    const double phase_fraction = static_cast<double>(scaled_phase % impl_->denominator) /
+                                  static_cast<double>(impl_->denominator);
+    const size_t kernel_base = static_cast<size_t>(phase_index) * kTaps;
+    const size_t next_kernel_base = static_cast<size_t>(phase_index + 1) * kTaps;
+
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      double sum = 0.0;
+      for (uint32_t tap = 0; tap < kTaps; ++tap) {
+        const int32_t offset = static_cast<int32_t>(tap) - static_cast<int32_t>(kHistoryFrames);
+        const float sample = impl_->sampleAt(cursor, offset, channel);
+        const double coefficient = impl_->phase_kernels[kernel_base + tap] +
+                                   (impl_->phase_kernels[next_kernel_base + tap] -
+                                    impl_->phase_kernels[kernel_base + tap]) *
+                                       phase_fraction;
+        sum += coefficient * static_cast<double>(sample);
+      }
+      output[channel][frame] = static_cast<float>(sum);
+    }
+
+    const uint64_t phase_total = impl_->phase_remainder + impl_->phase_increment;
+    const uint64_t consumed = phase_total / impl_->denominator;
+    impl_->phase_remainder = phase_total % impl_->denominator;
+    for (uint64_t input_frame = 0; input_frame < consumed; ++input_frame) {
+      impl_->rememberConsumedFrame(cursor);
+      ++cursor;
+    }
+  }
+
+  impl_->read_index.store(cursor, std::memory_order_release);
+  impl_->output_frames_produced += frames;
+  result.status = DirectionalSrcStatus::Ok;
+  result.input_frames_consumed = static_cast<uint32_t>(cursor - read);
+  result.output_frames_produced = frames;
+  return result;
+}
+
+bool DirectionalSampleRateConverter::setInputRateCorrectionPpm(int32_t ppm) noexcept {
+  if (!impl_ || !impl_->config.allow_input_rate_correction || ppm < -kMaximumCorrectionPpm ||
+      ppm > kMaximumCorrectionPpm) {
+    return false;
+  }
+  impl_->correction_ppm = ppm;
+  impl_->phase_increment = impl_->correctedPhaseIncrement(ppm);
+  return true;
+}
+
+bool DirectionalSampleRateConverter::isPrimed() const noexcept {
+  return impl_ != nullptr && impl_->primed.load(std::memory_order_acquire);
+}
+uint32_t DirectionalSampleRateConverter::bufferedInputFrames() const noexcept {
+  return impl_ ? impl_->bufferedFrames() : 0;
+}
+
+uint32_t DirectionalSampleRateConverter::latencyOutputFrames() const noexcept {
+  if (!impl_) {
+    return 0;
+  }
+  const uint64_t numerator =
+      static_cast<uint64_t>(kHistoryFrames + impl_->config.prime_input_frames) *
+      impl_->config.output_rate;
+  return static_cast<uint32_t>(ceilDivide(numerator, impl_->config.input_rate));
+}
+
+void DirectionalSampleRateConverter::reset() noexcept {
+  if (!impl_) {
+    return;
+  }
+  impl_->write_index.store(0, std::memory_order_relaxed);
+  impl_->read_index.store(0, std::memory_order_relaxed);
+  impl_->phase_remainder = 0;
+  impl_->primed.store(false, std::memory_order_release);
+  impl_->phase_increment = impl_->nominal_phase_increment;
+  impl_->correction_ppm = 0;
+  impl_->output_frames_produced = 0;
+  impl_->history_head = 0;
+  std::fill(impl_->fifo.begin(), impl_->fifo.end(), 0.0F);
+  std::fill(impl_->history.begin(), impl_->history.end(), 0.0F);
+}
+
+} // namespace orpheus::audio_utils

--- a/src/platform/audio_drivers/CMakeLists.txt
+++ b/src/platform/audio_drivers/CMakeLists.txt
@@ -97,8 +97,10 @@ if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
     target_link_libraries(orpheus_audio_driver_coreaudio
         PUBLIC
             orpheus_session  # For SessionGraphError
+            orpheus_audio_utils  # For directional sample-rate conversion
             "-framework CoreAudio"
             "-framework AudioToolbox"
+            "-framework CoreFoundation"
     )
 
     target_compile_features(orpheus_audio_driver_coreaudio PUBLIC cxx_std_20)

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -812,6 +812,7 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
   auto monitor_lease = driver->performance_monitor_target_.tryAcquire();
   const UInt64 callback_start = monitor_lease ? AudioGetCurrentHostTime() : UInt64{0};
   IAudioCallback* callback = callback_lease.get();
+  const uint64_t session_callback_base = driver->session_frame_position_;
   bool first_chunk = true;
   for (uint32_t offset = 0; offset < host_frames;) {
     const uint32_t frames = std::min(chunk_frames, host_frames - offset);
@@ -876,7 +877,7 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     block.num_output_channels = static_cast<uint16_t>(num_output_channels);
     block.num_frames = frames;
     if (driver->input_conversion_active_ || driver->output_conversion_active_) {
-      block.device_sample_position = driver->session_frame_position_ + offset;
+      block.device_sample_position = session_callback_base + offset;
       block.discontinuity = first_chunk && !driver->conversion_timeline_initialized_;
       block.host_time_nanoseconds =
           host_valid ? hostTimeForOffset(host_base, offset, sample_rate) : 0;
@@ -904,9 +905,9 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
 
     first_chunk = false;
     offset += frames;
-    if (driver->input_conversion_active_ || driver->output_conversion_active_) {
-      driver->session_frame_position_ += frames;
-    }
+  }
+  if (driver->input_conversion_active_ || driver->output_conversion_active_) {
+    driver->session_frame_position_ = session_callback_base + host_frames;
   }
 
   if (driver->output_conversion_active_) {

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -10,17 +10,46 @@
 #include <cstring>
 #include <limits>
 #include <sstream>
-#include <utility>
 
 namespace orpheus {
 namespace {
 
-bool addLatencyTerm(const std::optional<UInt32>& term, uint32_t& total) {
-  if (!term.has_value()) {
+bool checkedAddFrames(uint32_t lhs, uint32_t rhs, uint32_t& result) {
+  if (rhs > std::numeric_limits<uint32_t>::max() - lhs) {
     return false;
   }
-  const uint64_t sum = static_cast<uint64_t>(total) + *term;
-  total = static_cast<uint32_t>(std::min<uint64_t>(sum, std::numeric_limits<uint32_t>::max()));
+  result = lhs + rhs;
+  return true;
+}
+
+bool checkedScaleToSession(uint32_t frames, uint32_t source_rate, uint32_t session_rate,
+                           uint32_t& result) {
+  if (source_rate == 0 || session_rate == 0) {
+    return false;
+  }
+  const uint64_t numerator = static_cast<uint64_t>(frames) * session_rate;
+  if (numerator > std::numeric_limits<uint64_t>::max() - (source_rate - 1u)) {
+    return false;
+  }
+  const uint64_t scaled = (numerator + source_rate - 1u) / source_rate;
+  if (scaled > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  result = static_cast<uint32_t>(scaled);
+  return true;
+}
+
+bool checkedSecondsToSession(Float64 seconds, uint32_t session_rate, uint32_t& result) {
+  if (!std::isfinite(seconds) || seconds < 0.0 || session_rate == 0) {
+    return false;
+  }
+  const long double scaled =
+      std::ceil(static_cast<long double>(seconds) * static_cast<long double>(session_rate));
+  if (!std::isfinite(scaled) ||
+      scaled > static_cast<long double>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+  result = static_cast<uint32_t>(scaled);
   return true;
 }
 
@@ -41,6 +70,8 @@ AudioRouteRuntimeOutcome outcomeForCompatibility(AudioRouteCompatibilityStatus s
   case AudioRouteCompatibilityStatus::Compatible:
   case AudioRouteCompatibilityStatus::RequiresSampleRateChange:
     return AudioRouteRuntimeOutcome::BackendFailure;
+  case AudioRouteCompatibilityStatus::ProfileConflict:
+    return AudioRouteRuntimeOutcome::ProfileConflict;
   }
   return AudioRouteRuntimeOutcome::BackendFailure;
 }
@@ -128,7 +159,7 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
 
   // Resolution is intentionally the first backend operation. It is the only
   // source of advertised-rate support facts and performs no activation writes.
-  const detail::ResolvedCoreAudioRoute resolved_route = route_resolver_.resolve(config);
+  detail::ResolvedCoreAudioRoute resolved_route = route_resolver_.resolve(config);
 
   stopRouteMonitor();
   std::lock_guard<std::mutex> lock(mutex_);
@@ -171,13 +202,29 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     return SessionGraphError::InvalidParameter;
   }
 
-  input_device_id_ = resolved_route.input_device_id;
-  output_device_id_ = resolved_route.output_device_id;
-  available_input_channels_ = resolved_route.input_channel_count;
-  available_output_channels_ = resolved_route.output_channel_count;
-  input_channel_map_ = resolved_route.input_channel_map;
-  output_channel_map_ = resolved_route.output_channel_map;
-  device_id_ = output_device_id_;
+  const auto apply_resolved_route = [&](const detail::ResolvedCoreAudioRoute& settled_route) {
+    input_device_id_ = settled_route.input_device_id;
+    output_device_id_ = settled_route.output_device_id;
+    available_input_channels_ = settled_route.input_channel_count;
+    available_output_channels_ = settled_route.output_channel_count;
+    input_channel_map_ = settled_route.input_channel_map;
+    output_channel_map_ = settled_route.output_channel_map;
+    device_id_ = output_device_id_;
+    input_physical_rate_ = settled_route.compatibility.current_input_sample_rate;
+    output_physical_rate_ = settled_route.compatibility.current_output_sample_rate;
+    input_client_channels_ = static_cast<uint16_t>(input_channel_map_.size());
+    output_client_channels_ = static_cast<uint16_t>(output_channel_map_.size());
+    input_conversion_active_ = settled_route.compatibility.input_conversion_required;
+    output_conversion_active_ = settled_route.compatibility.output_conversion_required;
+    input_virtual_format_channels_ = settled_route.compatibility.input_virtual_format_channels;
+    output_virtual_format_channels_ = settled_route.compatibility.output_virtual_format_channels;
+    input_is_bluetooth_ = settled_route.compatibility.input_is_bluetooth;
+    output_is_bluetooth_ = settled_route.compatibility.output_is_bluetooth;
+    endpoints_related_ = settled_route.compatibility.endpoints_related;
+    output_mono_fallback_ = settled_route.compatibility.output_mono_fallback_planned;
+  };
+
+  apply_resolved_route(resolved_route);
 
   if (config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate) {
     const AudioRouteRuntimeOutcome hog_result = disableAutomaticHogModeLocked();
@@ -188,11 +235,17 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     }
   }
 
+  const bool has_planned_rate_write =
+      std::any_of(resolved_route.device_rate_plans.begin(), resolved_route.device_rate_plans.end(),
+                  [](const detail::CoreAudioDeviceRatePlan& plan) {
+                    return plan.requested_write_rate.has_value();
+                  });
   const bool rate_transaction_active =
-      config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate;
+      config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate ||
+      has_planned_rate_write;
   std::optional<CoreAudioSampleRateTransaction> rate_transaction;
   if (rate_transaction_active) {
-    rate_transaction.emplace(*property_api_, resolved_route, config.sample_rate);
+    rate_transaction.emplace(*property_api_, resolved_route.device_rate_plans);
     if (config.num_inputs > 0) {
       notifyInputOperation(
           detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::RateTransaction);
@@ -205,6 +258,54 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
       }
       cleanupAudioUnit();
       return SessionGraphError::InvalidParameter;
+    }
+  }
+
+  const bool input_unit_was_requested = input_conversion_active_;
+  if (input_unit_was_requested) {
+    const SessionGraphError input_unit_result = setupInputAudioUnit();
+    if (input_unit_result != SessionGraphError::OK) {
+      route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+      restoreAutomaticHogModeLocked();
+      cleanupAudioUnit();
+      return input_unit_result;
+    }
+  }
+
+  // Rate writes and Bluetooth input binding can change device-global facts.
+  // Resolve again without proposing a second write; activation consumes only
+  // this settled, no-write route.
+  if (rate_transaction_active || input_unit_was_requested) {
+    resolved_route = route_resolver_.resolve(config, false);
+    if (!resolved_route.resolved) {
+      route_outcome_.store(outcomeForCompatibility(resolved_route.compatibility.status),
+                           std::memory_order_release);
+      restoreAutomaticHogModeLocked();
+      cleanupAudioUnit();
+      return SessionGraphError::InvalidParameter;
+    }
+
+    const auto dispose_input_unit = [&]() noexcept {
+      if (input_audio_unit_ == nullptr) {
+        return;
+      }
+      AudioOutputUnitStop(input_audio_unit_);
+      AudioUnitUninitialize(input_audio_unit_);
+      AudioComponentInstanceDispose(input_audio_unit_);
+      input_audio_unit_ = nullptr;
+    };
+    if (input_unit_was_requested) {
+      dispose_input_unit();
+    }
+    apply_resolved_route(resolved_route);
+    if (input_unit_was_requested && input_conversion_active_) {
+      const SessionGraphError input_unit_result = setupInputAudioUnit();
+      if (input_unit_result != SessionGraphError::OK) {
+        route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+        restoreAutomaticHogModeLocked();
+        cleanupAudioUnit();
+        return input_unit_result;
+      }
     }
   }
 
@@ -221,26 +322,8 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     device_id_ = aggregate_device_id_;
   }
 
-  const SessionGraphError setup_result = setupAudioUnit(device_id_);
-  if (setup_result != SessionGraphError::OK) {
-    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
-    restoreAutomaticHogModeLocked();
-    cleanupAudioUnit();
-    return setup_result;
-  }
-
-  refreshActiveRouteLocked();
-  if (active_route_.output_device_id.empty() || active_route_.actual_sample_rate == 0 ||
-      active_route_.actual_buffer_frames == 0 ||
-      (config_.num_inputs > 0 && active_route_.input_device_id.empty())) {
-    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
-    restoreAutomaticHogModeLocked();
-    cleanupAudioUnit();
-    active_route_ = {};
-    return SessionGraphError::InternalError;
-  }
-
-  uint32_t maximum_frames = active_route_.actual_buffer_frames;
+  uint32_t maximum_frames = config_.buffer_size;
+  uint32_t input_maximum_frames = config_.buffer_size;
   const auto consider_capacity = [&](AudioDeviceID endpoint,
                                      AudioObjectPropertyScope scope) -> bool {
     const auto capacity = queryMaximumBufferFrames(endpoint, scope);
@@ -252,12 +335,16 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
   };
   if (config_.num_inputs > 0) {
     notifyInputOperation(detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::Capacity);
-    if (!consider_capacity(input_device_id_, kAudioObjectPropertyScopeInput)) {
+    const auto input_capacity =
+        queryMaximumBufferFrames(input_device_id_, kAudioObjectPropertyScopeInput);
+    if (!input_capacity.has_value()) {
       route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
       restoreAutomaticHogModeLocked();
       cleanupAudioUnit();
       return SessionGraphError::InternalError;
     }
+    input_maximum_frames = std::max(input_maximum_frames, *input_capacity);
+    maximum_frames = std::max(maximum_frames, input_maximum_frames);
   }
   if (!consider_capacity(output_device_id_, kAudioObjectPropertyScopeOutput) ||
       !consider_capacity(device_id_, kAudioObjectPropertyScopeGlobal)) {
@@ -266,13 +353,37 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     cleanupAudioUnit();
     return SessionGraphError::InternalError;
   }
-  if (!allocateRenderBuffers(maximum_frames)) {
+  if ((input_conversion_active_ || output_conversion_active_) && maximum_frames > 4096u) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    restoreAutomaticHogModeLocked();
+    cleanupAudioUnit();
+    return SessionGraphError::NotSupported;
+  }
+  render_capacity_frames_ = maximum_frames;
+  input_render_capacity_frames_ = config_.num_inputs > 0 ? input_maximum_frames : 0;
+  if (!prepareConverters() || !allocateRenderBuffers(maximum_frames)) {
     route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
     restoreAutomaticHogModeLocked();
     cleanupAudioUnit();
     return SessionGraphError::InternalError;
   }
-
+  const SessionGraphError setup_result = setupAudioUnit(device_id_);
+  if (setup_result != SessionGraphError::OK) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    restoreAutomaticHogModeLocked();
+    cleanupAudioUnit();
+    return setup_result;
+  }
+  refreshActiveRouteLocked();
+  if (active_route_.output_device_id.empty() || active_route_.actual_sample_rate == 0 ||
+      active_route_.actual_buffer_frames == 0 ||
+      (config_.num_inputs > 0 && active_route_.input_device_id.empty())) {
+    route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
+    restoreAutomaticHogModeLocked();
+    cleanupAudioUnit();
+    active_route_ = {};
+    return SessionGraphError::InternalError;
+  }
   if (!createRouteMonitor()) {
     route_outcome_.store(AudioRouteRuntimeOutcome::BackendFailure, std::memory_order_release);
     restoreAutomaticHogModeLocked();
@@ -280,13 +391,21 @@ SessionGraphError CoreAudioDriver::initialize(const AudioDriverConfig& config) {
     return SessionGraphError::InternalError;
   }
 
-  render_capacity_frames_ = maximum_frames;
-  render_sample_rate_.store(active_route_.actual_sample_rate, std::memory_order_release);
+  render_sample_rate_.store(config_.sample_rate, std::memory_order_release);
   render_max_callback_frames_.store(maximum_frames, std::memory_order_release);
-  render_chunk_frames_.store(config_.buffer_size, std::memory_order_release);
-  render_input_channels_.store(config_.num_inputs, std::memory_order_release);
-  render_output_channels_.store(config_.num_outputs, std::memory_order_release);
+  input_render_max_callback_frames_.store(input_maximum_frames, std::memory_order_release);
+  render_chunk_frames_.store(std::min<uint32_t>(config_.buffer_size, 4096u),
+                             std::memory_order_release);
+  render_input_channels_.store(input_client_channels_, std::memory_order_release);
+  render_output_channels_.store(output_client_channels_, std::memory_order_release);
   input_render_failures_.store(0, std::memory_order_release);
+  input_fifo_overruns_.store(0, std::memory_order_release);
+  input_fifo_underruns_.store(0, std::memory_order_release);
+  input_conversion_failures_.store(0, std::memory_order_release);
+  output_conversion_failures_.store(0, std::memory_order_release);
+  input_pi_integral_ = 0;
+  session_frame_position_ = 0;
+  conversion_timeline_initialized_ = false;
   route_outcome_.store(AudioRouteRuntimeOutcome::Healthy, std::memory_order_release);
   if (rate_transaction.has_value()) {
     rate_transaction->commit();
@@ -321,7 +440,7 @@ SessionGraphError CoreAudioDriver::initializeAudioOutput(const AudioOutputRouteR
 SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  if (!audio_unit_ || !route_monitor_) {
+  if (!audio_unit_ || !route_monitor_ || (input_conversion_active_ && !input_audio_unit_)) {
     return SessionGraphError::NotReady;
   }
   if (is_running_.load(std::memory_order_acquire)) {
@@ -334,13 +453,13 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
     return SessionGraphError::NotReady;
   }
 
-  if (render_sample_rate_.load(std::memory_order_acquire) == 0) {
-    render_sample_rate_.store(active_route_.actual_sample_rate, std::memory_order_release);
-    render_max_callback_frames_.store(render_capacity_frames_, std::memory_order_release);
-    render_chunk_frames_.store(config_.buffer_size, std::memory_order_release);
-    render_input_channels_.store(config_.num_inputs, std::memory_order_release);
-    render_output_channels_.store(config_.num_outputs, std::memory_order_release);
-  }
+  render_sample_rate_.store(config_.sample_rate, std::memory_order_release);
+  render_max_callback_frames_.store(render_capacity_frames_, std::memory_order_release);
+  input_render_max_callback_frames_.store(input_render_capacity_frames_, std::memory_order_release);
+  render_chunk_frames_.store(std::min<uint32_t>(config_.buffer_size, 4096u),
+                             std::memory_order_release);
+  render_input_channels_.store(input_client_channels_, std::memory_order_release);
+  render_output_channels_.store(output_client_channels_, std::memory_order_release);
 
   if (!startRouteMonitorLocked()) {
     route_monitor_->stop();
@@ -348,13 +467,41 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
     return SessionGraphError::InternalError;
   }
 
+  if (input_conversion_active_) {
+    input_callback_target_.replaceAndDrain(this);
+    if (AudioOutputUnitStart(input_audio_unit_) != noErr) {
+      input_callback_target_.replaceAndDrain(nullptr);
+      route_monitor_->stop();
+      stopRenderingLocked();
+      publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::BackendFailure);
+      return SessionGraphError::InternalError;
+    }
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!input_converter_.isPrimed() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (!input_converter_.isPrimed()) {
+      input_callback_target_.replaceAndDrain(nullptr);
+      AudioOutputUnitStop(input_audio_unit_);
+      route_monitor_->closeAdmission();
+      route_monitor_->stop();
+      cleanupAudioUnit();
+      active_route_ = {};
+      recordInputConversionFailure();
+      publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::InputConversionFailed);
+      return SessionGraphError::NotReady;
+    }
+  }
+
   callback_target_.replaceAndDrain(callback);
+  output_callback_target_.replaceAndDrain(this);
   expected_stream_sample_ = 0;
+  session_frame_position_ = 0;
   stream_timeline_initialized_ = false;
+  conversion_timeline_initialized_ = false;
   is_running_.store(true, std::memory_order_release);
 
-  const OSStatus status = AudioOutputUnitStart(audio_unit_);
-  if (status != noErr) {
+  if (AudioOutputUnitStart(audio_unit_) != noErr) {
     stopRenderingLocked();
     route_monitor_->stop();
     publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::BackendFailure);
@@ -401,8 +548,15 @@ uint32_t CoreAudioDriver::getLatencySamples() const {
 }
 
 AudioIoTelemetry CoreAudioDriver::getTelemetry() const noexcept {
-  return {input_render_failures_.load(std::memory_order_acquire),
-          route_outcome_.load(std::memory_order_acquire)};
+  AudioIoTelemetry telemetry;
+  telemetry.input_render_failures = input_render_failures_.load(std::memory_order_acquire);
+  telemetry.route_outcome = route_outcome_.load(std::memory_order_acquire);
+  telemetry.input_fifo_overruns = input_fifo_overruns_.load(std::memory_order_acquire);
+  telemetry.input_fifo_underruns = input_fifo_underruns_.load(std::memory_order_acquire);
+  telemetry.input_conversion_failures = input_conversion_failures_.load(std::memory_order_acquire);
+  telemetry.output_conversion_failures =
+      output_conversion_failures_.load(std::memory_order_acquire);
+  return telemetry;
 }
 
 AudioRouteCompatibility CoreAudioDriver::probeRoute(const AudioDriverConfig& config) const {
@@ -451,6 +605,22 @@ AudioIoRouteState CoreAudioDriver::getAudioIoRouteState() const {
   state.actual_sample_rate = active_route_.actual_sample_rate;
   state.requested_buffer_size = config_.buffer_size;
   state.actual_buffer_size = active_route_.actual_buffer_frames;
+  state.input_physical_sample_rate = active_route_.input_physical_sample_rate;
+  state.output_physical_sample_rate = active_route_.output_physical_sample_rate;
+  state.input_client_sample_rate = active_route_.input_client_sample_rate;
+  state.output_client_sample_rate = active_route_.output_client_sample_rate;
+  state.requested_output_channels = active_route_.requested_output_channels;
+  state.resolved_output_channels = active_route_.resolved_output_channels;
+  state.input_virtual_format_channels = active_route_.input_virtual_format_channels;
+  state.output_virtual_format_channels = active_route_.output_virtual_format_channels;
+  state.input_client_format_channels = active_route_.input_client_format_channels;
+  state.output_client_format_channels = active_route_.output_client_format_channels;
+  state.input_conversion_active = active_route_.input_conversion_active;
+  state.output_conversion_active = active_route_.output_conversion_active;
+  state.input_is_bluetooth = active_route_.input_is_bluetooth;
+  state.output_is_bluetooth = active_route_.output_is_bluetooth;
+  state.endpoints_related = active_route_.endpoints_related;
+  state.output_mono_fallback = active_route_.output_mono_fallback;
   state.latency = queryDetailedLatencyBreakdown();
   return state;
 }
@@ -465,6 +635,33 @@ void CoreAudioDriver::incrementInputRenderFailuresForTesting() noexcept {
 
 void CoreAudioDriver::recordInputRenderFailure() noexcept {
   detail::publishSaturatingIncrement(input_render_failures_);
+}
+void CoreAudioDriver::recordInputFifoOverrun() noexcept {
+  detail::publishSaturatingIncrement(input_fifo_overruns_);
+}
+
+void CoreAudioDriver::recordInputFifoUnderrun() noexcept {
+  detail::publishSaturatingIncrement(input_fifo_underruns_);
+}
+
+void CoreAudioDriver::recordInputConversionFailure() noexcept {
+  detail::publishSaturatingIncrement(input_conversion_failures_);
+}
+
+void CoreAudioDriver::recordOutputConversionFailure() noexcept {
+  detail::publishSaturatingIncrement(output_conversion_failures_);
+}
+
+void CoreAudioDriver::failRealtimeConversion(AudioRouteRuntimeOutcome outcome) noexcept {
+  if (outcome == AudioRouteRuntimeOutcome::InputConversionFailed) {
+    recordInputConversionFailure();
+  } else if (outcome == AudioRouteRuntimeOutcome::OutputConversionFailed) {
+    recordOutputConversionFailure();
+  }
+  if (route_monitor_) {
+    route_monitor_->closeAdmission();
+  }
+  publishTerminalRouteOutcome(outcome);
 }
 
 void CoreAudioDriver::notifyInputOperation(
@@ -521,31 +718,22 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     }
   }
 
+  const uint32_t native_frames = inNumberFrames;
   const uint32_t max_frames = driver->render_max_callback_frames_.load(std::memory_order_acquire);
   const uint32_t num_input_channels =
       driver->render_input_channels_.load(std::memory_order_acquire);
   const uint32_t num_output_channels =
       driver->render_output_channels_.load(std::memory_order_acquire);
-  if (max_frames != 0 && inNumberFrames <= max_frames) {
-    for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
-      std::memset(driver->input_buffers_[channel], 0,
-                  static_cast<size_t>(inNumberFrames) * sizeof(float));
-    }
-    for (uint32_t channel = 0; channel < num_output_channels; ++channel) {
-      std::memset(driver->output_buffers_[channel], 0,
-                  static_cast<size_t>(inNumberFrames) * sizeof(float));
-    }
-  }
-
-  const uint64_t frame_bytes = requiredBytes(inNumberFrames);
-  bool malformed_output = ioData == nullptr || max_frames == 0 || inNumberFrames > max_frames;
+  const uint64_t native_frame_bytes = requiredBytes(native_frames);
+  bool malformed_output = ioData == nullptr || max_frames == 0 || native_frames > max_frames;
   if (!malformed_output) {
     if (ioData->mNumberBuffers < num_output_channels) {
       malformed_output = true;
     } else {
       for (uint32_t channel = 0; channel < num_output_channels; ++channel) {
         const AudioBuffer& buffer = ioData->mBuffers[channel];
-        if (buffer.mData == nullptr || static_cast<uint64_t>(buffer.mDataByteSize) < frame_bytes) {
+        if (buffer.mData == nullptr ||
+            static_cast<uint64_t>(buffer.mDataByteSize) < native_frame_bytes) {
           malformed_output = true;
           break;
         }
@@ -560,35 +748,60 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     return noErr;
   }
 
-  if (!driver->is_running_.load(std::memory_order_acquire) || !driver->route_monitor_ ||
-      !driver->route_monitor_->permitsRendering()) {
+  auto output_state_lease = driver->output_callback_target_.tryAcquire();
+  if (!output_state_lease || !driver->is_running_.load(std::memory_order_acquire) ||
+      !driver->route_monitor_ || !driver->route_monitor_->permitsRendering()) {
     return noErr;
   }
-
   auto callback_lease = driver->callback_target_.tryAcquire();
   if (!callback_lease) {
     return noErr;
   }
 
-  if (num_input_channels > 0) {
-    auto* input_abl = reinterpret_cast<AudioBufferList*>(driver->input_abl_storage_.data());
-    input_abl->mNumberBuffers = num_input_channels;
-    for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
-      input_abl->mBuffers[channel].mNumberChannels = 1;
-      input_abl->mBuffers[channel].mDataByteSize = static_cast<UInt32>(frame_bytes);
-      input_abl->mBuffers[channel].mData = driver->input_buffers_[channel];
+  const uint32_t sample_rate = driver->render_sample_rate_.load(std::memory_order_acquire);
+  const uint32_t chunk_frames = driver->render_chunk_frames_.load(std::memory_order_acquire);
+  if (chunk_frames == 0 || sample_rate == 0) {
+    driver->failRealtimeConversion(AudioRouteRuntimeOutcome::BackendFailure);
+    return noErr;
+  }
+
+  uint32_t host_frames = native_frames;
+  if (driver->output_conversion_active_) {
+    uint32_t required = 0;
+    if (driver->output_converter_.requiredInputFrames(native_frames, required) !=
+        audio_utils::DirectionalSrcStatus::Ok) {
+      driver->failRealtimeConversion(AudioRouteRuntimeOutcome::OutputConversionFailed);
+      return noErr;
     }
-    driver->notifyInputOperation(
-        detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::InputRender);
-    const OSStatus render_status = AudioUnitRender(driver->audio_unit_, ioActionFlags, inTimeStamp,
-                                                   /*inputBus=*/1, inNumberFrames, input_abl);
-    if (render_status != noErr) {
-      driver->recordInputRenderFailure();
+    host_frames = required;
+  }
+  if (host_frames == 0 && !driver->output_conversion_active_) {
+    driver->failRealtimeConversion(AudioRouteRuntimeOutcome::BackendFailure);
+    return noErr;
+  }
+
+  if (driver->input_conversion_active_) {
+    const uint32_t target_buffered = 128u + driver->input_prime_frames_;
+    const int64_t buffered = static_cast<int64_t>(driver->input_converter_.bufferedInputFrames());
+    const int64_t error = buffered - static_cast<int64_t>(target_buffered);
+    const int64_t normalized = error * 1'000'000 / static_cast<int64_t>(target_buffered);
+    const bool saturated_outward = (driver->input_correction_ppm_ >= 1'000 && normalized > 0) ||
+                                   (driver->input_correction_ppm_ <= -1'000 && normalized < 0);
+    if (!saturated_outward) {
+      driver->input_pi_integral_ =
+          std::clamp<int64_t>(driver->input_pi_integral_ + normalized, -4'096'000, 4'096'000);
+    }
+    const int64_t correction =
+        std::clamp<int64_t>(normalized / 64 + driver->input_pi_integral_ / 4'096, -1'000, 1'000);
+    driver->input_correction_ppm_ = static_cast<int32_t>(correction);
+    if (!driver->input_converter_.setInputRateCorrectionPpm(driver->input_correction_ppm_)) {
+      driver->failRealtimeConversion(AudioRouteRuntimeOutcome::InputConversionFailed);
+      return noErr;
     }
   }
 
   uint64_t sample_base = 0;
-  const bool sample_valid = validSampleTimestamp(inTimeStamp, inNumberFrames, sample_base);
+  const bool sample_valid = validSampleTimestamp(inTimeStamp, native_frames, sample_base);
   uint64_t host_base = 0;
   const bool host_valid =
       inTimeStamp != nullptr && (inTimeStamp->mFlags & kAudioTimeStampHostTimeValid) != 0;
@@ -596,27 +809,63 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     host_base = AudioConvertHostTimeToNanos(inTimeStamp->mHostTime);
   }
 
-  const uint32_t sample_rate = driver->render_sample_rate_.load(std::memory_order_acquire);
-  const uint32_t chunk_frames = driver->render_chunk_frames_.load(std::memory_order_acquire);
-  if (chunk_frames == 0 || sample_rate == 0) {
-    if (driver->route_monitor_) {
-      driver->route_monitor_->closeAdmission();
-    }
-    driver->publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::BackendFailure);
-    return noErr;
-  }
-
   auto monitor_lease = driver->performance_monitor_target_.tryAcquire();
   const UInt64 callback_start = monitor_lease ? AudioGetCurrentHostTime() : UInt64{0};
   IAudioCallback* callback = callback_lease.get();
   bool first_chunk = true;
-  for (uint32_t offset = 0; offset < inNumberFrames;) {
-    const uint32_t frames = std::min(chunk_frames, inNumberFrames - offset);
+  for (uint32_t offset = 0; offset < host_frames;) {
+    const uint32_t frames = std::min(chunk_frames, host_frames - offset);
     for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
+      driver->input_render_chunk_buffers_[channel] = driver->input_buffers_[channel] + offset;
       driver->input_chunk_buffers_[channel] = driver->input_buffers_[channel] + offset;
     }
     for (uint32_t channel = 0; channel < num_output_channels; ++channel) {
       driver->output_chunk_buffers_[channel] = driver->output_buffers_[channel] + offset;
+    }
+
+    if (driver->input_conversion_active_) {
+      const auto transfer =
+          driver->input_converter_.renderOutput(driver->input_render_chunk_buffers_.data(),
+                                                static_cast<uint16_t>(num_input_channels), frames);
+      if (transfer.status != audio_utils::DirectionalSrcStatus::Ok ||
+          transfer.output_frames_produced != frames) {
+        driver->recordInputFifoUnderrun();
+        driver->failRealtimeConversion(AudioRouteRuntimeOutcome::InputConversionFailed);
+        return noErr;
+      }
+    } else if (num_input_channels > 0) {
+      const uint64_t frame_bytes = requiredBytes(frames);
+      auto* input_abl = reinterpret_cast<AudioBufferList*>(driver->input_abl_storage_.data());
+      input_abl->mNumberBuffers = num_input_channels;
+      for (uint32_t channel = 0; channel < num_input_channels; ++channel) {
+        float* const destination = driver->input_buffers_[channel] + offset;
+        std::memset(destination, 0, frame_bytes);
+        input_abl->mBuffers[channel].mNumberChannels = 1;
+        input_abl->mBuffers[channel].mDataByteSize = static_cast<UInt32>(frame_bytes);
+        input_abl->mBuffers[channel].mData = destination;
+      }
+      AudioTimeStamp adjusted_timestamp{};
+      const AudioTimeStamp* render_timestamp = inTimeStamp;
+      if (inTimeStamp != nullptr && offset != 0) {
+        adjusted_timestamp = *inTimeStamp;
+        if (sample_valid) {
+          adjusted_timestamp.mSampleTime += static_cast<Float64>(offset);
+        }
+        if (host_valid) {
+          const uint64_t adjusted_host_nanos = hostTimeForOffset(host_base, offset, sample_rate);
+          if (adjusted_host_nanos != 0) {
+            adjusted_timestamp.mHostTime = AudioConvertNanosToHostTime(adjusted_host_nanos);
+          }
+        }
+        render_timestamp = &adjusted_timestamp;
+      }
+      driver->notifyInputOperation(
+          detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::InputRender);
+      const OSStatus render_status = AudioUnitRender(driver->audio_unit_, ioActionFlags,
+                                                     render_timestamp, 1, frames, input_abl);
+      if (render_status != noErr) {
+        driver->recordInputRenderFailure();
+      }
     }
 
     AudioProcessBlock block;
@@ -626,21 +875,55 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     block.num_input_channels = static_cast<uint16_t>(num_input_channels);
     block.num_output_channels = static_cast<uint16_t>(num_output_channels);
     block.num_frames = frames;
-    block.device_sample_position = sample_valid ? sample_base + offset : 0;
-    block.host_time_nanoseconds =
-        host_valid ? hostTimeForOffset(host_base, offset, sample_rate) : 0;
-    block.discontinuity =
-        sample_valid
-            ? (first_chunk && (!driver->stream_timeline_initialized_ ||
-                               block.device_sample_position != driver->expected_stream_sample_))
-            : first_chunk;
+    if (driver->input_conversion_active_ || driver->output_conversion_active_) {
+      block.device_sample_position = driver->session_frame_position_ + offset;
+      block.discontinuity = first_chunk && !driver->conversion_timeline_initialized_;
+      block.host_time_nanoseconds =
+          host_valid ? hostTimeForOffset(host_base, offset, sample_rate) : 0;
+    } else {
+      block.device_sample_position = sample_valid ? sample_base + offset : 0;
+      block.host_time_nanoseconds =
+          host_valid ? hostTimeForOffset(host_base, offset, sample_rate) : 0;
+      block.discontinuity =
+          sample_valid
+              ? (first_chunk && (!driver->stream_timeline_initialized_ ||
+                                 block.device_sample_position != driver->expected_stream_sample_))
+              : first_chunk;
+    }
     callback->processAudio(block);
+
+    if (driver->output_conversion_active_) {
+      const auto transfer = driver->output_converter_.pushInput(
+          driver->output_chunk_buffers_.data(), static_cast<uint16_t>(num_output_channels), frames);
+      if (transfer.status != audio_utils::DirectionalSrcStatus::Ok ||
+          transfer.input_frames_consumed != frames) {
+        driver->failRealtimeConversion(AudioRouteRuntimeOutcome::OutputConversionFailed);
+        return noErr;
+      }
+    }
+
     first_chunk = false;
     offset += frames;
+    if (driver->input_conversion_active_ || driver->output_conversion_active_) {
+      driver->session_frame_position_ += frames;
+    }
   }
 
-  if (sample_valid) {
-    driver->expected_stream_sample_ = sample_base + inNumberFrames;
+  if (driver->output_conversion_active_) {
+    const auto transfer = driver->output_converter_.renderOutput(
+        driver->output_native_buffers_.data(), static_cast<uint16_t>(num_output_channels),
+        native_frames);
+    if (transfer.status != audio_utils::DirectionalSrcStatus::Ok ||
+        transfer.output_frames_produced != native_frames) {
+      driver->failRealtimeConversion(AudioRouteRuntimeOutcome::OutputConversionFailed);
+      return noErr;
+    }
+  }
+
+  if (driver->input_conversion_active_ || driver->output_conversion_active_) {
+    driver->conversion_timeline_initialized_ = true;
+  } else if (sample_valid) {
+    driver->expected_stream_sample_ = sample_base + native_frames;
     driver->stream_timeline_initialized_ = true;
   } else {
     driver->expected_stream_sample_ = 0;
@@ -652,15 +935,72 @@ OSStatus CoreAudioDriver::renderCallback(void* inRefCon, AudioUnitRenderActionFl
     const uint64_t duration_ns = AudioConvertHostTimeToNanos(callback_end - callback_start);
     const uint64_t callback_duration_us = duration_ns / 1000u;
     const uint64_t buffer_duration_us =
-        (static_cast<uint64_t>(inNumberFrames) * 1'000'000ull) / sample_rate;
+        (static_cast<uint64_t>(native_frames) * 1'000'000ull) /
+        (driver->output_physical_rate_ == 0 ? sample_rate : driver->output_physical_rate_);
     if (auto* monitor = monitor_lease.get()) {
       monitor->recordAudioCallback(callback_duration_us, buffer_duration_us,
-                                   callback->activeClipCount(), sample_rate, inNumberFrames);
+                                   callback->activeClipCount(), sample_rate, host_frames);
     }
   }
 
   for (uint32_t channel = 0; channel < num_output_channels; ++channel) {
-    std::memcpy(ioData->mBuffers[channel].mData, driver->output_buffers_[channel], frame_bytes);
+    const float* source = driver->output_conversion_active_
+                              ? driver->output_native_buffers_[channel]
+                              : driver->output_buffers_[channel];
+    std::memcpy(ioData->mBuffers[channel].mData, source, native_frame_bytes);
+  }
+  return noErr;
+}
+
+OSStatus CoreAudioDriver::inputRenderCallback(void* inRefCon,
+                                              AudioUnitRenderActionFlags* ioActionFlags,
+                                              const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber,
+                                              UInt32 inNumberFrames, AudioBufferList* ioData) {
+  (void)inBusNumber;
+  (void)ioData;
+  auto* driver = static_cast<CoreAudioDriver*>(inRefCon);
+  assert(driver != nullptr);
+  auto state_lease = driver->input_callback_target_.tryAcquire();
+  if (!state_lease ||
+      driver->route_outcome_.load(std::memory_order_acquire) != AudioRouteRuntimeOutcome::Healthy) {
+    return noErr;
+  }
+  const uint32_t max_frames =
+      driver->input_render_max_callback_frames_.load(std::memory_order_acquire);
+  const uint32_t channels = driver->render_input_channels_.load(std::memory_order_acquire);
+  if (inNumberFrames == 0) {
+    return noErr;
+  }
+  if (max_frames == 0 || inNumberFrames > max_frames || channels == 0 ||
+      driver->input_capture_buffers_.size() < channels) {
+    driver->failRealtimeConversion(AudioRouteRuntimeOutcome::InputConversionFailed);
+    return noErr;
+  }
+
+  const uint64_t frame_bytes = requiredBytes(inNumberFrames);
+  auto* input_abl = reinterpret_cast<AudioBufferList*>(driver->input_abl_storage_.data());
+  input_abl->mNumberBuffers = channels;
+  for (uint32_t channel = 0; channel < channels; ++channel) {
+    std::memset(driver->input_capture_buffers_[channel], 0, frame_bytes);
+    input_abl->mBuffers[channel].mNumberChannels = 1;
+    input_abl->mBuffers[channel].mDataByteSize = static_cast<UInt32>(frame_bytes);
+    input_abl->mBuffers[channel].mData = driver->input_capture_buffers_[channel];
+  }
+  driver->notifyInputOperation(
+      detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::InputRender);
+  if (AudioUnitRender(driver->input_audio_unit_, ioActionFlags, inTimeStamp, 1, inNumberFrames,
+                      input_abl) != noErr) {
+    driver->recordInputRenderFailure();
+    return noErr;
+  }
+  const auto transfer = driver->input_converter_.pushInput(
+      driver->input_capture_const_buffers_.data(), static_cast<uint16_t>(channels), inNumberFrames);
+  if (transfer.status != audio_utils::DirectionalSrcStatus::Ok ||
+      transfer.input_frames_consumed != inNumberFrames) {
+    if (transfer.status == audio_utils::DirectionalSrcStatus::InputOverflow) {
+      driver->recordInputFifoOverrun();
+    }
+    driver->failRealtimeConversion(AudioRouteRuntimeOutcome::InputConversionFailed);
   }
   return noErr;
 }
@@ -904,13 +1244,13 @@ AudioDeviceID CoreAudioDriver::createAggregateDevice(AudioDeviceID input_device_
 bool CoreAudioDriver::createRouteMonitor() {
   std::vector<CoreAudioRouteDevice> devices;
   devices.reserve(config_.num_inputs > 0 ? 3 : 2);
-  devices.push_back({output_device_id_, false, true, false});
+  devices.push_back({output_device_id_, false, true, false, output_physical_rate_});
   if (config_.num_inputs > 0) {
     notifyInputOperation(detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::Monitor);
-    devices.push_back({input_device_id_, true, false, false});
+    devices.push_back({input_device_id_, true, false, false, input_physical_rate_});
   }
   if (aggregate_device_id_ != 0) {
-    devices.push_back({aggregate_device_id_, false, false, true});
+    devices.push_back({aggregate_device_id_, false, false, true, output_physical_rate_});
   }
 
   std::vector<CoreAudioRouteStream> streams;
@@ -1072,6 +1412,7 @@ void CoreAudioDriver::refreshActiveRouteLocked() {
   } else {
     active_route_.input_device_id.clear();
   }
+  active_route_.requested_output_channels = config_.num_outputs;
   active_route_.output_device_id = getDeviceUID(output_device_id_).value_or("");
   active_route_.input_channels = input_channel_map_;
   active_route_.output_channels = output_channel_map_;
@@ -1080,18 +1421,28 @@ void CoreAudioDriver::refreshActiveRouteLocked() {
   active_route_.available_output_channels = static_cast<uint16_t>(
       std::min<uint32_t>(available_output_channels_, std::numeric_limits<uint16_t>::max()));
   active_route_.requested_sample_rate = config_.sample_rate;
-  active_route_.actual_sample_rate = 0;
-  active_route_.actual_buffer_frames = 0;
-  const auto actual_rate = getOptionalFloat64Property(
-      device_id_, kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal);
-  if (actual_rate.has_value() && std::isfinite(*actual_rate) && *actual_rate > 0.0 &&
-      *actual_rate <= std::numeric_limits<uint32_t>::max()) {
-    active_route_.actual_sample_rate = static_cast<uint32_t>(std::llround(*actual_rate));
-  }
+  active_route_.actual_sample_rate = config_.sample_rate;
   active_route_.actual_buffer_frames =
       getOptionalUInt32Property(device_id_, kAudioDevicePropertyBufferFrameSize,
                                 kAudioObjectPropertyScopeGlobal)
           .value_or(0);
+  active_route_.input_physical_sample_rate = input_physical_rate_;
+  active_route_.output_physical_sample_rate = output_physical_rate_;
+  active_route_.input_client_sample_rate =
+      input_conversion_active_ ? input_physical_rate_ : config_.sample_rate;
+  active_route_.output_client_sample_rate =
+      output_conversion_active_ ? output_physical_rate_ : config_.sample_rate;
+  active_route_.resolved_output_channels = output_client_channels_;
+  active_route_.input_virtual_format_channels = input_virtual_format_channels_;
+  active_route_.output_virtual_format_channels = output_virtual_format_channels_;
+  active_route_.input_client_format_channels = input_client_channels_;
+  active_route_.output_client_format_channels = output_client_channels_;
+  active_route_.input_conversion_active = input_conversion_active_;
+  active_route_.output_conversion_active = output_conversion_active_;
+  active_route_.input_is_bluetooth = input_is_bluetooth_;
+  active_route_.output_is_bluetooth = output_is_bluetooth_;
+  active_route_.endpoints_related = endpoints_related_;
+  active_route_.output_mono_fallback = output_mono_fallback_;
   active_route_.latency = queryLatencyBreakdown();
   active_route_.input_alive = config_.num_inputs > 0 &&
                               getUInt32Property(input_device_id_, kAudioDevicePropertyDeviceIsAlive,
@@ -1102,10 +1453,81 @@ void CoreAudioDriver::refreshActiveRouteLocked() {
 }
 
 AudioRouteLatency CoreAudioDriver::queryLatencyBreakdown() const {
-  AudioRouteLatency latency;
-  uint32_t capture_frames = 0;
-  uint32_t playback_frames = 0;
-  uint32_t processing_frames = 0;
+  AudioRouteLatency aggregate;
+  const AudioLatencyBreakdown detailed = queryDetailedLatencyBreakdown();
+  if (!detailed.complete) {
+    return aggregate;
+  }
+
+  const auto add = [](const std::optional<uint32_t>& term, uint32_t& total) {
+    return term.has_value() && checkedAddFrames(total, *term, total);
+  };
+  bool capture_complete = config_.num_inputs == 0;
+  if (config_.num_inputs > 0) {
+    capture_complete = add(detailed.input_device_frames, aggregate.capture_frames) &&
+                       add(detailed.input_safety_offset_frames, aggregate.capture_frames) &&
+                       add(detailed.input_stream_frames, aggregate.capture_frames) &&
+                       add(detailed.input_audio_unit_frames, aggregate.capture_frames) &&
+                       add(detailed.input_converter_frames, aggregate.capture_frames);
+  }
+  bool playback_complete = add(detailed.output_converter_frames, aggregate.playback_frames);
+  if (aggregate_device_id_ == 0) {
+    playback_complete =
+        playback_complete && add(detailed.output_audio_unit_frames, aggregate.playback_frames);
+  }
+  playback_complete = playback_complete &&
+                      add(detailed.output_device_frames, aggregate.playback_frames) &&
+                      add(detailed.output_safety_offset_frames, aggregate.playback_frames) &&
+                      add(detailed.output_stream_frames, aggregate.playback_frames);
+  const bool processing_complete =
+      add(detailed.callback_buffer_frames, aggregate.processing_frames) &&
+      add(detailed.aggregate_or_audio_unit_frames, aggregate.processing_frames);
+  aggregate.complete = capture_complete && playback_complete && processing_complete;
+  if (!aggregate.complete) {
+    aggregate.capture_frames = 0;
+    aggregate.playback_frames = 0;
+    aggregate.processing_frames = 0;
+  }
+  return aggregate;
+}
+
+AudioLatencyBreakdown CoreAudioDriver::queryDetailedLatencyBreakdown() const {
+  AudioLatencyBreakdown latency;
+  const uint32_t session_rate = config_.sample_rate;
+  const uint32_t input_rate = input_physical_rate_ != 0 ? input_physical_rate_ : session_rate;
+  const uint32_t output_rate = output_physical_rate_ != 0 ? output_physical_rate_ : session_rate;
+  bool complete = session_rate != 0;
+
+  const auto assign_native = [&](std::optional<UInt32> native, uint32_t native_rate,
+                                 std::optional<uint32_t>& destination) {
+    if (!native.has_value()) {
+      return false;
+    }
+    uint32_t normalized = 0;
+    if (!checkedScaleToSession(*native, native_rate, session_rate, normalized)) {
+      return false;
+    }
+    destination = normalized;
+    return true;
+  };
+  const auto assign_unit = [&](AudioUnit unit, std::optional<uint32_t>& destination) {
+    if (unit == nullptr) {
+      return false;
+    }
+    Float64 seconds = 0.0;
+    UInt32 size = sizeof(seconds);
+    const OSStatus unit_status = AudioUnitGetProperty(unit, kAudioUnitProperty_Latency,
+                                                      kAudioUnitScope_Global, 0, &seconds, &size);
+    if (unit_status != noErr || size != sizeof(seconds)) {
+      return false;
+    }
+    uint32_t frames = 0;
+    if (!checkedSecondsToSession(seconds, session_rate, frames)) {
+      return false;
+    }
+    destination = frames;
+    return true;
+  };
 
   std::optional<UInt32> input_device_latency;
   std::optional<UInt32> input_safety_offset;
@@ -1118,7 +1540,24 @@ AudioRouteLatency CoreAudioDriver::queryLatencyBreakdown() const {
         input_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeInput);
     input_stream_latency =
         getOptionalStreamLatency(input_device_id_, kAudioObjectPropertyScopeInput);
+    complete = assign_native(input_device_latency, input_rate, latency.input_device_frames) &&
+               assign_native(input_safety_offset, input_rate, latency.input_safety_offset_frames) &&
+               assign_native(input_stream_latency, input_rate, latency.input_stream_frames) &&
+               complete;
+    if (input_conversion_active_) {
+      const uint32_t converter_frames = input_converter_.latencyOutputFrames();
+      if (converter_frames == 0) {
+        complete = false;
+      } else {
+        latency.input_converter_frames = converter_frames;
+      }
+      complete = assign_unit(input_audio_unit_, latency.input_audio_unit_frames) && complete;
+    } else {
+      latency.input_converter_frames = 0;
+      latency.input_audio_unit_frames = 0;
+    }
   }
+
   const auto output_device_latency = getOptionalUInt32Property(
       output_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeOutput);
   const auto output_safety_offset = getOptionalUInt32Property(
@@ -1127,82 +1566,38 @@ AudioRouteLatency CoreAudioDriver::queryLatencyBreakdown() const {
       getOptionalStreamLatency(output_device_id_, kAudioObjectPropertyScopeOutput);
   const auto callback_buffer_frames = getOptionalUInt32Property(
       device_id_, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
-
-  std::optional<uint32_t> audio_unit_latency;
-  if (audio_unit_ != nullptr) {
-    Float64 seconds = 0.0;
-    UInt32 size = sizeof(seconds);
-    if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
-                             &seconds, &size) == noErr &&
-        size == sizeof(seconds) && std::isfinite(seconds) && seconds >= 0.0) {
-      const uint32_t rate = active_route_.actual_sample_rate != 0 ? active_route_.actual_sample_rate
-                                                                  : config_.sample_rate;
-      const uint64_t frames = static_cast<uint64_t>(std::llround(seconds * rate));
-      audio_unit_latency =
-          static_cast<uint32_t>(std::min<uint64_t>(frames, std::numeric_limits<uint32_t>::max()));
+  complete =
+      assign_native(output_device_latency, output_rate, latency.output_device_frames) &&
+      assign_native(output_safety_offset, output_rate, latency.output_safety_offset_frames) &&
+      assign_native(output_stream_latency, output_rate, latency.output_stream_frames) && complete;
+  if (output_conversion_active_) {
+    const uint32_t converter_frames = output_converter_.latencyOutputFrames();
+    uint32_t normalized = 0;
+    if (converter_frames == 0 ||
+        !checkedScaleToSession(converter_frames, output_rate, session_rate, normalized)) {
+      complete = false;
+    } else {
+      latency.output_converter_frames = normalized;
     }
+  } else {
+    latency.output_converter_frames = 0;
   }
 
-  bool input_complete = config_.num_inputs == 0;
-  if (config_.num_inputs > 0) {
-    input_complete = addLatencyTerm(input_device_latency, capture_frames) &&
-                     addLatencyTerm(input_safety_offset, capture_frames) &&
-                     addLatencyTerm(input_stream_latency, capture_frames);
+  if (aggregate_device_id_ != 0) {
+    latency.output_audio_unit_frames = std::nullopt;
+    latency.aggregate_or_audio_unit_frames = 0;
+    complete = assign_unit(audio_unit_, latency.aggregate_or_audio_unit_frames) && complete;
+  } else {
+    latency.aggregate_or_audio_unit_frames = 0;
+    complete = assign_unit(audio_unit_, latency.output_audio_unit_frames) && complete;
   }
-  const bool output_complete = addLatencyTerm(output_device_latency, playback_frames) &&
-                               addLatencyTerm(output_safety_offset, playback_frames) &&
-                               addLatencyTerm(output_stream_latency, playback_frames);
-  const bool processing_complete = addLatencyTerm(callback_buffer_frames, processing_frames) &&
-                                   addLatencyTerm(audio_unit_latency, processing_frames);
-  latency.capture_frames = capture_frames;
-  latency.playback_frames = playback_frames;
-  latency.processing_frames = processing_frames;
-  latency.complete = input_complete && output_complete && processing_complete;
-  return latency;
-}
-
-AudioLatencyBreakdown CoreAudioDriver::queryDetailedLatencyBreakdown() const {
-  AudioLatencyBreakdown latency;
-  if (config_.num_inputs > 0) {
-    notifyInputOperation(detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::Latency);
-    latency.input_device_frames = getOptionalUInt32Property(
-        input_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeInput);
-    latency.input_safety_offset_frames = getOptionalUInt32Property(
-        input_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeInput);
-    latency.input_stream_frames =
-        getOptionalStreamLatency(input_device_id_, kAudioObjectPropertyScopeInput);
+  complete = assign_native(callback_buffer_frames, output_rate, latency.callback_buffer_frames) &&
+             complete;
+  if (config_.num_inputs == 0) {
+    latency.input_converter_frames = 0;
+    latency.input_audio_unit_frames = 0;
   }
-  latency.output_device_frames = getOptionalUInt32Property(
-      output_device_id_, kAudioDevicePropertyLatency, kAudioObjectPropertyScopeOutput);
-  latency.output_safety_offset_frames = getOptionalUInt32Property(
-      output_device_id_, kAudioDevicePropertySafetyOffset, kAudioObjectPropertyScopeOutput);
-  latency.output_stream_frames =
-      getOptionalStreamLatency(output_device_id_, kAudioObjectPropertyScopeOutput);
-  latency.callback_buffer_frames = getOptionalUInt32Property(
-      device_id_, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
-  if (audio_unit_ != nullptr) {
-    Float64 seconds = 0.0;
-    UInt32 size = sizeof(seconds);
-    if (AudioUnitGetProperty(audio_unit_, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0,
-                             &seconds, &size) == noErr &&
-        size == sizeof(seconds) && std::isfinite(seconds) && seconds >= 0.0) {
-      const uint32_t rate = active_route_.actual_sample_rate != 0 ? active_route_.actual_sample_rate
-                                                                  : config_.sample_rate;
-      const uint64_t frames = static_cast<uint64_t>(std::llround(seconds * rate));
-      latency.aggregate_or_audio_unit_frames =
-          static_cast<uint32_t>(std::min<uint64_t>(frames, std::numeric_limits<uint32_t>::max()));
-    }
-  }
-  const bool input_complete =
-      config_.num_inputs == 0 ||
-      (latency.input_device_frames.has_value() && latency.input_safety_offset_frames.has_value() &&
-       latency.input_stream_frames.has_value());
-  const bool output_complete = latency.output_device_frames.has_value() &&
-                               latency.output_safety_offset_frames.has_value() &&
-                               latency.output_stream_frames.has_value();
-  const bool processing_complete = latency.callback_buffer_frames.has_value() &&
-                                   latency.aggregate_or_audio_unit_frames.has_value();
-  latency.complete = input_complete && output_complete && processing_complete;
+  latency.complete = complete;
   return latency;
 }
 
@@ -1211,9 +1606,13 @@ uint32_t CoreAudioDriver::queryDeviceLatency() const {
   if (!latency.complete) {
     return 0;
   }
-  const uint64_t total = static_cast<uint64_t>(latency.capture_frames) + latency.playback_frames +
-                         latency.processing_frames;
-  return static_cast<uint32_t>(std::min<uint64_t>(total, std::numeric_limits<uint32_t>::max()));
+  uint32_t total = 0;
+  if (!checkedAddFrames(total, latency.capture_frames, total) ||
+      !checkedAddFrames(total, latency.playback_frames, total) ||
+      !checkedAddFrames(total, latency.processing_frames, total)) {
+    return 0;
+  }
+  return total;
 }
 
 std::optional<uint32_t>
@@ -1260,36 +1659,85 @@ CoreAudioDriver::queryMaximumBufferFrames(AudioDeviceID device_id,
 }
 
 bool CoreAudioDriver::allocateRenderBuffers(uint32_t maximum_frames) noexcept {
+  uint32_t host_capacity = maximum_frames;
+  if (output_conversion_active_) {
+    const uint64_t numerator = static_cast<uint64_t>(maximum_frames) * config_.sample_rate;
+    const uint64_t converted =
+        (numerator + output_physical_rate_ - 1) / output_physical_rate_ + 255u;
+    if (converted > std::numeric_limits<uint32_t>::max()) {
+      return false;
+    }
+    host_capacity = std::max(host_capacity, static_cast<uint32_t>(converted));
+  }
+
   size_t input_size = 0;
   size_t output_size = 0;
-  if (!checkedPlanarSize(config_.num_inputs, maximum_frames, input_size) ||
-      !checkedPlanarSize(config_.num_outputs, maximum_frames, output_size)) {
+  if (!checkedPlanarSize(input_client_channels_, host_capacity, input_size) ||
+      !checkedPlanarSize(output_client_channels_, host_capacity, output_size)) {
     return false;
   }
-  if (config_.num_inputs > 0 &&
-      config_.num_inputs - 1 >
+  size_t capture_size = 0;
+  size_t native_output_size = 0;
+  if (input_conversion_active_ &&
+      !checkedPlanarSize(input_client_channels_, maximum_frames, capture_size)) {
+    return false;
+  }
+  if (output_conversion_active_ &&
+      !checkedPlanarSize(output_client_channels_, maximum_frames, native_output_size)) {
+    return false;
+  }
+  if (input_client_channels_ > 0 &&
+      input_client_channels_ - 1 >
           (std::numeric_limits<size_t>::max() - sizeof(AudioBufferList)) / sizeof(AudioBuffer)) {
     return false;
   }
   try {
     input_storage_.assign(input_size, 0.0f);
     output_storage_.assign(output_size, 0.0f);
-    input_buffers_.resize(config_.num_inputs);
-    output_buffers_.resize(config_.num_outputs);
-    input_chunk_buffers_.resize(config_.num_inputs);
-    output_chunk_buffers_.resize(config_.num_outputs);
-    for (uint16_t channel = 0; channel < config_.num_inputs; ++channel) {
+    input_buffers_.resize(input_client_channels_);
+    output_buffers_.resize(output_client_channels_);
+    input_render_chunk_buffers_.resize(input_client_channels_);
+    input_chunk_buffers_.resize(input_client_channels_);
+    output_chunk_buffers_.resize(output_client_channels_);
+    for (uint16_t channel = 0; channel < input_client_channels_; ++channel) {
       input_buffers_[channel] =
-          input_storage_.data() + static_cast<size_t>(channel) * maximum_frames;
+          input_storage_.data() + static_cast<size_t>(channel) * host_capacity;
     }
-    for (uint16_t channel = 0; channel < config_.num_outputs; ++channel) {
+    for (uint16_t channel = 0; channel < output_client_channels_; ++channel) {
       output_buffers_[channel] =
-          output_storage_.data() + static_cast<size_t>(channel) * maximum_frames;
+          output_storage_.data() + static_cast<size_t>(channel) * host_capacity;
     }
-    if (config_.num_inputs > 0) {
+
+    if (input_conversion_active_) {
+      input_capture_storage_.assign(capture_size, 0.0f);
+      input_capture_buffers_.resize(input_client_channels_);
+      input_capture_const_buffers_.resize(input_client_channels_);
+      for (uint16_t channel = 0; channel < input_client_channels_; ++channel) {
+        input_capture_buffers_[channel] =
+            input_capture_storage_.data() + static_cast<size_t>(channel) * maximum_frames;
+        input_capture_const_buffers_[channel] = input_capture_buffers_[channel];
+      }
+    } else {
+      input_capture_storage_.clear();
+      input_capture_buffers_.clear();
+      input_capture_const_buffers_.clear();
+    }
+    if (output_conversion_active_) {
+      output_native_storage_.assign(native_output_size, 0.0f);
+      output_native_buffers_.resize(output_client_channels_);
+      for (uint16_t channel = 0; channel < output_client_channels_; ++channel) {
+        output_native_buffers_[channel] =
+            output_native_storage_.data() + static_cast<size_t>(channel) * maximum_frames;
+      }
+    } else {
+      output_native_storage_.clear();
+      output_native_buffers_.clear();
+    }
+
+    if (input_client_channels_ > 0) {
       const size_t buffer_list_size =
           sizeof(AudioBufferList) +
-          static_cast<size_t>(config_.num_inputs - 1) * sizeof(AudioBuffer);
+          static_cast<size_t>(input_client_channels_ - 1) * sizeof(AudioBuffer);
       input_abl_storage_.assign(buffer_list_size, 0);
     } else {
       input_abl_storage_.clear();
@@ -1311,6 +1759,158 @@ std::optional<std::string> CoreAudioDriver::getDeviceUID(AudioDeviceID device_id
   return converted ? std::optional<std::string>(std::string(buffer)) : std::nullopt;
 }
 
+bool CoreAudioDriver::prepareConverters() {
+  input_prime_frames_ = 0;
+  const uint32_t chunk_frames = std::min<uint32_t>(config_.buffer_size, 4096u);
+  if (input_conversion_active_) {
+    if (config_.num_inputs == 0 || input_physical_rate_ == 0 ||
+        input_physical_rate_ == config_.sample_rate || input_render_capacity_frames_ == 0 ||
+        input_render_capacity_frames_ > 4096u || chunk_frames == 0) {
+      return false;
+    }
+    audio_utils::DirectionalSrcConfig input_config;
+    input_config.input_rate = input_physical_rate_;
+    input_config.output_rate = config_.sample_rate;
+    input_config.channels = input_client_channels_;
+    input_config.max_input_frames = input_render_capacity_frames_;
+    input_config.max_output_frames = chunk_frames;
+    input_config.fifo_capacity_frames = 32768;
+    input_prime_frames_ = std::min<uint32_t>(4u * input_render_capacity_frames_,
+                                             input_config.fifo_capacity_frames / 2u);
+    input_config.prime_input_frames = input_prime_frames_;
+    input_config.allow_input_rate_correction = true;
+    if (input_converter_.prepare(input_config) != SessionGraphError::OK) {
+      input_prime_frames_ = 0;
+      return false;
+    }
+    input_converter_.reset();
+  }
+
+  if (output_conversion_active_) {
+    if (output_physical_rate_ == 0 || output_physical_rate_ == config_.sample_rate ||
+        render_capacity_frames_ > 4096u) {
+      return false;
+    }
+    audio_utils::DirectionalSrcConfig output_config;
+    output_config.input_rate = config_.sample_rate;
+    output_config.output_rate = output_physical_rate_;
+    output_config.channels = output_client_channels_;
+    output_config.max_input_frames = chunk_frames;
+    output_config.max_output_frames = render_capacity_frames_;
+    output_config.fifo_capacity_frames = 32768;
+    output_config.prime_input_frames = 0;
+    output_config.allow_input_rate_correction = false;
+    if (output_converter_.prepare(output_config) != SessionGraphError::OK) {
+      return false;
+    }
+    output_converter_.reset();
+  }
+  return true;
+}
+
+bool CoreAudioDriver::validateAudioUnitFormat(AudioUnit unit, AudioUnitScope scope, UInt32 element,
+                                              Float64 expected_rate,
+                                              UInt16 expected_channels) const noexcept {
+  if (unit == nullptr || !std::isfinite(expected_rate) || expected_rate <= 0.0 ||
+      expected_channels == 0) {
+    return false;
+  }
+  AudioStreamBasicDescription observed{};
+  UInt32 size = sizeof(observed);
+  if (AudioUnitGetProperty(unit, kAudioUnitProperty_StreamFormat, scope, element, &observed,
+                           &size) != noErr ||
+      size != sizeof(observed)) {
+    return false;
+  }
+  return std::isfinite(observed.mSampleRate) &&
+         std::abs(observed.mSampleRate - expected_rate) <= 0.001 &&
+         observed.mChannelsPerFrame == expected_channels;
+}
+
+SessionGraphError CoreAudioDriver::setupInputAudioUnit() {
+  if (!input_conversion_active_) {
+    return SessionGraphError::OK;
+  }
+  AudioComponentDescription description = {};
+  description.componentType = kAudioUnitType_Output;
+  description.componentSubType = kAudioUnitSubType_HALOutput;
+  description.componentManufacturer = kAudioUnitManufacturer_Apple;
+  AudioComponent component = AudioComponentFindNext(nullptr, &description);
+  if (!component || AudioComponentInstanceNew(component, &input_audio_unit_) != noErr ||
+      !input_audio_unit_) {
+    input_audio_unit_ = nullptr;
+    return SessionGraphError::InternalError;
+  }
+  const auto fail = [&]() {
+    AudioUnitUninitialize(input_audio_unit_);
+    AudioComponentInstanceDispose(input_audio_unit_);
+    input_audio_unit_ = nullptr;
+    return SessionGraphError::InternalError;
+  };
+
+  UInt32 enable_output = 0;
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioOutputUnitProperty_EnableIO,
+                           kAudioUnitScope_Output, 0, &enable_output,
+                           sizeof(enable_output)) != noErr) {
+    return fail();
+  }
+  UInt32 enable_input = 1;
+  notifyInputOperation(
+      detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::AudioUnitEnable);
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioOutputUnitProperty_EnableIO,
+                           kAudioUnitScope_Input, 1, &enable_input,
+                           sizeof(enable_input)) != noErr) {
+    return fail();
+  }
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioOutputUnitProperty_CurrentDevice,
+                           kAudioUnitScope_Global, 0, &input_device_id_,
+                           sizeof(input_device_id_)) != noErr) {
+    return fail();
+  }
+
+  AudioStreamBasicDescription input_format = {};
+  input_format.mSampleRate = input_physical_rate_;
+  input_format.mFormatID = kAudioFormatLinearPCM;
+  input_format.mFormatFlags =
+      kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved;
+  input_format.mBytesPerPacket = sizeof(float);
+  input_format.mFramesPerPacket = 1;
+  input_format.mBytesPerFrame = sizeof(float);
+  input_format.mChannelsPerFrame = input_client_channels_;
+  input_format.mBitsPerChannel = 32;
+  notifyInputOperation(
+      detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::AudioUnitConfigure);
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioUnitProperty_StreamFormat,
+                           kAudioUnitScope_Output, 1, &input_format,
+                           sizeof(input_format)) != noErr) {
+    return fail();
+  }
+  std::vector<SInt32> input_channel_map;
+  input_channel_map.reserve(input_channel_map_.size());
+  for (const uint16_t channel : input_channel_map_) {
+    input_channel_map.push_back(static_cast<SInt32>(channel));
+  }
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioOutputUnitProperty_ChannelMap,
+                           kAudioUnitScope_Output, 1, input_channel_map.data(),
+                           static_cast<UInt32>(input_channel_map.size() * sizeof(SInt32))) !=
+      noErr) {
+    return fail();
+  }
+
+  AURenderCallbackStruct callback = {};
+  callback.inputProc = &CoreAudioDriver::inputRenderCallback;
+  callback.inputProcRefCon = this;
+  if (AudioUnitSetProperty(input_audio_unit_, kAudioOutputUnitProperty_SetInputCallback,
+                           kAudioUnitScope_Global, 0, &callback, sizeof(callback)) != noErr ||
+      AudioUnitInitialize(input_audio_unit_) != noErr ||
+      !validateAudioUnitFormat(input_audio_unit_, kAudioUnitScope_Output, 1,
+                               static_cast<Float64>(input_physical_rate_),
+                               input_client_channels_)) {
+    return fail();
+  }
+  return SessionGraphError::OK;
+}
+
 SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
   AudioComponentDescription description = {};
   description.componentType = kAudioUnitType_Output;
@@ -1321,8 +1921,8 @@ SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
     return SessionGraphError::InternalError;
   }
 
-  UInt32 enable_input = config_.num_inputs > 0 ? 1 : 0;
-  if (config_.num_inputs > 0) {
+  UInt32 enable_input = config_.num_inputs > 0 && !input_conversion_active_ ? 1u : 0u;
+  if (config_.num_inputs > 0 && !input_conversion_active_) {
     notifyInputOperation(
         detail::CoreAudioDriverDirectionAudit::InputDirectionOperation::AudioUnitEnable);
   }
@@ -1345,14 +1945,15 @@ SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
   }
 
   AudioStreamBasicDescription output_format = {};
-  output_format.mSampleRate = config_.sample_rate;
+  output_format.mSampleRate =
+      output_conversion_active_ ? output_physical_rate_ : config_.sample_rate;
   output_format.mFormatID = kAudioFormatLinearPCM;
   output_format.mFormatFlags =
       kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved;
   output_format.mBytesPerPacket = sizeof(float);
   output_format.mFramesPerPacket = 1;
   output_format.mBytesPerFrame = sizeof(float);
-  output_format.mChannelsPerFrame = config_.num_outputs;
+  output_format.mChannelsPerFrame = output_client_channels_;
   output_format.mBitsPerChannel = 32;
 
   if (config_.num_inputs > 0) {
@@ -1377,9 +1978,10 @@ SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
     return SessionGraphError::InternalError;
   }
 
-  if (config_.num_inputs > 0) {
+  if (config_.num_inputs > 0 && !input_conversion_active_) {
     AudioStreamBasicDescription input_format = output_format;
-    input_format.mChannelsPerFrame = config_.num_inputs;
+    input_format.mSampleRate = config_.sample_rate;
+    input_format.mChannelsPerFrame = input_client_channels_;
     status = AudioUnitSetProperty(audio_unit_, kAudioUnitProperty_StreamFormat,
                                   kAudioUnitScope_Output, 1, &input_format, sizeof(input_format));
     if (status != noErr) {
@@ -1406,8 +2008,17 @@ SessionGraphError CoreAudioDriver::setupAudioUnit(AudioDeviceID device_id) {
   if (status != noErr) {
     return SessionGraphError::InternalError;
   }
-  status = AudioUnitInitialize(audio_unit_);
-  return status == noErr ? SessionGraphError::OK : SessionGraphError::InternalError;
+  if (AudioUnitInitialize(audio_unit_) != noErr ||
+      !validateAudioUnitFormat(audio_unit_, kAudioUnitScope_Input, 0,
+                               static_cast<Float64>(output_format.mSampleRate),
+                               output_client_channels_) ||
+      (config_.num_inputs > 0 && !input_conversion_active_ &&
+       !validateAudioUnitFormat(audio_unit_, kAudioUnitScope_Output, 1,
+                                static_cast<Float64>(config_.sample_rate),
+                                input_client_channels_))) {
+    return SessionGraphError::InternalError;
+  }
+  return SessionGraphError::OK;
 }
 
 AudioRouteRuntimeOutcome CoreAudioDriver::disableAutomaticHogModeLocked() noexcept {
@@ -1474,18 +2085,31 @@ bool CoreAudioDriver::restoreAutomaticHogModeLocked() noexcept {
 }
 
 void CoreAudioDriver::cleanupAudioUnit() {
+  input_callback_target_.replaceAndDrain(nullptr);
+  output_callback_target_.replaceAndDrain(nullptr);
   if (audio_unit_) {
+    AudioOutputUnitStop(audio_unit_);
     AudioUnitUninitialize(audio_unit_);
     AudioComponentInstanceDispose(audio_unit_);
     audio_unit_ = nullptr;
   }
+  if (input_audio_unit_) {
+    AudioOutputUnitStop(input_audio_unit_);
+    AudioUnitUninitialize(input_audio_unit_);
+    AudioComponentInstanceDispose(input_audio_unit_);
+    input_audio_unit_ = nullptr;
+  }
   callback_target_.replaceAndDrain(nullptr);
   render_capacity_frames_ = 0;
+  input_render_capacity_frames_ = 0;
   render_sample_rate_.store(0, std::memory_order_release);
   render_max_callback_frames_.store(0, std::memory_order_release);
+  input_render_max_callback_frames_.store(0, std::memory_order_release);
   render_chunk_frames_.store(0, std::memory_order_release);
   render_input_channels_.store(0, std::memory_order_release);
   render_output_channels_.store(0, std::memory_order_release);
+  input_converter_.reset();
+  output_converter_.reset();
 
   if (aggregate_device_id_ != 0) {
     AudioHardwareDestroyAggregateDevice(aggregate_device_id_);
@@ -1499,24 +2123,59 @@ void CoreAudioDriver::cleanupAudioUnit() {
   available_output_channels_ = 0;
   input_channel_map_.clear();
   output_channel_map_.clear();
+  input_physical_rate_ = 0;
+  output_physical_rate_ = 0;
+  input_client_channels_ = 0;
+  output_client_channels_ = 0;
+  input_conversion_active_ = false;
+  output_conversion_active_ = false;
+  input_virtual_format_channels_ = 0;
+  output_virtual_format_channels_ = 0;
+  input_is_bluetooth_ = false;
+  input_prime_frames_ = 0;
+  output_is_bluetooth_ = false;
+  endpoints_related_ = false;
+  output_mono_fallback_ = false;
+  input_correction_ppm_ = 0;
+  input_pi_integral_ = 0;
   route_monitor_.reset();
   input_buffers_.clear();
   output_buffers_.clear();
+  input_render_chunk_buffers_.clear();
   input_chunk_buffers_.clear();
   output_chunk_buffers_.clear();
   input_storage_.clear();
   output_storage_.clear();
   input_abl_storage_.clear();
+  input_capture_const_buffers_.clear();
+  input_capture_buffers_.clear();
+  output_native_buffers_.clear();
+  input_capture_storage_.clear();
+  output_native_storage_.clear();
 }
 
 void CoreAudioDriver::stopRenderingLocked() {
+  input_callback_target_.replaceAndDrain(nullptr);
+  output_callback_target_.replaceAndDrain(nullptr);
   if (audio_unit_) {
     AudioOutputUnitStop(audio_unit_);
   }
+  if (input_audio_unit_) {
+    AudioOutputUnitStop(input_audio_unit_);
+  }
   callback_target_.replaceAndDrain(nullptr);
+  // Stopping is the explicit continuous-device discontinuity boundary. Both
+  // converter FIFOs are now quiescent and may be reset before a later start.
+  input_converter_.reset();
+  output_converter_.reset();
+  input_correction_ppm_ = 0;
+  input_pi_integral_ = 0;
+  session_frame_position_ = 0;
+  conversion_timeline_initialized_ = false;
   is_running_.store(false, std::memory_order_release);
   render_sample_rate_.store(0, std::memory_order_release);
   render_max_callback_frames_.store(0, std::memory_order_release);
+  input_render_max_callback_frames_.store(0, std::memory_order_release);
   render_chunk_frames_.store(0, std::memory_order_release);
   render_input_channels_.store(0, std::memory_order_release);
   render_output_channels_.store(0, std::memory_order_release);

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.h
@@ -7,6 +7,7 @@
 #include "coreaudio_route_resolver.h"
 
 #include <orpheus/audio_driver.h>
+#include <orpheus/directional_sample_rate_converter.h>
 
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudio.h>
@@ -86,8 +87,15 @@ private:
   static OSStatus renderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
                                  const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber,
                                  UInt32 inNumberFrames, AudioBufferList* ioData);
-
+  static OSStatus inputRenderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
+                                      const AudioTimeStamp* inTimeStamp, UInt32 inBusNumber,
+                                      UInt32 inNumberFrames, AudioBufferList* ioData);
   void recordInputRenderFailure() noexcept;
+  void recordInputFifoOverrun() noexcept;
+  void recordInputFifoUnderrun() noexcept;
+  void recordInputConversionFailure() noexcept;
+  void recordOutputConversionFailure() noexcept;
+  void failRealtimeConversion(AudioRouteRuntimeOutcome outcome) noexcept;
   void notifyInputOperation(
       detail::CoreAudioDriverDirectionAudit::InputDirectionOperation) const noexcept;
 
@@ -112,7 +120,11 @@ private:
 
   AudioDeviceID createAggregateDevice(AudioDeviceID input_device_id,
                                       AudioDeviceID output_device_id);
+  bool validateAudioUnitFormat(AudioUnit unit, AudioUnitScope scope, UInt32 element,
+                               Float64 expected_rate, UInt16 expected_channels) const noexcept;
+  SessionGraphError setupInputAudioUnit();
   SessionGraphError setupAudioUnit(AudioDeviceID device_id);
+  bool prepareConverters();
   bool createRouteMonitor();
   bool startRouteMonitorLocked();
   void stopRouteMonitor();
@@ -138,9 +150,10 @@ private:
   ICoreAudioPropertyApi* property_api_{nullptr};
   std::shared_ptr<ICoreAudioPropertyApi> injected_property_api_;
   detail::CoreAudioDriverDirectionAudit* direction_audit_{nullptr};
-
   AudioDriverConfig config_;
+
   AudioUnit audio_unit_{nullptr};
+  AudioUnit input_audio_unit_{nullptr};
   AudioDeviceID device_id_{0};
   AudioDeviceID aggregate_device_id_{0};
   AudioDeviceID input_device_id_{0};
@@ -148,38 +161,70 @@ private:
   uint32_t input_channel_offset_{0};
   uint32_t available_input_channels_{0};
   uint32_t available_output_channels_{0};
-  std::vector<uint16_t> input_channel_map_;
-  std::vector<uint16_t> output_channel_map_;
 
   std::atomic<bool> is_running_{false};
   std::atomic<uint64_t> input_render_failures_{0};
+  std::atomic<uint64_t> input_fifo_overruns_{0};
+  std::atomic<uint64_t> input_fifo_underruns_{0};
+  std::atomic<uint64_t> input_conversion_failures_{0};
+  std::atomic<uint64_t> output_conversion_failures_{0};
   uint32_t render_capacity_frames_{0};
+  uint32_t input_render_capacity_frames_{0};
   std::atomic<AudioRouteRuntimeOutcome> route_outcome_{AudioRouteRuntimeOutcome::Healthy};
   std::atomic<AudioRouteState> unavailable_route_state_{AudioRouteState::Failed};
   std::atomic<uint32_t> render_sample_rate_{0};
   std::atomic<uint32_t> render_max_callback_frames_{0};
+  std::atomic<uint32_t> input_render_max_callback_frames_{0};
   std::atomic<uint32_t> render_chunk_frames_{0};
   std::atomic<uint16_t> render_input_channels_{0};
   std::atomic<uint16_t> render_output_channels_{0};
 
+  std::vector<uint16_t> input_channel_map_;
+  std::vector<uint16_t> output_channel_map_;
+  uint32_t input_physical_rate_{0};
+  uint32_t output_physical_rate_{0};
+  uint16_t input_client_channels_{0};
+  uint16_t output_client_channels_{0};
+  bool input_conversion_active_{false};
+  bool output_conversion_active_{false};
+  uint16_t input_virtual_format_channels_{0};
+  uint16_t output_virtual_format_channels_{0};
+  bool input_is_bluetooth_{false};
+  bool output_is_bluetooth_{false};
+  bool endpoints_related_{false};
+  bool output_mono_fallback_{false};
+  uint32_t input_prime_frames_{0};
+  int64_t input_pi_integral_{0};
+  audio_utils::DirectionalSampleRateConverter input_converter_;
+  audio_utils::DirectionalSampleRateConverter output_converter_;
+  int32_t input_correction_ppm_{0};
   std::unique_ptr<CoreAudioRouteMonitor> route_monitor_;
   std::atomic<bool> route_monitor_active_{false};
   std::mutex route_monitor_mutex_;
   std::thread route_monitor_thread_;
 
+  detail::RealtimeBorrowedTarget<CoreAudioDriver> input_callback_target_;
+  detail::RealtimeBorrowedTarget<CoreAudioDriver> output_callback_target_;
   detail::RealtimeBorrowedTarget<IAudioCallback> callback_target_;
   detail::RealtimeBorrowedTarget<IPerformanceMonitor> performance_monitor_target_;
   uint64_t expected_stream_sample_{0};
+  uint64_t session_frame_position_{0};
   bool stream_timeline_initialized_{false};
+  bool conversion_timeline_initialized_{false};
 
   std::vector<float*> input_buffers_;
   std::vector<float*> output_buffers_;
+  std::vector<float*> input_render_chunk_buffers_;
   std::vector<const float*> input_chunk_buffers_;
   std::vector<float*> output_chunk_buffers_;
   std::vector<float> input_storage_;
   std::vector<float> output_storage_;
   std::vector<uint8_t> input_abl_storage_;
-
+  std::vector<const float*> input_capture_const_buffers_;
+  std::vector<float*> input_capture_buffers_;
+  std::vector<float*> output_native_buffers_;
+  std::vector<float> input_capture_storage_;
+  std::vector<float> output_native_storage_;
   bool automatic_hog_mode_changed_{false};
   UInt32 previous_hog_mode_allowed_{0};
   ActiveAudioRoute active_route_;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
@@ -157,11 +157,14 @@ CoreAudioRoutePollResult CoreAudioRouteMonitor::poll() noexcept {
       return CoreAudioRoutePollResult::BackendFailure;
     }
 
+    const Float64 expected_rate = device.expected_sample_rate != 0
+                                      ? static_cast<Float64>(device.expected_sample_rate)
+                                      : expected_sample_rate_;
     Float64 observed_rate = 0.0;
     if (!readFloat64(property_api_, device.device_id, rate_address, observed_rate)) {
       return CoreAudioRoutePollResult::BackendFailure;
     }
-    if (observed_rate != expected_sample_rate_) {
+    if (observed_rate != expected_rate) {
       return CoreAudioRoutePollResult::SampleRateChanged;
     }
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
@@ -22,12 +22,12 @@ enum class CoreAudioRoutePollResult : uint8_t {
   BackendFailure,
 };
 
-/// A physical device contributing one or both directions of an active route.
 struct CoreAudioRouteDevice {
   AudioDeviceID device_id = 0;
   bool monitors_input = false;
   bool monitors_output = false;
   bool is_private_aggregate = false;
+  uint32_t expected_sample_rate = 0;
 };
 
 /// One stream whose virtual and physical formats are part of the active route.

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.cpp
@@ -10,6 +10,7 @@ namespace orpheus::detail {
 namespace {
 
 constexpr double kSampleRateEpsilonHz = 0.001;
+bool normalizeCurrentSampleRate(double value, uint32_t& normalized);
 
 bool isPermissionDenied(OSStatus status) {
   return status == kAudioDevicePermissionsError;
@@ -238,8 +239,133 @@ public:
     }
     return successQueryResult(value != 0);
   }
+  CoreAudioRouteQueryResult<uint32_t> transportType(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<uint32_t>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyTransportType,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 value = 0;
+    UInt32 data_size = sizeof(value);
+    const OSStatus status =
+        AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, &value);
+    if (status != noErr) {
+      return queryResultForStatus<uint32_t>(status);
+    }
+    return successQueryResult(static_cast<uint32_t>(value));
+  }
+
+  CoreAudioRouteQueryResult<std::vector<AudioDeviceID>>
+  relatedDeviceIDs(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<std::vector<AudioDeviceID>>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyRelatedDevices,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    UInt32 data_size = 0;
+    OSStatus status = AudioObjectGetPropertyDataSize(device_id, &address, 0, nullptr, &data_size);
+    if (status != noErr) {
+      return queryResultForStatus<std::vector<AudioDeviceID>>(status);
+    }
+    if (data_size == 0) {
+      return successQueryResult(std::vector<AudioDeviceID>{});
+    }
+    if (data_size % sizeof(AudioDeviceID) != 0) {
+      return queryResultForStatus<std::vector<AudioDeviceID>>(kAudioHardwareBadPropertySizeError);
+    }
+    std::vector<AudioDeviceID> related(data_size / sizeof(AudioDeviceID));
+    status =
+        AudioObjectGetPropertyData(device_id, &address, 0, nullptr, &data_size, related.data());
+    if (status != noErr) {
+      return queryResultForStatus<std::vector<AudioDeviceID>>(status);
+    }
+    return successQueryResult(std::move(related));
+  }
+
+  CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  physicalStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    return streamFormat(device_id, scope, kAudioStreamPropertyPhysicalFormat);
+  }
+
+  CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  virtualStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    return streamFormat(device_id, scope, kAudioStreamPropertyVirtualFormat);
+  }
+
+  CoreAudioRouteQueryResult<bool>
+  nominalSampleRateSettable(AudioDeviceID device_id) const override {
+    if (device_id == 0) {
+      return missingQueryResult<bool>();
+    }
+    const AudioObjectPropertyAddress address = {kAudioDevicePropertyNominalSampleRate,
+                                                kAudioObjectPropertyScopeGlobal,
+                                                kAudioObjectPropertyElementMain};
+    Boolean settable = 0;
+    const OSStatus status = AudioObjectIsPropertySettable(device_id, &address, &settable);
+    if (status != noErr) {
+      return queryResultForStatus<bool>(status);
+    }
+    return successQueryResult(settable != 0);
+  }
+
+  CoreAudioRouteQueryResult<uint32_t>
+  physicalChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    return channelCount(device_id, scope);
+  }
 
 private:
+  CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  streamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope,
+               AudioObjectPropertySelector selector) const {
+    if (device_id == 0) {
+      return missingQueryResult<CoreAudioStreamFormat>();
+    }
+    const AudioObjectPropertyAddress streams_address = {kAudioDevicePropertyStreams, scope,
+                                                        kAudioObjectPropertyElementMain};
+    UInt32 data_size = 0;
+    OSStatus status =
+        AudioObjectGetPropertyDataSize(device_id, &streams_address, 0, nullptr, &data_size);
+    if (status != noErr) {
+      return queryResultForStatus<CoreAudioStreamFormat>(status);
+    }
+    if (data_size == 0) {
+      return missingQueryResult<CoreAudioStreamFormat>();
+    }
+    if (data_size % sizeof(AudioStreamID) != 0) {
+      return queryResultForStatus<CoreAudioStreamFormat>(kAudioHardwareBadPropertySizeError);
+    }
+    std::vector<AudioStreamID> streams(data_size / sizeof(AudioStreamID));
+    status = AudioObjectGetPropertyData(device_id, &streams_address, 0, nullptr, &data_size,
+                                        streams.data());
+    if (status != noErr || streams.empty()) {
+      return status == noErr ? missingQueryResult<CoreAudioStreamFormat>()
+                             : queryResultForStatus<CoreAudioStreamFormat>(status);
+    }
+
+    const AudioObjectPropertyAddress format_address = {selector, kAudioObjectPropertyScopeGlobal,
+                                                       kAudioObjectPropertyElementMain};
+    AudioStreamBasicDescription asbd{};
+    UInt32 format_size = sizeof(asbd);
+    status = AudioObjectGetPropertyData(streams.front(), &format_address, 0, nullptr, &format_size,
+                                        &asbd);
+    if (status != noErr) {
+      return queryResultForStatus<CoreAudioStreamFormat>(status);
+    }
+    if (!std::isfinite(asbd.mSampleRate) || asbd.mSampleRate <= 0.0 ||
+        asbd.mChannelsPerFrame == 0 ||
+        asbd.mChannelsPerFrame > std::numeric_limits<uint16_t>::max()) {
+      return queryResultForStatus<CoreAudioStreamFormat>(kAudioHardwareBadPropertySizeError);
+    }
+    uint32_t sample_rate = 0;
+    if (!normalizeCurrentSampleRate(asbd.mSampleRate, sample_rate)) {
+      return queryResultForStatus<CoreAudioStreamFormat>(kAudioHardwareBadPropertySizeError);
+    }
+    return successQueryResult(
+        CoreAudioStreamFormat{sample_rate, static_cast<uint16_t>(asbd.mChannelsPerFrame)});
+  }
+
   CoreAudioRouteQueryResult<std::string> readDeviceUID(AudioDeviceID device_id) const {
     const AudioObjectPropertyAddress address = {kAudioDevicePropertyDeviceUID,
                                                 kAudioObjectPropertyScopeGlobal,
@@ -325,6 +451,23 @@ bool supportsRequestedRate(const std::vector<CoreAudioEndpointRange>& ranges, ui
            requested_rate <= range.maximum + kSampleRateEpsilonHz;
   });
 }
+bool isBluetoothTransport(uint32_t transport) {
+  return transport == kAudioDeviceTransportTypeBluetooth ||
+         transport == kAudioDeviceTransportTypeBluetoothLE;
+}
+
+bool isConverterRate(uint32_t rate) {
+  return rate == 16'000 || rate == 24'000 || rate == 44'100 || rate == 48'000;
+}
+
+bool containsDevice(const std::vector<AudioDeviceID>& devices, AudioDeviceID device_id) {
+  return std::find(devices.begin(), devices.end(), device_id) != devices.end();
+}
+
+bool requestsExplicitStereoMap(const AudioDriverConfig& config) {
+  return config.num_outputs == 2 &&
+         config.channel_map.output_channels == std::vector<uint16_t>{0, 1};
+}
 
 } // namespace
 
@@ -360,9 +503,11 @@ bool resolveCoreAudioChannelMap(const std::vector<uint16_t>& requested, uint16_t
 CoreAudioRouteResolver::CoreAudioRouteResolver(std::shared_ptr<const ICoreAudioRouteQuery> query)
     : query_(std::move(query)) {}
 
-ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& config) const {
+ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& config,
+                                                       bool allow_rate_writes) const {
   ResolvedCoreAudioRoute route;
   route.compatibility.requested_sample_rate = config.sample_rate;
+  route.compatibility.requested_output_channels = config.num_outputs;
 
   if (config.num_outputs == 0) {
     setFailure(route, AudioRouteCompatibilityStatus::OutputUnavailable, "config", true);
@@ -377,28 +522,33 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
     return route;
   }
 
+  struct EndpointFacts {
+    AudioDeviceID device_id = 0;
+    uint32_t physical_channels = 0;
+    uint32_t transport = 0;
+    uint32_t observed_rate = 0;
+    bool running = false;
+    bool settable = false;
+    bool is_bluetooth = false;
+    std::vector<CoreAudioEndpointRange> ranges;
+    CoreAudioStreamFormat physical_format;
+    CoreAudioStreamFormat virtual_format;
+  };
+
   const auto resolve_endpoint = [&](bool output, const std::string& requested,
-                                    ResolvedCoreAudioEndpoint& endpoint) -> bool {
+                                    EndpointFacts& facts) -> bool {
     const auto resolved =
         requested.empty() ? query_->resolveDefault(output) : query_->resolveDeviceUID(requested);
     if (setQueryFailure(route, resolved.status, "resolve", output)) {
       return false;
     }
-    endpoint = resolved.value;
-    if (endpoint.device_id == 0) {
+    if (resolved.value.device_id == 0) {
       setFailure(route, unavailableStatus(output), "resolve", output);
       return false;
     }
-    if (endpoint.device_uid.empty()) {
-      if (requested.empty()) {
-        setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "resolve", output);
-        return false;
-      }
-      endpoint.device_uid = requested;
-    }
-    const auto channels =
-        query_->channelCount(endpoint.device_id, output ? kAudioObjectPropertyScopeOutput
-                                                        : kAudioObjectPropertyScopeInput);
+    const auto channels = query_->physicalChannelCount(resolved.value.device_id,
+                                                       output ? kAudioObjectPropertyScopeOutput
+                                                              : kAudioObjectPropertyScopeInput);
     if (setQueryFailure(route, channels.status, "channels", output)) {
       return false;
     }
@@ -406,120 +556,316 @@ ResolvedCoreAudioRoute CoreAudioRouteResolver::resolve(const AudioDriverConfig& 
       setFailure(route, unavailableStatus(output), "channels", output);
       return false;
     }
+
+    facts.device_id = resolved.value.device_id;
+    facts.physical_channels = channels.value;
     if (output) {
-      route.output_device_id = endpoint.device_id;
-      route.output_channel_count = channels.value;
-      route.compatibility.resolved_output_device_id = endpoint.device_uid;
+      route.output_device_id = facts.device_id;
+      route.output_channel_count = facts.physical_channels;
+      route.compatibility.resolved_output_device_id =
+          resolved.value.device_uid.empty() ? requested : resolved.value.device_uid;
     } else {
-      route.input_device_id = endpoint.device_id;
-      route.input_channel_count = channels.value;
-      route.compatibility.resolved_input_device_id = endpoint.device_uid;
+      route.input_device_id = facts.device_id;
+      route.input_channel_count = facts.physical_channels;
+      route.compatibility.resolved_input_device_id =
+          resolved.value.device_uid.empty() ? requested : resolved.value.device_uid;
     }
     return true;
   };
 
-  ResolvedCoreAudioEndpoint output_endpoint;
-  if (!resolve_endpoint(true, config.output_device_id, output_endpoint)) {
+  EndpointFacts output_facts;
+  if (!resolve_endpoint(true, config.output_device_id, output_facts)) {
     return route;
   }
 
-  ResolvedCoreAudioEndpoint input_endpoint;
-  if (config.num_inputs > 0 && !resolve_endpoint(false, config.input_device_id, input_endpoint)) {
+  EndpointFacts input_facts;
+  const bool has_input = config.num_inputs > 0;
+  if (has_input && !resolve_endpoint(false, config.input_device_id, input_facts)) {
     return route;
   }
 
-  if (!resolveCoreAudioChannelMap(config.channel_map.output_channels, config.num_outputs,
-                                  route.output_channel_count, route.output_channel_map)) {
+  const auto read_transport = [&](EndpointFacts& facts, bool output) -> bool {
+    const auto transport = query_->transportType(facts.device_id);
+    if (setQueryFailure(route, transport.status, "transport", output, false)) {
+      return false;
+    }
+    facts.transport = transport.value;
+    facts.is_bluetooth = isBluetoothTransport(facts.transport);
+    return true;
+  };
+  if (!read_transport(output_facts, true)) {
+    return route;
+  }
+  if (has_input && input_facts.device_id != output_facts.device_id &&
+      !read_transport(input_facts, false)) {
+    return route;
+  }
+  if (has_input && input_facts.device_id == output_facts.device_id) {
+    input_facts.transport = output_facts.transport;
+    input_facts.is_bluetooth = output_facts.is_bluetooth;
+  }
+  route.output_transport_type = output_facts.transport;
+  route.output_is_bluetooth = output_facts.is_bluetooth;
+  route.compatibility.output_is_bluetooth = output_facts.is_bluetooth;
+  if (has_input) {
+    route.input_transport_type = input_facts.transport;
+    route.input_is_bluetooth = input_facts.is_bluetooth;
+    route.compatibility.input_is_bluetooth = input_facts.is_bluetooth;
+  }
+
+  if (has_input && input_facts.device_id != output_facts.device_id) {
+    const auto output_related = query_->relatedDeviceIDs(output_facts.device_id);
+    if (setQueryFailure(route, output_related.status, "related", true, false)) {
+      return route;
+    }
+    const auto input_related = query_->relatedDeviceIDs(input_facts.device_id);
+    if (setQueryFailure(route, input_related.status, "related", false, false)) {
+      return route;
+    }
+    route.endpoints_related = containsDevice(output_related.value, input_facts.device_id) ||
+                              containsDevice(input_related.value, output_facts.device_id);
+  } else {
+    route.endpoints_related = has_input;
+  }
+  route.compatibility.endpoints_related = route.endpoints_related;
+
+  if (requestsExplicitStereoMap(config) && route.output_channel_count == 1 &&
+      output_facts.is_bluetooth) {
+    if (config.output_channel_policy == AudioOutputChannelPolicy::AllowMonoFallback) {
+      route.output_channel_map = {0};
+      route.output_mono_fallback = true;
+      route.compatibility.output_mono_fallback_planned = true;
+    } else {
+      setFailure(route, AudioRouteCompatibilityStatus::ProfileConflict, "channels", true);
+      return route;
+    }
+  } else if (!resolveCoreAudioChannelMap(config.channel_map.output_channels, config.num_outputs,
+                                         route.output_channel_count, route.output_channel_map)) {
     setFailure(route, AudioRouteCompatibilityStatus::InvalidChannelMap, "map", true);
     return route;
   }
-  if (config.num_inputs > 0 &&
+  if (has_input &&
       !resolveCoreAudioChannelMap(config.channel_map.input_channels, config.num_inputs,
                                   route.input_channel_count, route.input_channel_map)) {
     setFailure(route, AudioRouteCompatibilityStatus::InvalidChannelMap, "map", false);
     return route;
   }
+  route.compatibility.resolved_output_channels =
+      static_cast<uint16_t>(route.output_channel_map.size());
 
-  bool output_rate_supported = false;
-  const auto output_ranges = query_->advertisedSampleRateRanges(route.output_device_id);
-  if (setQueryFailure(route, output_ranges.status, "ranges", true, false)) {
-    return route;
-  }
-  output_rate_supported = supportsRequestedRate(output_ranges.value, config.sample_rate);
-  if (!output_rate_supported) {
-    setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", true);
-    return route;
-  }
-
-  bool input_rate_supported = true;
-  if (config.num_inputs > 0 && route.input_device_id != route.output_device_id) {
-    const auto input_ranges = query_->advertisedSampleRateRanges(route.input_device_id);
-    if (setQueryFailure(route, input_ranges.status, "ranges", false, false)) {
-      return route;
+  const auto read_global_facts = [&](EndpointFacts& facts, bool output) -> bool {
+    const auto ranges = query_->advertisedSampleRateRanges(facts.device_id);
+    if (setQueryFailure(route, ranges.status, "ranges", output, false)) {
+      return false;
     }
-    input_rate_supported = supportsRequestedRate(input_ranges.value, config.sample_rate);
-    if (!input_rate_supported) {
-      setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", false);
-      return route;
+    facts.ranges = ranges.value;
+    const bool session_supported = supportsRequestedRate(facts.ranges, config.sample_rate);
+    if (config.sample_rate_policy != AudioSampleRatePolicy::RequestExactRateOrConvert &&
+        !session_supported) {
+      setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", output);
+      return false;
     }
-  }
 
-  const auto query_global_facts = [&](AudioDeviceID device_id, bool output, uint32_t& rate,
-                                      bool& running) -> bool {
-    const auto current = query_->currentSampleRate(device_id);
+    const auto current = query_->currentSampleRate(facts.device_id);
     if (setQueryFailure(route, current.status, "current_rate", output, false)) {
       return false;
     }
-    if (!normalizeCurrentSampleRate(current.value, rate)) {
+    if (!normalizeCurrentSampleRate(current.value, facts.observed_rate)) {
       setFailure(route, AudioRouteCompatibilityStatus::BackendFailure, "current_rate", output);
       return false;
     }
-    const auto is_running = query_->isRunningSomewhere(device_id);
-    if (setQueryFailure(route, is_running.status, "running", output, false)) {
+    if (!isConverterRate(facts.observed_rate) ||
+        !supportsRequestedRate(facts.ranges, facts.observed_rate)) {
+      setFailure(route, AudioRouteCompatibilityStatus::SampleRateUnsupported, "ranges", output);
       return false;
     }
-    running = is_running.value;
+
+    const auto running = query_->isRunningSomewhere(facts.device_id);
+    if (setQueryFailure(route, running.status, "running", output, false)) {
+      return false;
+    }
+    facts.running = running.value;
+
+    const auto settable = query_->nominalSampleRateSettable(facts.device_id);
+    if (setQueryFailure(route, settable.status, "settable", output, false)) {
+      return false;
+    }
+    facts.settable = settable.value;
     return true;
   };
 
-  uint32_t output_current_rate = 0;
-  bool output_running = false;
-  if (!query_global_facts(route.output_device_id, true, output_current_rate, output_running)) {
+  const auto read_stream_facts = [&](EndpointFacts& facts, bool output) -> bool {
+    const auto physical = query_->physicalStreamFormat(
+        facts.device_id, output ? kAudioObjectPropertyScopeOutput : kAudioObjectPropertyScopeInput);
+    if (setQueryFailure(route, physical.status, "physical_format", output, false)) {
+      return false;
+    }
+    facts.physical_format = physical.value;
+    const auto virtual_format = query_->virtualStreamFormat(
+        facts.device_id, output ? kAudioObjectPropertyScopeOutput : kAudioObjectPropertyScopeInput);
+    if (setQueryFailure(route, virtual_format.status, "virtual_format", output, false)) {
+      return false;
+    }
+    facts.virtual_format = virtual_format.value;
+    return true;
+  };
+
+  if (!read_global_facts(output_facts, true) || !read_stream_facts(output_facts, true)) {
     return route;
   }
-
-  uint32_t input_current_rate = 0;
-  bool input_running = false;
-  if (config.num_inputs > 0) {
-    if (route.input_device_id == route.output_device_id) {
-      input_current_rate = output_current_rate;
-      input_running = output_running;
-    } else if (!query_global_facts(route.input_device_id, false, input_current_rate,
-                                   input_running)) {
+  if (has_input) {
+    if (input_facts.device_id == output_facts.device_id) {
+      input_facts.observed_rate = output_facts.observed_rate;
+      input_facts.running = output_facts.running;
+      input_facts.settable = output_facts.settable;
+      input_facts.ranges = output_facts.ranges;
+    } else if (!read_global_facts(input_facts, false)) {
+      return route;
+    }
+    if (!read_stream_facts(input_facts, false)) {
       return route;
     }
   }
 
-  route.compatibility.current_output_sample_rate = output_current_rate;
-  route.compatibility.output_is_running_somewhere = output_running;
-  route.compatibility.output_rate_change_required = output_current_rate != config.sample_rate;
-  if (config.num_inputs > 0) {
-    route.compatibility.current_input_sample_rate = input_current_rate;
-    route.compatibility.input_is_running_somewhere = input_running;
-    route.compatibility.input_rate_change_required = input_current_rate != config.sample_rate;
+  route.output_physical_format = output_facts.physical_format;
+  route.output_virtual_format = output_facts.virtual_format;
+  route.compatibility.output_virtual_format_channels = output_facts.virtual_format.channels;
+  route.compatibility.current_output_sample_rate = output_facts.observed_rate;
+  route.compatibility.output_is_running_somewhere = output_facts.running;
+  route.compatibility.output_rate_change_required =
+      output_facts.observed_rate != config.sample_rate;
+  if (has_input) {
+    route.input_physical_format = input_facts.physical_format;
+    route.input_virtual_format = input_facts.virtual_format;
+    route.compatibility.input_virtual_format_channels = input_facts.virtual_format.channels;
+    route.compatibility.current_input_sample_rate = input_facts.observed_rate;
+    route.compatibility.input_is_running_somewhere = input_facts.running;
+    route.compatibility.input_rate_change_required =
+        input_facts.observed_rate != config.sample_rate;
   }
 
-  const bool rate_change_required = route.compatibility.output_rate_change_required ||
-                                    route.compatibility.input_rate_change_required;
-  route.compatibility.status =
-      rate_change_required && config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate
-          ? AudioRouteCompatibilityStatus::RequiresSampleRateChange
-          : AudioRouteCompatibilityStatus::Compatible;
+  route.device_rate_plans.reserve(2);
+  const auto add_plan = [&](AudioDeviceID device_id,
+                            uint32_t observed_rate) -> CoreAudioDeviceRatePlan& {
+    for (auto& plan : route.device_rate_plans) {
+      if (plan.device_id == device_id) {
+        return plan;
+      }
+    }
+    route.device_rate_plans.push_back(CoreAudioDeviceRatePlan{});
+    auto& plan = route.device_rate_plans.back();
+    plan.device_id = device_id;
+    plan.observed_rate = observed_rate;
+    return plan;
+  };
+  auto& output_plan = add_plan(output_facts.device_id, output_facts.observed_rate);
+  CoreAudioDeviceRatePlan* input_plan = nullptr;
+  if (has_input) {
+    input_plan = &add_plan(input_facts.device_id, input_facts.observed_rate);
+  }
+
+  const bool exact_policy = config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRate;
+  const bool conversion_policy =
+      config.sample_rate_policy == AudioSampleRatePolicy::RequestExactRateOrConvert;
+  const bool related_bluetooth_duplex =
+      has_input && route.endpoints_related && input_facts.is_bluetooth && output_facts.is_bluetooth;
+  const bool unrelated_bluetooth_duplex = has_input && !route.endpoints_related &&
+                                          input_facts.is_bluetooth && output_facts.is_bluetooth;
+
+  const auto can_write_rate = [&](const EndpointFacts& facts) {
+    return !facts.running && facts.settable &&
+           supportsRequestedRate(facts.ranges, config.sample_rate);
+  };
+  const auto write_if_safe = [&](const EndpointFacts& facts, CoreAudioDeviceRatePlan& plan,
+                                 bool allow_write) {
+    if (allow_write && allow_rate_writes && facts.observed_rate != config.sample_rate &&
+        can_write_rate(facts)) {
+      plan.requested_write_rate = config.sample_rate;
+      return true;
+    }
+    return false;
+  };
+
+  bool input_converts = has_input && input_facts.observed_rate != config.sample_rate;
+  bool output_converts = output_facts.observed_rate != config.sample_rate;
+  if (conversion_policy) {
+    const bool output_is_unrelated_mac = !output_facts.is_bluetooth && has_input &&
+                                         input_facts.is_bluetooth && !route.endpoints_related;
+    const bool output_write_allowed = !related_bluetooth_duplex && !unrelated_bluetooth_duplex &&
+                                              (!output_facts.is_bluetooth || !has_input) &&
+                                              !output_is_unrelated_mac
+                                          ? true
+                                          : output_is_unrelated_mac;
+    const bool input_write_allowed =
+        !input_facts.is_bluetooth && !related_bluetooth_duplex && !unrelated_bluetooth_duplex;
+    if (has_input && input_plan != &output_plan) {
+      (void)write_if_safe(input_facts, *input_plan, input_write_allowed);
+    } else if (has_input) {
+      (void)write_if_safe(input_facts, output_plan, input_write_allowed);
+    }
+    (void)write_if_safe(output_facts, output_plan, output_write_allowed);
+    input_converts = has_input && input_facts.observed_rate != config.sample_rate &&
+                     (!input_plan || !input_plan->requested_write_rate.has_value());
+    output_converts = output_facts.observed_rate != config.sample_rate &&
+                      !output_plan.requested_write_rate.has_value();
+  } else if (exact_policy) {
+    if (has_input && input_plan != &output_plan) {
+      if (!write_if_safe(input_facts, *input_plan,
+                         !input_facts.is_bluetooth && !related_bluetooth_duplex)) {
+        input_converts = false;
+      } else {
+        input_converts = false;
+      }
+    } else if (has_input && input_facts.observed_rate != config.sample_rate) {
+      (void)write_if_safe(input_facts, output_plan, !input_facts.is_bluetooth);
+      input_converts = false;
+    }
+    (void)write_if_safe(output_facts, output_plan,
+                        !related_bluetooth_duplex && !unrelated_bluetooth_duplex);
+  }
+
+  if (input_plan != nullptr) {
+    input_plan->input_uses_external_src = input_converts;
+  }
+  output_plan.output_uses_external_src = output_converts;
+  if (input_plan == &output_plan) {
+    output_plan.output_uses_external_src = output_converts;
+    output_plan.input_uses_external_src = input_converts;
+  }
+
+  if (exact_policy) {
+    const bool exact_input_failure = has_input && input_facts.observed_rate != config.sample_rate &&
+                                     (!input_plan || !input_plan->requested_write_rate.has_value());
+    const bool exact_output_failure = output_facts.observed_rate != config.sample_rate &&
+                                      !output_plan.requested_write_rate.has_value();
+    if (exact_input_failure || exact_output_failure) {
+      const bool bluetooth_conflict = (exact_input_failure && input_facts.is_bluetooth) ||
+                                      (exact_output_failure && output_facts.is_bluetooth) ||
+                                      related_bluetooth_duplex;
+      route.resolved = false;
+      route.compatibility.status = bluetooth_conflict
+                                       ? AudioRouteCompatibilityStatus::ProfileConflict
+                                       : AudioRouteCompatibilityStatus::RequiresSampleRateChange;
+      route.compatibility.detail.clear();
+      return route;
+    }
+    input_converts = false;
+    output_converts = false;
+  }
+
+  route.compatibility.planned_input_client_rate =
+      has_input ? (input_converts ? input_facts.observed_rate : config.sample_rate) : 0;
+  route.compatibility.planned_output_client_rate =
+      output_converts ? output_facts.observed_rate : config.sample_rate;
+  route.compatibility.input_conversion_required = input_converts;
+  route.compatibility.output_conversion_required = output_converts;
+  route.compatibility.requires_post_bind_reprobe =
+      has_input && (input_facts.is_bluetooth || related_bluetooth_duplex);
+  route.requires_private_aggregate =
+      has_input && input_facts.device_id != output_facts.device_id && !input_converts;
   route.compatibility.detail.clear();
   route.resolved = true;
-  route.requires_private_aggregate =
-      config.num_inputs > 0 && route.input_device_id != route.output_device_id;
-  (void)input_rate_supported;
+  route.compatibility.status = AudioRouteCompatibilityStatus::Compatible;
   return route;
 }
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_resolver.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -31,6 +32,19 @@ struct ResolvedCoreAudioEndpoint {
   std::string device_uid;
 };
 
+struct CoreAudioStreamFormat {
+  uint32_t sample_rate = 0;
+  uint16_t channels = 0;
+};
+
+struct CoreAudioDeviceRatePlan {
+  AudioDeviceID device_id = 0;
+  uint32_t observed_rate = 0;
+  std::optional<uint32_t> requested_write_rate;
+  bool input_uses_external_src = false;
+  bool output_uses_external_src = false;
+};
+
 class ICoreAudioRouteQuery {
 public:
   virtual ~ICoreAudioRouteQuery() = default;
@@ -45,6 +59,18 @@ public:
   advertisedSampleRateRanges(AudioDeviceID device_id) const = 0;
   virtual CoreAudioRouteQueryResult<double> currentSampleRate(AudioDeviceID device_id) const = 0;
   virtual CoreAudioRouteQueryResult<bool> isRunningSomewhere(AudioDeviceID device_id) const = 0;
+
+  virtual CoreAudioRouteQueryResult<uint32_t> transportType(AudioDeviceID device_id) const = 0;
+  virtual CoreAudioRouteQueryResult<std::vector<AudioDeviceID>>
+  relatedDeviceIDs(AudioDeviceID device_id) const = 0;
+  virtual CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  physicalStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const = 0;
+  virtual CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  virtualStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const = 0;
+  virtual CoreAudioRouteQueryResult<bool>
+  nominalSampleRateSettable(AudioDeviceID device_id) const = 0;
+  virtual CoreAudioRouteQueryResult<uint32_t>
+  physicalChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const = 0;
 };
 
 struct ResolvedCoreAudioRoute {
@@ -56,6 +82,17 @@ struct ResolvedCoreAudioRoute {
   uint32_t output_channel_count = 0;
   std::vector<uint16_t> input_channel_map;
   std::vector<uint16_t> output_channel_map;
+  std::vector<CoreAudioDeviceRatePlan> device_rate_plans;
+  CoreAudioStreamFormat input_physical_format;
+  CoreAudioStreamFormat output_physical_format;
+  CoreAudioStreamFormat input_virtual_format;
+  CoreAudioStreamFormat output_virtual_format;
+  uint32_t input_transport_type = 0;
+  uint32_t output_transport_type = 0;
+  bool input_is_bluetooth = false;
+  bool output_is_bluetooth = false;
+  bool endpoints_related = false;
+  bool output_mono_fallback = false;
   bool requires_private_aggregate = false;
 };
 
@@ -65,7 +102,8 @@ bool resolveCoreAudioChannelMap(const std::vector<uint16_t>& requested, uint16_t
 class CoreAudioRouteResolver {
 public:
   explicit CoreAudioRouteResolver(std::shared_ptr<const ICoreAudioRouteQuery> query);
-  ResolvedCoreAudioRoute resolve(const AudioDriverConfig& config) const;
+  ResolvedCoreAudioRoute resolve(const AudioDriverConfig& config,
+                                 bool allow_rate_writes = true) const;
 
 private:
   std::shared_ptr<const ICoreAudioRouteQuery> query_;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_transaction.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_transaction.cpp
@@ -8,16 +8,20 @@
 namespace orpheus {
 
 CoreAudioSampleRateTransaction::CoreAudioSampleRateTransaction(
-    ICoreAudioPropertyApi& property_api, const detail::ResolvedCoreAudioRoute& route,
-    uint32_t requested_rate, std::chrono::milliseconds timeout) noexcept
-    : property_api_(property_api), requested_rate_(static_cast<Float64>(requested_rate)),
-      timeout_(timeout) {
-  if (route.output_device_id != 0) {
-    endpoints_[endpoint_count_++].device_id = route.output_device_id;
-  }
-  if (route.input_device_id != 0 && route.input_device_id != route.output_device_id &&
-      endpoint_count_ < endpoints_.size()) {
-    endpoints_[endpoint_count_++].device_id = route.input_device_id;
+    ICoreAudioPropertyApi& property_api, const std::vector<detail::CoreAudioDeviceRatePlan>& plans,
+    std::chrono::milliseconds timeout) noexcept
+    : property_api_(property_api), timeout_(timeout) {
+  for (const auto& plan : plans) {
+    if (plan.device_id == 0) {
+      continue;
+    }
+    has_plans_ = true;
+    if (!plan.requested_write_rate.has_value() || endpoint_count_ >= endpoints_.size()) {
+      continue;
+    }
+    auto& endpoint = endpoints_[endpoint_count_++];
+    endpoint.device_id = plan.device_id;
+    endpoint.requested_rate = static_cast<Float64>(*plan.requested_write_rate);
   }
 }
 
@@ -28,8 +32,17 @@ CoreAudioSampleRateTransaction::~CoreAudioSampleRateTransaction() {
 }
 
 AudioRouteRuntimeOutcome CoreAudioSampleRateTransaction::begin() noexcept {
-  if (begun_ || committed_ || endpoint_count_ == 0 || requested_rate_ <= 0.0) {
+  if (begun_ || committed_ || !has_plans_) {
     return fail(AudioRouteRuntimeOutcome::BackendFailure);
+  }
+  if (endpoint_count_ == 0) {
+    begun_ = true;
+    return AudioRouteRuntimeOutcome::Healthy;
+  }
+  for (size_t index = 0; index < endpoint_count_; ++index) {
+    if (endpoints_[index].requested_rate <= 0.0) {
+      return fail(AudioRouteRuntimeOutcome::BackendFailure);
+    }
   }
   begun_ = true;
 
@@ -42,7 +55,7 @@ AudioRouteRuntimeOutcome CoreAudioSampleRateTransaction::begin() noexcept {
       return fail(AudioRouteRuntimeOutcome::BackendFailure);
     }
     endpoint.previous_rate = current_rate;
-    endpoint.needs_change = current_rate != requested_rate_;
+    endpoint.needs_change = current_rate != endpoint.requested_rate;
     endpoint.confirmed = !endpoint.needs_change;
     any_change = any_change || endpoint.needs_change;
   }
@@ -84,8 +97,8 @@ AudioRouteRuntimeOutcome CoreAudioSampleRateTransaction::begin() noexcept {
       continue;
     }
     endpoint.write_started = true;
-    if (property_api_.setPropertyData(endpoint.device_id, &address, sizeof(requested_rate_),
-                                      &requested_rate_) != noErr) {
+    if (property_api_.setPropertyData(endpoint.device_id, &address, sizeof(endpoint.requested_rate),
+                                      &endpoint.requested_rate) != noErr) {
       return fail(AudioRouteRuntimeOutcome::SampleRateChangeFailed);
     }
   }
@@ -104,7 +117,7 @@ AudioRouteRuntimeOutcome CoreAudioSampleRateTransaction::begin() noexcept {
         if (!readRate(endpoint, observed_rate)) {
           return fail(AudioRouteRuntimeOutcome::BackendFailure);
         }
-        if (observed_rate == requested_rate_) {
+        if (observed_rate == endpoint.requested_rate) {
           endpoint.confirmed = true;
         }
       }
@@ -189,7 +202,7 @@ void CoreAudioSampleRateTransaction::rollback() noexcept {
     UInt32 size = sizeof(current_rate);
     if (property_api_.getPropertyData(endpoint.device_id, &address, &size, &current_rate) !=
             noErr ||
-        size != sizeof(current_rate) || current_rate != requested_rate_) {
+        size != sizeof(current_rate) || current_rate != endpoint.requested_rate) {
       continue;
     }
     property_api_.setPropertyData(endpoint.device_id, &address, sizeof(endpoint.previous_rate),

--- a/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_transaction.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_sample_rate_transaction.h
@@ -13,14 +13,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <vector>
 
 namespace orpheus {
 
 /// Bounded, listener-confirmed activation transaction for physical endpoints.
 class CoreAudioSampleRateTransaction final {
 public:
-  CoreAudioSampleRateTransaction(ICoreAudioPropertyApi&, const detail::ResolvedCoreAudioRoute&,
-                                 uint32_t requested_rate,
+  CoreAudioSampleRateTransaction(ICoreAudioPropertyApi&,
+                                 const std::vector<detail::CoreAudioDeviceRatePlan>&,
                                  std::chrono::milliseconds timeout = std::chrono::seconds{
                                      2}) noexcept;
   ~CoreAudioSampleRateTransaction();
@@ -34,6 +35,7 @@ public:
 private:
   struct Endpoint {
     AudioDeviceID device_id = 0;
+    Float64 requested_rate = 0.0;
     Float64 previous_rate = 0.0;
     bool needs_change = false;
     bool write_started = false;
@@ -54,8 +56,8 @@ private:
   ICoreAudioPropertyApi& property_api_;
   std::array<Endpoint, 2> endpoints_{};
   size_t endpoint_count_{0};
-  const Float64 requested_rate_;
   const std::chrono::milliseconds timeout_;
+  bool has_plans_{false};
   std::atomic<uint32_t> notification_bits_{0};
   std::condition_variable notification_changed_;
   std::mutex notification_mutex_;

--- a/tests/audio_io/CMakeLists.txt
+++ b/tests/audio_io/CMakeLists.txt
@@ -4,6 +4,7 @@
 # orpheus_audio_utils (no libsndfile, no JUCE, host-neutral).
 add_executable(polyphase_resampler_test
     polyphase_resampler_test.cpp
+    directional_sample_rate_converter_test.cpp
 )
 
 target_link_libraries(polyphase_resampler_test

--- a/tests/audio_io/coreaudio_output_only_injected_test.cpp
+++ b/tests/audio_io/coreaudio_output_only_injected_test.cpp
@@ -73,6 +73,48 @@ public:
     }
     return {detail::CoreAudioRouteQueryStatus::Success, false};
   }
+  detail::CoreAudioRouteQueryResult<uint32_t>
+  transportType(AudioDeviceID device_id) const override {
+    if (device_id != output_id_) {
+      return {detail::CoreAudioRouteQueryStatus::Missing, 0};
+    }
+    return {detail::CoreAudioRouteQueryStatus::Success, kAudioDeviceTransportTypeBuiltIn};
+  }
+
+  detail::CoreAudioRouteQueryResult<std::vector<AudioDeviceID>>
+  relatedDeviceIDs(AudioDeviceID device_id) const override {
+    if (device_id != output_id_) {
+      return {detail::CoreAudioRouteQueryStatus::Missing, {}};
+    }
+    return {detail::CoreAudioRouteQueryStatus::Success, {output_id_}};
+  }
+
+  detail::CoreAudioRouteQueryResult<detail::CoreAudioStreamFormat>
+  physicalStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    if (device_id != output_id_ || scope != kAudioObjectPropertyScopeOutput) {
+      return {detail::CoreAudioRouteQueryStatus::Missing, {}};
+    }
+    return {detail::CoreAudioRouteQueryStatus::Success,
+            {static_cast<uint32_t>(rate_), static_cast<uint16_t>(channels_)}};
+  }
+
+  detail::CoreAudioRouteQueryResult<detail::CoreAudioStreamFormat>
+  virtualStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    return physicalStreamFormat(device_id, scope);
+  }
+
+  detail::CoreAudioRouteQueryResult<bool>
+  nominalSampleRateSettable(AudioDeviceID device_id) const override {
+    if (device_id != output_id_) {
+      return {detail::CoreAudioRouteQueryStatus::Missing, false};
+    }
+    return {detail::CoreAudioRouteQueryStatus::Success, true};
+  }
+
+  detail::CoreAudioRouteQueryResult<uint32_t>
+  physicalChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    return channelCount(device_id, scope);
+  }
 
 private:
   AudioDeviceID output_id_;

--- a/tests/audio_io/coreaudio_route_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_route_monitor_test.cpp
@@ -71,6 +71,29 @@ TEST(CoreAudioRouteMonitorTest, RegistersInSuppliedOrderAndCleansUp) {
   EXPECT_EQ(fixture.api.listenerCount(), 0u);
 }
 
+TEST(CoreAudioRouteMonitorTest, DeduplicatesSharedDeviceAndStreamRegistrations) {
+  FakeCoreAudioPropertyApi api;
+  api.setAlive(1, 1);
+  api.setRate(1, 48000.0);
+  api.setBuffer(1, 512);
+  const AudioStreamBasicDescription format = testFormat();
+  api.setFormat(100, kAudioStreamPropertyVirtualFormat, format);
+  api.setFormat(100, kAudioStreamPropertyPhysicalFormat, format);
+
+  CoreAudioRouteMonitor monitor(
+      api, 48000, 512,
+      std::vector<CoreAudioRouteDevice>{{1, true, false, false, 48000},
+                                        {1, false, true, false, 48000}},
+      std::vector<CoreAudioRouteStream>{{100, format, format}, {100, format, format}});
+
+  ASSERT_TRUE(monitor.start());
+  EXPECT_EQ(api.listenerCount(), 5u);
+  monitor.requestCheck();
+  EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+  monitor.stop();
+  EXPECT_EQ(api.listenerCount(), 0u);
+}
+
 TEST(CoreAudioRouteMonitorTest, AliveLossClosesAdmissionAndReportsOutputUnavailable) {
   RouteMonitorFixture fixture;
   ASSERT_TRUE(fixture.initialization_ok);

--- a/tests/audio_io/coreaudio_route_probe_test.cpp
+++ b/tests/audio_io/coreaudio_route_probe_test.cpp
@@ -16,7 +16,10 @@ namespace {
 using detail::CoreAudioEndpointRange;
 using detail::CoreAudioRouteQueryResult;
 using detail::CoreAudioRouteQueryStatus;
+using detail::CoreAudioRouteResolver;
+using detail::CoreAudioStreamFormat;
 using detail::ICoreAudioRouteQuery;
+
 using detail::ResolvedCoreAudioEndpoint;
 
 struct FakeLedger {
@@ -28,6 +31,12 @@ struct FakeLedger {
   int sample_rate_range_reads = 0;
   int current_rate_reads = 0;
   int running_reads = 0;
+  int transport_reads = 0;
+  int related_reads = 0;
+  int physical_format_reads = 0;
+  int virtual_format_reads = 0;
+  int settable_reads = 0;
+  int physical_channel_reads = 0;
   int property_writes = 0;
   int aggregate_requests = 0;
   int auhal_actions = 0;
@@ -50,6 +59,18 @@ struct FakeEndpoint {
   CoreAudioRouteQueryStatus current_rate_status = CoreAudioRouteQueryStatus::Success;
   bool is_running_somewhere = false;
   CoreAudioRouteQueryStatus running_status = CoreAudioRouteQueryStatus::Success;
+  uint32_t transport_type = kAudioDeviceTransportTypeBuiltIn;
+  std::vector<AudioDeviceID> related_device_ids;
+  CoreAudioStreamFormat input_physical_format{48000, 0};
+  CoreAudioStreamFormat output_physical_format{48000, 0};
+  CoreAudioStreamFormat input_virtual_format{48000, 0};
+  CoreAudioStreamFormat output_virtual_format{48000, 0};
+  CoreAudioRouteQueryStatus transport_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus related_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus physical_format_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus virtual_format_status = CoreAudioRouteQueryStatus::Success;
+  CoreAudioRouteQueryStatus settable_status = CoreAudioRouteQueryStatus::Success;
+  bool nominal_sample_rate_settable = true;
 };
 
 template <typename T>
@@ -134,6 +155,79 @@ public:
     }
     return fakeResult(endpoint->second.running_status, endpoint->second.is_running_somewhere);
   }
+  CoreAudioRouteQueryResult<uint32_t> transportType(AudioDeviceID device_id) const override {
+    ++ledger.transport_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<uint32_t>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.transport_status, endpoint->second.transport_type);
+  }
+
+  CoreAudioRouteQueryResult<std::vector<AudioDeviceID>>
+  relatedDeviceIDs(AudioDeviceID device_id) const override {
+    ++ledger.related_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<std::vector<AudioDeviceID>>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.related_status, endpoint->second.related_device_ids);
+  }
+
+  CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  physicalStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    ++ledger.physical_format_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<CoreAudioStreamFormat>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.physical_format_status,
+                      scope == kAudioObjectPropertyScopeOutput
+                          ? endpoint->second.output_physical_format
+                          : endpoint->second.input_physical_format);
+  }
+
+  CoreAudioRouteQueryResult<CoreAudioStreamFormat>
+  virtualStreamFormat(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    ++ledger.virtual_format_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<CoreAudioStreamFormat>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.virtual_format_status,
+                      scope == kAudioObjectPropertyScopeOutput
+                          ? endpoint->second.output_virtual_format
+                          : endpoint->second.input_virtual_format);
+  }
+
+  CoreAudioRouteQueryResult<bool>
+  nominalSampleRateSettable(AudioDeviceID device_id) const override {
+    ++ledger.settable_reads;
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<bool>(CoreAudioRouteQueryStatus::Missing);
+    }
+    return fakeResult(endpoint->second.settable_status,
+                      endpoint->second.nominal_sample_rate_settable);
+  }
+
+  CoreAudioRouteQueryResult<uint32_t>
+  physicalChannelCount(AudioDeviceID device_id, AudioObjectPropertyScope scope) const override {
+    ++ledger.physical_channel_reads;
+    if (scope == kAudioObjectPropertyScopeOutput) {
+      ++ledger.output_channel_reads;
+    } else {
+      ++ledger.input_channel_reads;
+    }
+    const auto endpoint = endpoints.find(device_id);
+    if (endpoint == endpoints.end()) {
+      return fakeResult<uint32_t>(CoreAudioRouteQueryStatus::Missing);
+    }
+    if (scope == kAudioObjectPropertyScopeOutput) {
+      return fakeResult(endpoint->second.output_channel_status, endpoint->second.output_channels);
+    }
+    return fakeResult(endpoint->second.input_channel_status, endpoint->second.input_channels);
+  }
 
   void resetLedger() const {
     ledger = {};
@@ -176,9 +270,35 @@ void installSameDevice(FakeCoreAudioRouteQuery& fake) {
   endpoint.sample_rate_ranges = {{44100.0, 96000.0}};
   endpoint.current_sample_rate = 48000.0;
   endpoint.is_running_somewhere = true;
+  endpoint.related_device_ids = {endpoint.device_id};
+  endpoint.input_physical_format = {48000, 2};
+  endpoint.output_physical_format = {48000, 2};
+  endpoint.input_virtual_format = {48000, 2};
+  endpoint.output_virtual_format = {48000, 2};
   fake.endpoints.emplace(endpoint.device_id, endpoint);
   fake.default_input = endpoint.device_id;
   fake.default_output = endpoint.device_id;
+}
+
+FakeEndpoint makeEndpoint(AudioDeviceID device_id, std::string uid, uint32_t input_channels,
+                          uint32_t output_channels, uint32_t current_rate, uint32_t transport,
+                          std::vector<CoreAudioEndpointRange> ranges,
+                          std::vector<AudioDeviceID> related = {}) {
+  FakeEndpoint endpoint;
+  endpoint.device_id = device_id;
+  endpoint.device_uid = std::move(uid);
+  endpoint.input_channels = input_channels;
+  endpoint.output_channels = output_channels;
+  endpoint.sample_rate_ranges = std::move(ranges);
+  endpoint.current_sample_rate = static_cast<double>(current_rate);
+  endpoint.transport_type = transport;
+  endpoint.related_device_ids =
+      related.empty() ? std::vector<AudioDeviceID>{device_id} : std::move(related);
+  endpoint.input_physical_format = {current_rate, static_cast<uint16_t>(input_channels)};
+  endpoint.output_physical_format = {current_rate, static_cast<uint16_t>(output_channels)};
+  endpoint.input_virtual_format = {current_rate, static_cast<uint16_t>(input_channels)};
+  endpoint.output_virtual_format = {current_rate, static_cast<uint16_t>(output_channels)};
+  return endpoint;
 }
 
 void expectNoProhibitedActions(const FakeLedger& ledger) {
@@ -519,6 +639,180 @@ TEST(CoreAudioRouteProbeTest, ProbeDoesNotMutateCoreAudioDriverState) {
   EXPECT_EQ(after_state.requested_sample_rate, before_state.requested_sample_rate);
   EXPECT_EQ(after_state.actual_sample_rate, before_state.actual_sample_rate);
   expectNoProhibitedActions(fake->ledger);
+}
+TEST(CoreAudioRouteProbeTest, BluetoothInputUsesNativeRateAndWritesOnlyDistinctMacOutput) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  fake->endpoints.emplace(12, makeEndpoint(12, "bt-input", 1, 0, 16000,
+                                           kAudioDeviceTransportTypeBluetooth, {{16000.0, 16000.0}},
+                                           {12}));
+  fake->endpoints.emplace(11, makeEndpoint(11, "mac-output", 0, 2, 44100,
+                                           kAudioDeviceTransportTypeBuiltIn,
+                                           {{44100.0, 44100.0}, {48000.0, 48000.0}}, {11}));
+  CoreAudioRouteResolver resolver(fake);
+
+  auto config = duplexConfig();
+  config.num_inputs = 1;
+  config.input_device_id = "bt-input";
+  config.output_device_id = "mac-output";
+  config.channel_map.output_channels = {0, 1};
+  config.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+
+  const auto route = resolver.resolve(config);
+
+  ASSERT_TRUE(route.resolved);
+  ASSERT_EQ(route.compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_TRUE(route.compatibility.input_conversion_required);
+  EXPECT_FALSE(route.compatibility.output_conversion_required);
+  EXPECT_EQ(route.compatibility.planned_input_client_rate, 16000u);
+  EXPECT_EQ(route.compatibility.planned_output_client_rate, 48000u);
+  EXPECT_TRUE(route.compatibility.input_is_bluetooth);
+  EXPECT_FALSE(route.compatibility.output_is_bluetooth);
+  EXPECT_FALSE(route.compatibility.endpoints_related);
+  EXPECT_TRUE(route.compatibility.requires_post_bind_reprobe);
+  ASSERT_EQ(route.device_rate_plans.size(), 2u);
+  const auto input_plan =
+      std::find_if(route.device_rate_plans.begin(), route.device_rate_plans.end(),
+                   [](const auto& plan) { return plan.device_id == 12; });
+  const auto output_plan =
+      std::find_if(route.device_rate_plans.begin(), route.device_rate_plans.end(),
+                   [](const auto& plan) { return plan.device_id == 11; });
+  ASSERT_NE(input_plan, route.device_rate_plans.end());
+  ASSERT_NE(output_plan, route.device_rate_plans.end());
+  EXPECT_FALSE(input_plan->requested_write_rate.has_value());
+  EXPECT_TRUE(input_plan->input_uses_external_src);
+  ASSERT_TRUE(output_plan->requested_write_rate.has_value());
+  EXPECT_EQ(*output_plan->requested_write_rate, 48000u);
+  EXPECT_FALSE(output_plan->output_uses_external_src);
+}
+
+TEST(CoreAudioRouteProbeTest, RelatedBluetoothDuplexConvertsBothAndStrictPolicyConflicts) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  fake->endpoints.emplace(20, makeEndpoint(20, "headset", 2, 2, 16000,
+                                           kAudioDeviceTransportTypeBluetooth,
+                                           {{16000.0, 16000.0}, {48000.0, 48000.0}}, {20}));
+  CoreAudioRouteResolver resolver(fake);
+
+  auto conversion = duplexConfig();
+  conversion.input_device_id = "headset";
+  conversion.output_device_id = "headset";
+  conversion.channel_map.input_channels = {0, 1};
+  conversion.channel_map.output_channels = {0, 1};
+  conversion.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+
+  const auto converted = resolver.resolve(conversion);
+
+  ASSERT_TRUE(converted.resolved);
+  ASSERT_EQ(converted.compatibility.status, AudioRouteCompatibilityStatus::Compatible);
+  EXPECT_TRUE(converted.compatibility.input_conversion_required);
+  EXPECT_TRUE(converted.compatibility.output_conversion_required);
+  EXPECT_EQ(converted.compatibility.planned_input_client_rate, 16000u);
+  EXPECT_EQ(converted.compatibility.planned_output_client_rate, 16000u);
+  EXPECT_TRUE(converted.compatibility.input_is_bluetooth);
+  EXPECT_TRUE(converted.compatibility.output_is_bluetooth);
+  EXPECT_TRUE(converted.compatibility.endpoints_related);
+  ASSERT_EQ(converted.device_rate_plans.size(), 1u);
+  EXPECT_FALSE(converted.device_rate_plans.front().requested_write_rate.has_value());
+  EXPECT_TRUE(converted.device_rate_plans.front().input_uses_external_src);
+  EXPECT_TRUE(converted.device_rate_plans.front().output_uses_external_src);
+
+  conversion.sample_rate_policy = AudioSampleRatePolicy::RequestExactRate;
+  const auto strict = resolver.resolve(conversion);
+  EXPECT_FALSE(strict.resolved);
+  EXPECT_EQ(strict.compatibility.status, AudioRouteCompatibilityStatus::ProfileConflict);
+  EXPECT_TRUE(strict.compatibility.input_is_bluetooth);
+  EXPECT_TRUE(strict.compatibility.output_is_bluetooth);
+}
+
+TEST(CoreAudioRouteProbeTest, UnrelatedBluetoothDuplexPreservesBothNativeRatesWithoutWrites) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  fake->endpoints.emplace(21, makeEndpoint(21, "bt-input", 2, 0, 16000,
+                                           kAudioDeviceTransportTypeBluetooth, {{16000.0, 16000.0}},
+                                           {21}));
+  fake->endpoints.emplace(22, makeEndpoint(22, "bt-output", 0, 2, 24000,
+                                           kAudioDeviceTransportTypeBluetooth, {{24000.0, 24000.0}},
+                                           {22}));
+  CoreAudioRouteResolver resolver(fake);
+
+  auto config = duplexConfig();
+  config.input_device_id = "bt-input";
+  config.output_device_id = "bt-output";
+  config.channel_map.input_channels = {0, 1};
+  config.channel_map.output_channels = {0, 1};
+  config.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+
+  const auto route = resolver.resolve(config);
+
+  ASSERT_TRUE(route.resolved);
+  EXPECT_FALSE(route.compatibility.endpoints_related);
+  EXPECT_TRUE(route.compatibility.input_conversion_required);
+  EXPECT_TRUE(route.compatibility.output_conversion_required);
+  EXPECT_EQ(route.compatibility.planned_input_client_rate, 16000u);
+  EXPECT_EQ(route.compatibility.planned_output_client_rate, 24000u);
+  EXPECT_FALSE(route.requires_private_aggregate);
+  ASSERT_EQ(route.device_rate_plans.size(), 2u);
+  for (const auto& plan : route.device_rate_plans) {
+    EXPECT_FALSE(plan.requested_write_rate.has_value());
+  }
+}
+
+TEST(CoreAudioRouteProbeTest, BluetoothOutputOnlyNeverQueriesInputAndWritesWhenSafe) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  fake->default_input_status = CoreAudioRouteQueryStatus::PermissionDenied;
+  fake->endpoints.emplace(30, makeEndpoint(30, "bt-output", 0, 2, 16000,
+                                           kAudioDeviceTransportTypeBluetooth,
+                                           {{16000.0, 16000.0}, {48000.0, 48000.0}}, {30}));
+  CoreAudioRouteResolver resolver(fake);
+
+  auto config = duplexConfig();
+  config.num_inputs = 0;
+  config.input_device_id = "stale-input";
+  config.output_device_id = "bt-output";
+  config.channel_map.input_channels = {99, 99};
+  config.channel_map.output_channels = {0, 1};
+  config.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+
+  const auto route = resolver.resolve(config);
+
+  ASSERT_TRUE(route.resolved);
+  EXPECT_EQ(route.compatibility.current_input_sample_rate, 0u);
+  EXPECT_FALSE(route.compatibility.input_is_bluetooth);
+  EXPECT_TRUE(route.compatibility.output_is_bluetooth);
+  EXPECT_FALSE(route.compatibility.output_conversion_required);
+  ASSERT_EQ(route.device_rate_plans.size(), 1u);
+  ASSERT_TRUE(route.device_rate_plans.front().requested_write_rate.has_value());
+  EXPECT_EQ(*route.device_rate_plans.front().requested_write_rate, 48000u);
+  EXPECT_EQ(fake->ledger.default_input_reads, 0);
+  EXPECT_EQ(fake->ledger.uid_reads, 1);
+  EXPECT_EQ(fake->ledger.input_channel_reads, 0);
+  EXPECT_EQ(fake->ledger.physical_format_reads, 1);
+}
+
+TEST(CoreAudioRouteProbeTest, ExplicitBluetoothMonoFallbackIsTheOnlyAcceptedWidthReduction) {
+  auto fake = std::make_shared<FakeCoreAudioRouteQuery>();
+  fake->endpoints.emplace(31, makeEndpoint(31, "mono-output", 0, 1, 48000,
+                                           kAudioDeviceTransportTypeBluetooth, {{48000.0, 48000.0}},
+                                           {31}));
+  CoreAudioRouteResolver resolver(fake);
+
+  auto fallback = duplexConfig();
+  fallback.num_inputs = 0;
+  fallback.output_device_id = "mono-output";
+  fallback.channel_map.output_channels = {0, 1};
+  fallback.output_channel_policy = AudioOutputChannelPolicy::AllowMonoFallback;
+  fallback.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+  const auto accepted = resolver.resolve(fallback);
+
+  ASSERT_TRUE(accepted.resolved);
+  EXPECT_TRUE(accepted.output_mono_fallback);
+  EXPECT_EQ(accepted.output_channel_map, (std::vector<uint16_t>{0}));
+  EXPECT_EQ(accepted.compatibility.requested_output_channels, 2u);
+  EXPECT_EQ(accepted.compatibility.resolved_output_channels, 1u);
+  EXPECT_TRUE(accepted.compatibility.output_mono_fallback_planned);
+
+  fallback.output_channel_policy = AudioOutputChannelPolicy::RequireRequestedChannels;
+  const auto rejected = resolver.resolve(fallback);
+  EXPECT_FALSE(rejected.resolved);
+  EXPECT_EQ(rejected.compatibility.status, AudioRouteCompatibilityStatus::ProfileConflict);
 }
 
 } // namespace

--- a/tests/audio_io/coreaudio_sample_rate_transaction_test.cpp
+++ b/tests/audio_io/coreaudio_sample_rate_transaction_test.cpp
@@ -20,20 +20,18 @@ AudioObjectPropertyAddress nominalRateAddress() {
           kAudioObjectPropertyElementMain};
 }
 
-detail::ResolvedCoreAudioRoute distinctRoute() {
-  detail::ResolvedCoreAudioRoute route;
-  route.resolved = true;
-  route.output_device_id = kOutputDevice;
-  route.input_device_id = kInputDevice;
-  return route;
-}
-
-detail::ResolvedCoreAudioRoute sameDeviceRoute() {
-  detail::ResolvedCoreAudioRoute route;
-  route.resolved = true;
-  route.output_device_id = kOutputDevice;
-  route.input_device_id = kOutputDevice;
-  return route;
+std::vector<detail::CoreAudioDeviceRatePlan> writePlans(bool distinct) {
+  detail::CoreAudioDeviceRatePlan output;
+  output.device_id = kOutputDevice;
+  output.requested_write_rate = 48000u;
+  std::vector<detail::CoreAudioDeviceRatePlan> plans{output};
+  if (distinct) {
+    detail::CoreAudioDeviceRatePlan input;
+    input.device_id = kInputDevice;
+    input.requested_write_rate = 48000u;
+    plans.push_back(input);
+  }
+  return plans;
 }
 
 void seedRates(test_support::FakeCoreAudioPropertyApi& api, Float64 output_rate = 44100.0,
@@ -50,8 +48,7 @@ protected:
 TEST_F(CoreAudioSampleRateTransactionTest, SameRateHasNoListenersOrWrites) {
   seedRates(api, 48000.0, 48000.0);
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(20));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(20));
   EXPECT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::Healthy);
   EXPECT_TRUE(api.listenerLedger().empty());
   EXPECT_TRUE(api.writeLedger().empty());
@@ -60,8 +57,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, SameRateHasNoListenersOrWrites) {
 TEST_F(CoreAudioSampleRateTransactionTest, WritesOutputThenDistinctInputAndConfirmsEvents) {
   seedRates(api);
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(100));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(100));
   ASSERT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::Healthy);
 
   const auto listeners = api.listenerLedger();
@@ -82,7 +78,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, WritesOutputThenDistinctInputAndConfi
 TEST_F(CoreAudioSampleRateTransactionTest, SameDeviceDuplexUsesOneEndpoint) {
   seedRates(api, 44100.0, 44100.0);
 
-  CoreAudioSampleRateTransaction transaction(api, sameDeviceRoute(), 48000,
+  CoreAudioSampleRateTransaction transaction(api, writePlans(false),
                                              std::chrono::milliseconds(100));
   ASSERT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::Healthy);
 
@@ -98,8 +94,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, SettableFalseFailsBeforeListenersOrWr
   seedRates(api);
   api.setRateSettable(kOutputDevice, false);
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(20));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(20));
   EXPECT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::SampleRateChangeFailed);
   EXPECT_TRUE(api.listenerLedger().empty());
   EXPECT_TRUE(api.writeLedger().empty());
@@ -109,8 +104,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, SettableQueryErrorIsBackendFailure) {
   seedRates(api);
   api.failSettable(-50);
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(20));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(20));
   EXPECT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::BackendFailure);
   EXPECT_TRUE(api.listenerLedger().empty());
   EXPECT_TRUE(api.writeLedger().empty());
@@ -120,8 +114,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, TimeoutRollsBackInReverseOrder) {
   seedRates(api);
   api.suppressListenerDelivery();
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(5));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(5));
   EXPECT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::SampleRateChangeFailed);
 
   const auto writes = api.writeLedger();
@@ -137,8 +130,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, ThirdPartyRateChangeIsNotOverwrittenD
   seedRates(api);
   api.suppressListenerDelivery();
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(30));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(30));
   std::thread mutator([this] {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     api.thirdPartyRateMutation(kOutputDevice, 96000.0);
@@ -157,8 +149,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, SuppressedEventsCanBeDeliveredToCompl
   seedRates(api);
   api.suppressListenerDelivery();
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(200));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(200));
   std::thread delivery([this] {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     api.deliverPendingListeners();
@@ -172,8 +163,7 @@ TEST_F(CoreAudioSampleRateTransactionTest, WriteRefusalIsSampleRateChangeFailure
   seedRates(api);
   api.failSet(-1);
 
-  CoreAudioSampleRateTransaction transaction(api, distinctRoute(), 48000,
-                                             std::chrono::milliseconds(20));
+  CoreAudioSampleRateTransaction transaction(api, writePlans(true), std::chrono::milliseconds(20));
   EXPECT_EQ(transaction.begin(), AudioRouteRuntimeOutcome::SampleRateChangeFailed);
   EXPECT_EQ(api.listenerCount(), 0u);
   EXPECT_TRUE(api.writeLedger().empty());

--- a/tests/audio_io/directional_sample_rate_converter_test.cpp
+++ b/tests/audio_io/directional_sample_rate_converter_test.cpp
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+//
+// FTR085: bounded directional sample-rate conversion contracts.
+
+#include <orpheus/directional_sample_rate_converter.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using orpheus::SessionGraphError;
+using orpheus::audio_utils::DirectionalSampleRateConverter;
+using orpheus::audio_utils::DirectionalSrcConfig;
+using orpheus::audio_utils::DirectionalSrcStatus;
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+DirectionalSrcConfig makeConfig(uint32_t input_rate, uint32_t output_rate,
+                                bool allow_correction = false) {
+  DirectionalSrcConfig config;
+  config.input_rate = input_rate;
+  config.output_rate = output_rate;
+  config.channels = 1;
+  config.max_input_frames = 4096;
+  config.max_output_frames = 4096;
+  config.fifo_capacity_frames = 32768;
+  config.prime_input_frames = 0;
+  config.allow_input_rate_correction = allow_correction;
+  return config;
+}
+
+void pushPlanar(DirectionalSampleRateConverter& converter, const std::vector<float>& input) {
+  constexpr uint32_t kChunk = 4096;
+  for (size_t offset = 0; offset < input.size();) {
+    const uint32_t count = static_cast<uint32_t>(std::min<size_t>(kChunk, input.size() - offset));
+    const float* channels[] = {input.data() + offset};
+    const auto transfer = converter.pushInput(channels, 1, count);
+    ASSERT_EQ(transfer.status, DirectionalSrcStatus::Ok);
+    ASSERT_EQ(transfer.input_frames_consumed, count);
+    offset += count;
+  }
+}
+
+std::vector<float> renderPlanar(DirectionalSampleRateConverter& converter, uint32_t frames,
+                                uint32_t output_chunk) {
+  std::vector<float> output(frames, 0.0F);
+  for (uint32_t offset = 0; offset < frames;) {
+    const uint32_t count = std::min(output_chunk, frames - offset);
+    float* channels[] = {output.data() + offset};
+    uint32_t required = 0;
+    if (converter.requiredInputFrames(count, required) != DirectionalSrcStatus::Ok) {
+      ADD_FAILURE() << "requiredInputFrames failed";
+      return {};
+    }
+    const auto transfer = converter.renderOutput(channels, 1, count);
+    if (transfer.status != DirectionalSrcStatus::Ok || transfer.output_frames_produced != count) {
+      ADD_FAILURE() << "renderOutput failed";
+      return {};
+    }
+    offset += count;
+  }
+  return output;
+}
+
+std::vector<float> sine(uint32_t rate, double frequency, uint32_t frames) {
+  std::vector<float> result(frames);
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    result[frame] = static_cast<float>(std::sin(2.0 * kPi * frequency * frame / rate));
+  }
+  return result;
+}
+
+double rms(const std::vector<float>& signal, size_t begin) {
+  if (begin >= signal.size()) {
+    return 0.0;
+  }
+  double sum = 0.0;
+  for (size_t index = begin; index < signal.size(); ++index) {
+    sum += static_cast<double>(signal[index]) * signal[index];
+  }
+  return std::sqrt(sum / static_cast<double>(signal.size() - begin));
+}
+
+double measureFrequency(const std::vector<float>& signal, uint32_t rate, size_t begin) {
+  uint32_t crossings = 0;
+  for (size_t index = std::max<size_t>(begin, 1); index < signal.size(); ++index) {
+    if (signal[index - 1] <= 0.0F && signal[index] > 0.0F) {
+      ++crossings;
+    }
+  }
+  const double duration = static_cast<double>(signal.size() - begin) / rate;
+  return duration > 0.0 ? crossings / duration : 0.0;
+}
+
+std::vector<float> convertSine(uint32_t input_rate, uint32_t output_rate, double frequency,
+                               uint32_t output_frames, uint32_t output_chunk = 4096) {
+  DirectionalSampleRateConverter converter;
+  if (converter.prepare(makeConfig(input_rate, output_rate)) != SessionGraphError::OK) {
+    ADD_FAILURE() << "prepare failed";
+    return {};
+  }
+  const uint64_t needed =
+      (static_cast<uint64_t>(output_frames) * input_rate + output_rate - 1) / output_rate;
+  auto input = sine(input_rate, frequency, static_cast<uint32_t>(needed + 256));
+  pushPlanar(converter, input);
+  if (!converter.isPrimed()) {
+    ADD_FAILURE() << "converter did not prime";
+    return {};
+  }
+  return renderPlanar(converter, output_frames, output_chunk);
+}
+
+} // namespace
+
+TEST(DirectionalSampleRateConverterTest, RejectsUnsupportedPairsAndInvalidResources) {
+  DirectionalSampleRateConverter converter;
+  EXPECT_EQ(converter.prepare(makeConfig(16'000, 24'000)), SessionGraphError::NotSupported);
+  EXPECT_EQ(converter.prepare(makeConfig(8'000, 48'000)), SessionGraphError::NotSupported);
+
+  auto invalid = makeConfig(16'000, 48'000);
+  invalid.channels = 0;
+  EXPECT_EQ(converter.prepare(invalid), SessionGraphError::InvalidParameter);
+  invalid = makeConfig(16'000, 48'000);
+  invalid.fifo_capacity_frames = 2048;
+  invalid.max_input_frames = 512;
+  EXPECT_EQ(converter.prepare(invalid), SessionGraphError::InvalidParameter);
+  invalid = makeConfig(16'000, 48'000);
+  invalid.prime_input_frames = 16'385;
+  EXPECT_EQ(converter.prepare(invalid), SessionGraphError::InvalidParameter);
+}
+
+TEST(DirectionalSampleRateConverterTest, PreservesSineFrequencyAndPassbandGain) {
+  const auto upsampled = convertSine(16'000, 44'100, 1'000.0, 40'000);
+  const auto downsampled = convertSine(48'000, 24'000, 1'000.0, 12'000);
+
+  EXPECT_NEAR(measureFrequency(upsampled, 44'100, 2'000), 1'000.0, 2.0);
+  EXPECT_NEAR(measureFrequency(downsampled, 24'000, 1'000), 1'000.0, 2.0);
+  EXPECT_NEAR(rms(upsampled, 2'000), 1.0 / std::sqrt(2.0), 0.03);
+  EXPECT_NEAR(rms(downsampled, 1'000), 1.0 / std::sqrt(2.0), 0.03);
+}
+
+TEST(DirectionalSampleRateConverterTest, RejectsDownsamplingStopband) {
+  DirectionalSampleRateConverter converter;
+  ASSERT_EQ(converter.prepare(makeConfig(44'100, 16'000)), SessionGraphError::OK);
+  auto input = sine(44'100, 10'000.0, 20'000);
+  pushPlanar(converter, input);
+  const auto output = renderPlanar(converter, 7'000, 2'000);
+  EXPECT_LT(rms(output, 700), 0.08);
+}
+
+TEST(DirectionalSampleRateConverterTest, UsesTheExpectedImpulseOrder) {
+  DirectionalSampleRateConverter converter;
+  ASSERT_EQ(converter.prepare(makeConfig(44'100, 48'000)), SessionGraphError::OK);
+  std::vector<float> input(2'000, 0.0F);
+  input[0] = 1.0F;
+  pushPlanar(converter, input);
+  const auto output = renderPlanar(converter, 2'000, 1'024);
+  const auto peak = std::max_element(output.begin(), output.end(), [](float lhs, float rhs) {
+    return std::abs(lhs) < std::abs(rhs);
+  });
+  ASSERT_NE(peak, output.end());
+  EXPECT_LT(static_cast<size_t>(std::distance(output.begin(), peak)), 32u);
+  EXPECT_GT(std::abs(*peak), 0.5F);
+}
+
+TEST(DirectionalSampleRateConverterTest, MatchesLongRunRationalFrameConsumption) {
+  DirectionalSampleRateConverter converter;
+  ASSERT_EQ(converter.prepare(makeConfig(16'000, 44'100)), SessionGraphError::OK);
+  std::vector<float> input(16'256, 0.0F);
+  pushPlanar(converter, input);
+
+  uint64_t consumed = 0;
+  constexpr uint32_t kOutputFrames = 44'000;
+  for (uint32_t remaining = kOutputFrames; remaining > 0;) {
+    const uint32_t count = std::min<uint32_t>(remaining, 4096);
+    float* output[] = {input.data()};
+    const auto transfer = converter.renderOutput(output, 1, count);
+    ASSERT_EQ(transfer.status, DirectionalSrcStatus::Ok);
+    consumed += transfer.input_frames_consumed;
+    remaining -= count;
+  }
+  const uint64_t expected = (static_cast<uint64_t>(kOutputFrames) * 16'000) / 44'100;
+  EXPECT_EQ(consumed, expected);
+}
+
+TEST(DirectionalSampleRateConverterTest, CorrectionChangesConsumptionOnlyWhenEnabled) {
+  auto run = [](bool enabled, int32_t ppm) {
+    DirectionalSampleRateConverter converter;
+    auto config = makeConfig(16'000, 44'100, enabled);
+    EXPECT_EQ(converter.prepare(config), SessionGraphError::OK);
+    if (enabled) {
+      EXPECT_TRUE(converter.setInputRateCorrectionPpm(ppm));
+    } else {
+      EXPECT_FALSE(converter.setInputRateCorrectionPpm(ppm));
+    }
+    std::vector<float> input(8'000, 0.0F);
+    pushPlanar(converter, input);
+    uint64_t consumed = 0;
+    for (uint32_t remaining = 20'000; remaining > 0;) {
+      const uint32_t count = std::min<uint32_t>(remaining, 4096);
+      float* output[] = {input.data()};
+      const auto transfer = converter.renderOutput(output, 1, count);
+      EXPECT_EQ(transfer.status, DirectionalSrcStatus::Ok);
+      consumed += transfer.input_frames_consumed;
+      remaining -= count;
+    }
+    return consumed;
+  };
+
+  const auto nominal = run(false, 1'000);
+  const auto corrected = run(true, 1'000);
+  EXPECT_NE(nominal, corrected);
+}
+
+TEST(DirectionalSampleRateConverterTest, ChunkingAndResetAreDeterministic) {
+  auto config = makeConfig(16'000, 48'000);
+  DirectionalSampleRateConverter first;
+  DirectionalSampleRateConverter second;
+  ASSERT_EQ(first.prepare(config), SessionGraphError::OK);
+  ASSERT_EQ(second.prepare(config), SessionGraphError::OK);
+  const auto input = sine(16'000, 440.0, 5'000);
+
+  pushPlanar(first, input);
+  for (size_t offset = 0; offset < input.size();) {
+    const uint32_t count = static_cast<uint32_t>(std::min<size_t>(113, input.size() - offset));
+    const float* channels[] = {input.data() + offset};
+    ASSERT_EQ(second.pushInput(channels, 1, count).status, DirectionalSrcStatus::Ok);
+    offset += count;
+  }
+  const auto first_output = renderPlanar(first, 12'000, 4096);
+  const auto second_output = renderPlanar(second, 12'000, 257);
+  ASSERT_EQ(first_output.size(), second_output.size());
+  EXPECT_EQ(first_output, second_output);
+
+  first.reset();
+  EXPECT_FALSE(first.isPrimed());
+  EXPECT_EQ(first.bufferedInputFrames(), 0u);
+  EXPECT_EQ(first.latencyOutputFrames(), 381u);
+}
+
+TEST(DirectionalSampleRateConverterTest, EnforcesStartupUnderflowOverflowAndBufferOwnership) {
+  DirectionalSampleRateConverter converter;
+  uint32_t unused_required = 0;
+  EXPECT_EQ(converter.requiredInputFrames(1, unused_required), DirectionalSrcStatus::NotPrepared);
+  const auto config = makeConfig(16'000, 48'000);
+  ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
+
+  std::vector<float> sentinel(64, 7.0F);
+  float* output[] = {sentinel.data()};
+  EXPECT_EQ(converter.renderOutput(output, 1, 1).status, DirectionalSrcStatus::InputUnderflow);
+  EXPECT_TRUE(
+      std::all_of(sentinel.begin(), sentinel.end(), [](float value) { return value == 7.0F; }));
+
+  std::vector<float> input(128, 0.0F);
+  pushPlanar(converter, input);
+  EXPECT_TRUE(converter.isPrimed());
+  EXPECT_EQ(converter.renderOutput(output, 1, 1).status, DirectionalSrcStatus::Ok);
+
+  DirectionalSampleRateConverter bounded;
+  auto small = makeConfig(16'000, 48'000);
+  small.max_input_frames = 128;
+  small.max_output_frames = 128;
+  small.fifo_capacity_frames = 1024;
+  ASSERT_EQ(bounded.prepare(small), SessionGraphError::OK);
+  std::vector<float> block(128, 0.0F);
+  const float* block_channels[] = {block.data()};
+  for (int index = 0; index < 8; ++index) {
+    EXPECT_EQ(bounded.pushInput(block_channels, 1, 128).status, DirectionalSrcStatus::Ok);
+  }
+  EXPECT_EQ(bounded.pushInput(block_channels, 1, 1).status, DirectionalSrcStatus::InputOverflow);
+}
+
+TEST(DirectionalSampleRateConverterTest, ReportsLatencyFromConfiguredPrime) {
+  auto config = makeConfig(16'000, 48'000);
+  config.prime_input_frames = 64;
+  DirectionalSampleRateConverter converter;
+  ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
+  EXPECT_EQ(converter.latencyOutputFrames(), 573u);
+}

--- a/tests/audio_io/polyphase_resampler_test.cpp
+++ b/tests/audio_io/polyphase_resampler_test.cpp
@@ -7,6 +7,7 @@
 // for identical input). Frequency is measured by zero-crossing counting — no
 // FFT dependency, fully deterministic.
 
+#include <orpheus/directional_sample_rate_converter.h>
 #include <orpheus/polyphase_resampler.h>
 
 #include <algorithm>
@@ -66,6 +67,102 @@ double measureFreq(const std::vector<float>& interleaved, uint16_t ch, uint32_t 
   double periods = static_cast<double>(crossings - 1);
   double spanFrames = static_cast<double>(lastCross - firstCross);
   return periods * static_cast<double>(rate) / spanFrames;
+}
+
+using audio_utils::DirectionalSampleRateConverter;
+using audio_utils::DirectionalSrcConfig;
+using audio_utils::DirectionalSrcStatus;
+
+DirectionalSrcConfig converterConfig(uint32_t input_rate, uint32_t output_rate,
+                                     uint16_t channels = 1, uint32_t prime_input_frames = 0) {
+  DirectionalSrcConfig config;
+  config.input_rate = input_rate;
+  config.output_rate = output_rate;
+  config.channels = channels;
+  config.max_input_frames = 1024;
+  config.max_output_frames = 1024;
+  config.fifo_capacity_frames = 8192;
+  config.prime_input_frames = prime_input_frames;
+  config.allow_input_rate_correction = true;
+  return config;
+}
+
+void pushPlanar(DirectionalSampleRateConverter& converter, const std::vector<float>& input,
+                uint16_t channels, size_t offset, uint32_t frames) {
+  if (frames > 1024) {
+    for (uint32_t chunk_offset = 0; chunk_offset < frames;) {
+      const uint32_t chunk_frames = std::min<uint32_t>(1024, frames - chunk_offset);
+      pushPlanar(converter, input, channels, offset + chunk_offset, chunk_frames);
+      chunk_offset += chunk_frames;
+    }
+    return;
+  }
+  std::vector<float> planar(static_cast<size_t>(frames) * channels);
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      planar[static_cast<size_t>(channel) * frames + frame] =
+          input[(offset + frame) * channels + channel];
+    }
+  }
+  std::vector<const float*> planar_planes(channels);
+  for (uint16_t channel = 0; channel < channels; ++channel) {
+    planar_planes[channel] = planar.data() + static_cast<size_t>(channel) * frames;
+  }
+  const auto transfer = converter.pushInput(planar_planes.data(), channels, frames);
+  ASSERT_EQ(transfer.status, DirectionalSrcStatus::Ok);
+  ASSERT_EQ(transfer.input_frames_consumed, frames);
+}
+
+std::vector<float> renderPlanar(DirectionalSampleRateConverter& converter, uint16_t channels,
+                                uint32_t frames) {
+  std::vector<float> planar(static_cast<size_t>(frames) * channels, 0.0F);
+  std::vector<float*> planes(channels);
+  for (uint32_t offset = 0; offset < frames;) {
+    const uint32_t count = std::min<uint32_t>(1024, frames - offset);
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      planes[channel] = planar.data() + static_cast<size_t>(channel) * frames + offset;
+    }
+    const auto transfer = converter.renderOutput(planes.data(), channels, count);
+    EXPECT_EQ(transfer.status, DirectionalSrcStatus::Ok);
+    EXPECT_EQ(transfer.output_frames_produced, count);
+    offset += count;
+  }
+  std::vector<float> interleaved(static_cast<size_t>(frames) * channels);
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      interleaved[static_cast<size_t>(frame) * channels + channel] =
+          planar[static_cast<size_t>(channel) * frames + frame];
+    }
+  }
+  return interleaved;
+}
+
+bool renderChunked(DirectionalSampleRateConverter& converter, uint16_t channels, uint32_t frames,
+                   uint32_t chunk_frames, std::vector<float>& interleaved,
+                   uint32_t& input_consumed) {
+  interleaved.assign(static_cast<size_t>(frames) * channels, 0.0F);
+  std::vector<float> planar(static_cast<size_t>(chunk_frames) * channels);
+  std::vector<float*> planes(channels);
+  input_consumed = 0;
+  for (uint32_t offset = 0; offset < frames;) {
+    const uint32_t count = std::min(chunk_frames, frames - offset);
+    for (uint16_t channel = 0; channel < channels; ++channel) {
+      planes[channel] = planar.data() + static_cast<size_t>(channel) * chunk_frames;
+    }
+    const auto transfer = converter.renderOutput(planes.data(), channels, count);
+    if (transfer.status != DirectionalSrcStatus::Ok || transfer.output_frames_produced != count) {
+      return false;
+    }
+    input_consumed += transfer.input_frames_consumed;
+    for (uint32_t frame = 0; frame < count; ++frame) {
+      for (uint16_t channel = 0; channel < channels; ++channel) {
+        interleaved[static_cast<size_t>(offset + frame) * channels + channel] =
+            planes[channel][frame];
+      }
+    }
+    offset += count;
+  }
+  return true;
 }
 
 } // namespace
@@ -175,4 +272,169 @@ TEST(PolyphaseResamplerTest, StereoChannelsIndependent) {
     rEnergy += std::abs(static_cast<double>(out[i * 2 + 1]));
   EXPECT_LT(rEnergy / std::max<size_t>(1, frames), 1e-3)
       << "Silent right channel leaked energy from the left";
+}
+
+TEST(DirectionalSampleRateConverterTest, PreparationAndTransferSemantics) {
+  DirectionalSampleRateConverter converter;
+  uint32_t required = 123;
+  EXPECT_EQ(converter.requiredInputFrames(1, required), DirectionalSrcStatus::NotPrepared);
+  EXPECT_EQ(required, 0u);
+
+  auto unsupported = converterConfig(32000, 48000);
+  EXPECT_EQ(converter.prepare(unsupported), SessionGraphError::NotSupported);
+
+  auto config = converterConfig(16000, 48000, 1, 4);
+  ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
+  EXPECT_FALSE(converter.isPrimed());
+  EXPECT_EQ(converter.latencyOutputFrames(), 393u);
+
+  float input_value = 1.0F;
+  const float* input_plane = &input_value;
+  EXPECT_EQ(converter.pushInput(&input_plane, 2, 1).status, DirectionalSrcStatus::InvalidArgument);
+  EXPECT_EQ(converter.pushInput(nullptr, 1, 0).status, DirectionalSrcStatus::Ok);
+
+  float output_storage[8];
+  float* output_plane = output_storage;
+  std::fill(std::begin(output_storage), std::end(output_storage), 9.0F);
+  EXPECT_EQ(converter.renderOutput(&output_plane, 1, 1).status,
+            DirectionalSrcStatus::InputUnderflow);
+  EXPECT_TRUE(std::all_of(std::begin(output_storage), std::end(output_storage),
+                          [](float sample) { return sample == 9.0F; }));
+
+  std::vector<float> input(140, 0.25F);
+  pushPlanar(converter, input, 1, 0, static_cast<uint32_t>(input.size()));
+  EXPECT_TRUE(converter.isPrimed());
+  const auto output = renderPlanar(converter, 1, 1);
+  EXPECT_EQ(output.size(), 1u);
+  converter.reset();
+  EXPECT_FALSE(converter.isPrimed());
+  EXPECT_EQ(converter.bufferedInputFrames(), 0u);
+}
+
+TEST(DirectionalSampleRateConverterTest, RequiredInputAndNominalFrameRatio) {
+  DirectionalSampleRateConverter converter;
+  auto config = converterConfig(48000, 16000);
+  ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
+
+  std::vector<float> input(4096);
+  for (size_t index = 0; index < input.size(); ++index) {
+    input[index] = static_cast<float>(index % 31) / 31.0F;
+  }
+  pushPlanar(converter, input, 1, 0, static_cast<uint32_t>(input.size()));
+  ASSERT_TRUE(converter.isPrimed());
+
+  uint32_t required = 0;
+  ASSERT_EQ(converter.requiredInputFrames(1024, required), DirectionalSrcStatus::Ok);
+  EXPECT_EQ(required, 0u);
+  const auto first = renderPlanar(converter, 1, 1024);
+  EXPECT_EQ(first.size(), 1024u);
+  EXPECT_EQ(converter.bufferedInputFrames(), 4096u - 3072u);
+
+  ASSERT_EQ(converter.requiredInputFrames(200, required), DirectionalSrcStatus::Ok);
+  EXPECT_EQ(required, 0u);
+  const auto second = renderPlanar(converter, 1, 200);
+  EXPECT_EQ(second.size(), 200u);
+  EXPECT_EQ(converter.bufferedInputFrames(), 4096u - 3072u - 600u);
+}
+
+TEST(DirectionalSampleRateConverterTest, SinePitchPassbandAndDownsampleRejection) {
+  {
+    DirectionalSampleRateConverter converter;
+    ASSERT_EQ(converter.prepare(converterConfig(16000, 48000)), SessionGraphError::OK);
+    const auto input = makeSine(16000, 1000.0, 0.125);
+    pushPlanar(converter, input, 1, 0, static_cast<uint32_t>(input.size()));
+    const auto output = renderPlanar(converter, 1, 5000);
+    EXPECT_NEAR(measureFreq(output, 1, 48000, 500), 1000.0, 5.0);
+    float peak = 0.0F;
+    for (size_t index = 500; index < output.size(); ++index) {
+      peak = std::max(peak, std::abs(output[index]));
+    }
+    EXPECT_GT(peak, 0.85F);
+  }
+
+  {
+    DirectionalSampleRateConverter converter;
+    ASSERT_EQ(converter.prepare(converterConfig(48000, 16000)), SessionGraphError::OK);
+    const auto input = makeSine(48000, 1000.0, 0.125);
+    pushPlanar(converter, input, 1, 0, static_cast<uint32_t>(input.size()));
+    const auto output = renderPlanar(converter, 1, 1800);
+    EXPECT_NEAR(measureFreq(output, 1, 16000, 200), 1000.0, 5.0);
+
+    converter.reset();
+    const auto stopband = makeSine(48000, 10000.0, 0.125);
+    pushPlanar(converter, stopband, 1, 0, static_cast<uint32_t>(stopband.size()));
+    const auto rejected = renderPlanar(converter, 1, 1800);
+    double energy = 0.0;
+    for (size_t index = 200; index < rejected.size(); ++index) {
+      energy += static_cast<double>(rejected[index]) * rejected[index];
+    }
+    const double rms = std::sqrt(energy / static_cast<double>(rejected.size() - 200));
+    EXPECT_LT(rms, 0.08);
+  }
+}
+
+TEST(DirectionalSampleRateConverterTest, CorrectionAndChunkInvariance) {
+  const auto input = makeSine(16000, 440.0, 0.125);
+
+  DirectionalSampleRateConverter nominal;
+  DirectionalSampleRateConverter corrected;
+  ASSERT_EQ(nominal.prepare(converterConfig(16000, 48000)), SessionGraphError::OK);
+  ASSERT_EQ(corrected.prepare(converterConfig(16000, 48000)), SessionGraphError::OK);
+  EXPECT_FALSE(corrected.setInputRateCorrectionPpm(1001));
+  EXPECT_TRUE(corrected.setInputRateCorrectionPpm(1000));
+  pushPlanar(nominal, input, 1, 0, static_cast<uint32_t>(input.size()));
+  pushPlanar(corrected, input, 1, 0, static_cast<uint32_t>(input.size()));
+
+  std::vector<float> nominal_output;
+  std::vector<float> corrected_output;
+  uint32_t nominal_consumed = 0;
+  uint32_t corrected_consumed = 0;
+  ASSERT_TRUE(renderChunked(nominal, 1, 3000, 1024, nominal_output, nominal_consumed));
+  ASSERT_TRUE(renderChunked(corrected, 1, 3000, 1024, corrected_output, corrected_consumed));
+  EXPECT_GT(corrected_consumed, nominal_consumed);
+
+  DirectionalSampleRateConverter one_chunk;
+  DirectionalSampleRateConverter many_chunks;
+  ASSERT_EQ(one_chunk.prepare(converterConfig(16000, 48000)), SessionGraphError::OK);
+  ASSERT_EQ(many_chunks.prepare(converterConfig(16000, 48000)), SessionGraphError::OK);
+  pushPlanar(one_chunk, input, 1, 0, static_cast<uint32_t>(input.size()));
+  for (size_t offset = 0; offset < input.size(); offset += 137) {
+    const uint32_t frames = static_cast<uint32_t>(std::min<size_t>(137, input.size() - offset));
+    pushPlanar(many_chunks, input, 1, offset, frames);
+  }
+  std::vector<float> one_output;
+  std::vector<float> many_output;
+  uint32_t one_consumed = 0;
+  uint32_t many_consumed = 0;
+  ASSERT_TRUE(renderChunked(one_chunk, 1, 3000, 1024, one_output, one_consumed));
+  ASSERT_TRUE(renderChunked(many_chunks, 1, 3000, 257, many_output, many_consumed));
+  ASSERT_EQ(many_output.size(), one_output.size());
+  for (size_t index = 0; index < one_output.size(); ++index) {
+    EXPECT_FLOAT_EQ(one_output[index], many_output[index]);
+  }
+}
+
+TEST(DirectionalSampleRateConverterTest, StereoChannelsRemainIndependentAndOverflowIsTerminal) {
+  DirectionalSampleRateConverter converter;
+  ASSERT_EQ(converter.prepare(converterConfig(48000, 16000, 2)), SessionGraphError::OK);
+  std::vector<float> input(4096 * 2, 0.0F);
+  for (size_t frame = 0; frame < 4096; ++frame) {
+    input[frame * 2] = static_cast<float>(std::sin(2.0 * M_PI * 500.0 * frame / 48000.0));
+  }
+  pushPlanar(converter, input, 2, 0, 4096);
+  const auto output = renderPlanar(converter, 2, 1000);
+  double right_energy = 0.0;
+  for (size_t frame = 0; frame < output.size() / 2; ++frame) {
+    right_energy += std::abs(static_cast<double>(output[frame * 2 + 1]));
+  }
+  EXPECT_LT(right_energy / 1000.0, 1e-4);
+
+  DirectionalSampleRateConverter overflow_converter;
+  ASSERT_EQ(overflow_converter.prepare(converterConfig(48000, 16000, 1)), SessionGraphError::OK);
+  std::vector<float> full_fifo(8192, 0.5F);
+  pushPlanar(overflow_converter, full_fifo, 1, 0, 8192);
+  std::vector<const float*> planes = {full_fifo.data()};
+  const auto overflow = overflow_converter.pushInput(planes.data(), 1, 1);
+  EXPECT_EQ(overflow.status, DirectionalSrcStatus::InputOverflow);
+  EXPECT_EQ(overflow.input_frames_consumed, 0u);
 }

--- a/tests/cmake/find_package/audio_io_telemetry.cpp
+++ b/tests/cmake/find_package/audio_io_telemetry.cpp
@@ -48,11 +48,28 @@ concept AcceptsTwoTelemetryFields =
     requires { T{uint64_t{1}, orpheus::AudioRouteRuntimeOutcome::Healthy}; };
 
 template <typename T>
-concept AcceptsThreeTelemetryFields = requires {
-  T{uint64_t{1}, orpheus::AudioRouteRuntimeOutcome::Healthy,
-    orpheus::AudioRouteRuntimeOutcome::Healthy};
+concept AcceptsAllTelemetryFields = requires {
+  T{uint64_t{1}, orpheus::AudioRouteRuntimeOutcome::Healthy, uint64_t{2}, uint64_t{3}, uint64_t{4},
+    uint64_t{5}};
 };
 
+static_assert(static_cast<uint8_t>(orpheus::AudioSampleRatePolicy::PreserveDeviceRate) == 0);
+static_assert(static_cast<uint8_t>(orpheus::AudioSampleRatePolicy::RequestExactRate) == 1);
+static_assert(static_cast<uint8_t>(orpheus::AudioSampleRatePolicy::RequestExactRateOrConvert) == 2);
+static_assert(static_cast<uint8_t>(orpheus::AudioOutputChannelPolicy::RequireRequestedChannels) ==
+              0);
+static_assert(static_cast<uint8_t>(orpheus::AudioOutputChannelPolicy::AllowMonoFallback) == 1);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::Compatible) == 0);
+static_assert(
+    static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::RequiresSampleRateChange) == 1);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::InputUnavailable) == 2);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::OutputUnavailable) == 3);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::SampleRateUnsupported) ==
+              4);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::InvalidChannelMap) == 5);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::PermissionDenied) == 6);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::BackendFailure) == 7);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteCompatibilityStatus::ProfileConflict) == 8);
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::Healthy) == 0);
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::SampleRateUnsupported) == 1);
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::SampleRateChangeFailed) == 2);
@@ -64,8 +81,12 @@ static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::InputRoute
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::OutputRouteUnavailable) == 8);
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::PermissionDenied) == 9);
 static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::BackendFailure) == 10);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::ProfileConflict) == 11);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::InputConversionFailed) == 12);
+static_assert(static_cast<uint8_t>(orpheus::AudioRouteRuntimeOutcome::OutputConversionFailed) ==
+              13);
 static_assert(AcceptsTwoTelemetryFields<orpheus::AudioIoTelemetry>);
-static_assert(!AcceptsThreeTelemetryFields<orpheus::AudioIoTelemetry>);
+static_assert(AcceptsAllTelemetryFields<orpheus::AudioIoTelemetry>);
 
 } // namespace
 
@@ -81,7 +102,9 @@ int main() {
       !observed.output_device_id.empty() || !observed.device_name.empty() ||
       !observed.channel_map.input_channels.empty() ||
       observed.channel_map.output_channels != std::vector<uint16_t>{0, 1} ||
-      observed.sample_rate_policy != orpheus::AudioSampleRatePolicy::PreserveDeviceRate) {
+      observed.sample_rate_policy != orpheus::AudioSampleRatePolicy::PreserveDeviceRate ||
+      observed.output_channel_policy !=
+          orpheus::AudioOutputChannelPolicy::RequireRequestedChannels) {
     return 2;
   }
   const orpheus::AudioIoTelemetry telemetry{0, orpheus::AudioRouteRuntimeOutcome::Healthy};

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,3 +14,12 @@ if(WIN32 AND ORPHEUS_ENABLE_WASAPI)
     PRIVATE orpheus_audio_driver_manager)
   orpheus_enable_warnings(orpheus_wasapi_hardware_acceptance)
 endif()
+
+if(APPLE AND ORPHEUS_ENABLE_COREAUDIO)
+  add_executable(orpheus_coreaudio_hardware_acceptance
+    coreaudio_hardware_acceptance.cpp)
+  target_compile_features(orpheus_coreaudio_hardware_acceptance PRIVATE cxx_std_20)
+  target_link_libraries(orpheus_coreaudio_hardware_acceptance
+    PRIVATE orpheus_audio_driver_coreaudio)
+  orpheus_enable_warnings(orpheus_coreaudio_hardware_acceptance)
+endif()

--- a/tools/coreaudio_hardware_acceptance.cpp
+++ b/tools/coreaudio_hardware_acceptance.cpp
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: MIT
+#if defined(__APPLE__)
+
+#include <orpheus/audio_driver.h>
+#include <orpheus/errors.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct Options {
+  std::string output_uid;
+  std::optional<std::string> input_uid;
+  uint32_t sample_rate = 48000;
+  uint32_t seconds = 10;
+  bool allow_mono_fallback = false;
+  std::optional<double> expected_input_tone_hz;
+};
+
+std::string json_escape(const std::string& value) {
+  std::string escaped;
+  escaped.reserve(value.size() + 2);
+  for (const char character : value) {
+    switch (character) {
+    case '\\':
+      escaped += "\\\\";
+      break;
+    case '"':
+      escaped += "\\\"";
+      break;
+    case '\n':
+      escaped += "\\n";
+      break;
+    case '\r':
+      escaped += "\\r";
+      break;
+    case '\t':
+      escaped += "\\t";
+      break;
+    default:
+      if (static_cast<unsigned char>(character) < 0x20) {
+        escaped += '?';
+      } else {
+        escaped += character;
+      }
+      break;
+    }
+  }
+  return escaped;
+}
+[[noreturn]] void print_error(const std::string& reason, int exit_code) {
+  std::cout << "{\"status\":\"failed\",\"reason\":\"" << json_escape(reason) << "\"}\n";
+  std::exit(exit_code);
+}
+
+uint32_t parse_uint32(const std::string& value, const char* option) {
+  try {
+    size_t consumed = 0;
+    const unsigned long parsed = std::stoul(value, &consumed, 10);
+    if (consumed != value.size() || parsed > UINT32_MAX) {
+      throw std::invalid_argument("range");
+    }
+    return static_cast<uint32_t>(parsed);
+  } catch (const std::exception&) {
+    print_error(std::string("invalid-") + option, 2);
+  }
+}
+
+Options parse_options(int argc, char** argv) {
+  Options options;
+  for (int index = 1; index < argc; ++index) {
+    const std::string argument = argv[index];
+    auto require_value = [&](const char* option) -> std::string {
+      if (index + 1 >= argc) {
+        print_error(std::string("missing-") + option, 2);
+      }
+      return argv[++index];
+    };
+    if (argument == "--help") {
+      std::cout << "usage: orpheus_coreaudio_hardware_acceptance --output-uid UID "
+                   "[--input-uid UID] [--sample-rate 44100|48000] [--seconds N] "
+                   "[--output-policy strict|mono-fallback] [--expect-input-tone-hz HZ]\n";
+      std::exit(0);
+    }
+    if (argument == "--output-uid") {
+      options.output_uid = require_value("output-uid");
+    } else if (argument == "--input-uid") {
+      options.input_uid = require_value("input-uid");
+    } else if (argument == "--sample-rate") {
+      options.sample_rate = parse_uint32(require_value("sample-rate"), "sample-rate");
+    } else if (argument == "--seconds") {
+      options.seconds = parse_uint32(require_value("seconds"), "seconds");
+    } else if (argument == "--output-policy") {
+      const auto policy = require_value("output-policy");
+      if (policy == "strict") {
+        options.allow_mono_fallback = false;
+      } else if (policy == "mono-fallback") {
+        options.allow_mono_fallback = true;
+      } else {
+        print_error("invalid-output-policy", 2);
+      }
+    } else if (argument == "--expect-input-tone-hz") {
+      try {
+        size_t consumed = 0;
+        const double expected = std::stod(require_value("expect-input-tone-hz"), &consumed);
+        if (!std::isfinite(expected) || expected <= 0.0 || consumed == 0) {
+          throw std::invalid_argument("frequency");
+        }
+        options.expected_input_tone_hz = expected;
+      } catch (const std::exception&) {
+        print_error("invalid-expect-input-tone-hz", 2);
+      }
+    } else {
+      print_error("unknown-option", 2);
+    }
+  }
+  if (options.output_uid.empty()) {
+    print_error("missing-output-uid", 2);
+  }
+  if (options.sample_rate != 44100 && options.sample_rate != 48000) {
+    print_error("sample-rate-must-be-44100-or-48000", 2);
+  }
+  if (options.seconds == 0) {
+    print_error("seconds-must-be-positive", 2);
+  }
+  return options;
+}
+
+class AcceptanceCallback final : public orpheus::IAudioCallback {
+public:
+  void processAudio(const orpheus::AudioProcessBlock& block) noexcept override {
+    for (uint16_t channel = 0; channel < block.num_output_channels; ++channel) {
+      if (block.output_buffers != nullptr && block.output_buffers[channel] != nullptr) {
+        std::fill_n(block.output_buffers[channel], block.num_frames, 0.0f);
+      }
+    }
+    callbacks_.fetch_add(1, std::memory_order_relaxed);
+    callback_frames_.fetch_add(block.num_frames, std::memory_order_relaxed);
+    if (block.input_buffers == nullptr || block.num_input_channels == 0 || block.num_frames == 0 ||
+        block.input_buffers[0] == nullptr) {
+      return;
+    }
+    const float* input = block.input_buffers[0];
+    float previous = previous_input_sample_;
+    for (uint32_t frame = 0; frame < block.num_frames; ++frame) {
+      const float sample = input[frame];
+      peak_ = std::max(peak_, std::fabs(sample));
+      if ((previous < 0.0f && sample >= 0.0f) || (previous >= 0.0f && sample < 0.0f)) {
+        zero_crossings_.fetch_add(1, std::memory_order_relaxed);
+      }
+      previous = sample;
+    }
+    previous_input_sample_ = previous;
+    input_callbacks_.fetch_add(1, std::memory_order_relaxed);
+    input_frames_.fetch_add(block.num_frames, std::memory_order_relaxed);
+  }
+
+  uint64_t callbacks() const noexcept {
+    return callbacks_.load(std::memory_order_relaxed);
+  }
+  uint64_t callback_frames() const noexcept {
+    return callback_frames_.load(std::memory_order_relaxed);
+  }
+  uint64_t input_callbacks() const noexcept {
+    return input_callbacks_.load(std::memory_order_relaxed);
+  }
+  uint64_t input_frames() const noexcept {
+    return input_frames_.load(std::memory_order_relaxed);
+  }
+  uint64_t zero_crossings() const noexcept {
+    return zero_crossings_.load(std::memory_order_relaxed);
+  }
+  float peak() const noexcept {
+    return peak_;
+  }
+
+private:
+  std::atomic<uint64_t> callbacks_{0};
+  std::atomic<uint64_t> callback_frames_{0};
+  std::atomic<uint64_t> input_callbacks_{0};
+  std::atomic<uint64_t> input_frames_{0};
+  std::atomic<uint64_t> zero_crossings_{0};
+  float previous_input_sample_ = 0.0f;
+  float peak_ = 0.0f;
+};
+
+const char* route_outcome_name(orpheus::AudioRouteRuntimeOutcome outcome) {
+  switch (outcome) {
+  case orpheus::AudioRouteRuntimeOutcome::Healthy:
+    return "Healthy";
+  case orpheus::AudioRouteRuntimeOutcome::SampleRateUnsupported:
+    return "SampleRateUnsupported";
+  case orpheus::AudioRouteRuntimeOutcome::SampleRateChangeFailed:
+    return "SampleRateChangeFailed";
+  case orpheus::AudioRouteRuntimeOutcome::SampleRateChanged:
+    return "SampleRateChanged";
+  case orpheus::AudioRouteRuntimeOutcome::BufferSizeChanged:
+    return "BufferSizeChanged";
+  case orpheus::AudioRouteRuntimeOutcome::FormatChanged:
+    return "FormatChanged";
+  case orpheus::AudioRouteRuntimeOutcome::ChannelMapInvalid:
+    return "ChannelMapInvalid";
+  case orpheus::AudioRouteRuntimeOutcome::InputRouteUnavailable:
+    return "InputRouteUnavailable";
+  case orpheus::AudioRouteRuntimeOutcome::OutputRouteUnavailable:
+    return "OutputRouteUnavailable";
+  case orpheus::AudioRouteRuntimeOutcome::PermissionDenied:
+    return "PermissionDenied";
+  case orpheus::AudioRouteRuntimeOutcome::ProfileConflict:
+    return "ProfileConflict";
+  case orpheus::AudioRouteRuntimeOutcome::InputConversionFailed:
+    return "InputConversionFailed";
+  case orpheus::AudioRouteRuntimeOutcome::OutputConversionFailed:
+    return "OutputConversionFailed";
+  case orpheus::AudioRouteRuntimeOutcome::BackendFailure:
+    return "BackendFailure";
+  }
+  return "Unknown";
+}
+
+std::string output_policy_name(bool allow_mono_fallback) {
+  return allow_mono_fallback ? "mono-fallback" : "strict";
+}
+
+void append_string(std::ostringstream& json, const char* key, const std::string& value,
+                   bool& first) {
+  if (!first) {
+    json << ',';
+  }
+  first = false;
+  json << '"' << key << "\":\"" << json_escape(value) << '"';
+}
+
+void append_string(std::ostringstream& json, const char* key, const char* value, bool& first) {
+  append_string(json, key, std::string(value), first);
+}
+
+template <typename T>
+void append_number(std::ostringstream& json, const char* key, T value, bool& first) {
+  if (!first) {
+    json << ',';
+  }
+  first = false;
+  json << '"' << key << "\":" << value;
+}
+
+void append_bool(std::ostringstream& json, const char* key, bool value, bool& first) {
+  if (!first) {
+    json << ',';
+  }
+  first = false;
+  json << '"' << key << "\":" << (value ? "true" : "false");
+}
+
+void append_map(std::ostringstream& json, const char* key, const std::vector<uint16_t>& map,
+                bool& first) {
+  if (!first) {
+    json << ',';
+  }
+  first = false;
+  json << '"' << key << "\":[";
+  for (size_t index = 0; index < map.size(); ++index) {
+    if (index != 0) {
+      json << ',';
+    }
+    json << map[index];
+  }
+  json << ']';
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const Options options = parse_options(argc, argv);
+  auto driver = orpheus::createCoreAudioDriver();
+  if (!driver) {
+    print_error("coreaudio-driver-unavailable", 3);
+  }
+
+  orpheus::AudioDriverConfig config;
+  config.sample_rate = options.sample_rate;
+  config.buffer_size = 512;
+  config.num_inputs = options.input_uid.has_value() ? 1 : 0;
+  config.input_device_id = options.input_uid.value_or("");
+  config.num_outputs = 2;
+  config.output_device_id = options.output_uid;
+  config.channel_map.input_channels =
+      options.input_uid.has_value() ? std::vector<uint16_t>{0} : std::vector<uint16_t>{};
+  config.channel_map.output_channels = {0, 1};
+  config.sample_rate_policy = orpheus::AudioSampleRatePolicy::RequestExactRateOrConvert;
+  config.output_channel_policy = options.allow_mono_fallback
+                                     ? orpheus::AudioOutputChannelPolicy::AllowMonoFallback
+                                     : orpheus::AudioOutputChannelPolicy::RequireRequestedChannels;
+
+  const auto initialize_result = driver->initialize(config);
+  const auto active = driver->getActiveRoute();
+  const auto io_route = driver->getAudioIoRouteState();
+  const auto telemetry_before = driver->getTelemetry();
+  if (initialize_result != orpheus::SessionGraphError::OK) {
+    std::ostringstream json;
+    json << "{\"status\":\"failed\",\"reason\":\"initialize\",\"route_outcome\":\""
+         << route_outcome_name(telemetry_before.route_outcome) << "\",\"detail\":\""
+         << json_escape(io_route.detail) << "\"}\n";
+    std::cout << json.str();
+    return 4;
+  }
+
+  AcceptanceCallback callback;
+  const auto start_result = driver->start(&callback);
+  if (start_result != orpheus::SessionGraphError::OK) {
+    const auto telemetry = driver->getTelemetry();
+    std::ostringstream json;
+    json << "{\"status\":\"failed\",\"reason\":\"start\",\"route_outcome\":\""
+         << route_outcome_name(telemetry.route_outcome) << "\",\"detail\":\""
+         << json_escape(driver->getAudioIoRouteState().detail) << "\"}\n";
+    std::cout << json.str();
+    return 5;
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(options.seconds));
+  const auto stop_result = driver->stop();
+  const auto negotiated = driver->getActiveRoute();
+  const auto final_io_route = driver->getAudioIoRouteState();
+  const auto telemetry = driver->getTelemetry();
+  const auto route_outcome = telemetry.route_outcome;
+  const uint64_t expected_frames = static_cast<uint64_t>(options.sample_rate) * options.seconds;
+  const double zero_crossing_frequency =
+      callback.input_frames() == 0 ? 0.0
+                                   : static_cast<double>(callback.zero_crossings()) *
+                                         static_cast<double>(options.sample_rate) /
+                                         (2.0 * static_cast<double>(callback.input_frames()));
+  const bool counters_clear =
+      telemetry.input_render_failures == 0 && telemetry.input_fifo_overruns == 0 &&
+      telemetry.input_fifo_underruns == 0 && telemetry.input_conversion_failures == 0 &&
+      telemetry.output_conversion_failures == 0;
+  const bool input_activity_matches = options.input_uid.has_value()
+                                          ? callback.input_callbacks() > 0
+                                          : callback.input_callbacks() == 0;
+  const bool tone_in_tolerance =
+      !options.expected_input_tone_hz.has_value() ||
+      (callback.input_frames() != 0 &&
+       std::abs(zero_crossing_frequency - *options.expected_input_tone_hz) <= 20.0);
+  const bool passed = stop_result == orpheus::SessionGraphError::OK && callback.callbacks() > 0 &&
+                      route_outcome == orpheus::AudioRouteRuntimeOutcome::Healthy &&
+                      counters_clear && input_activity_matches && tone_in_tolerance;
+
+  std::ostringstream json;
+  json << std::setprecision(10) << '{';
+  bool first = true;
+  append_string(json, "status", passed ? "passed" : "failed", first);
+  append_string(json, "backend", "CoreAudio", first);
+  append_string(json, "input_uid", options.input_uid.value_or(""), first);
+  append_string(json, "output_uid", options.output_uid, first);
+  append_number(json, "sample_rate", options.sample_rate, first);
+  append_number(json, "seconds", options.seconds, first);
+  append_number(json, "requested_frames", expected_frames, first);
+  append_string(json, "output_policy", output_policy_name(options.allow_mono_fallback), first);
+  append_number(json, "input_physical_sample_rate", negotiated.input_physical_sample_rate, first);
+  append_number(json, "output_physical_sample_rate", negotiated.output_physical_sample_rate, first);
+  append_number(json, "input_client_sample_rate", negotiated.input_client_sample_rate, first);
+  append_number(json, "output_client_sample_rate", negotiated.output_client_sample_rate, first);
+  append_number(json, "available_input_channels", negotiated.available_input_channels, first);
+  append_number(json, "available_output_channels", negotiated.available_output_channels, first);
+  append_number(json, "requested_output_channels", negotiated.requested_output_channels, first);
+  append_number(json, "resolved_output_channels", negotiated.resolved_output_channels, first);
+  append_number(json, "input_client_format_channels", negotiated.input_client_format_channels,
+                first);
+  append_number(json, "output_client_format_channels", negotiated.output_client_format_channels,
+                first);
+  append_bool(json, "input_conversion_active", negotiated.input_conversion_active, first);
+  append_bool(json, "output_conversion_active", negotiated.output_conversion_active, first);
+  append_bool(json, "input_is_bluetooth", negotiated.input_is_bluetooth, first);
+  append_bool(json, "output_is_bluetooth", negotiated.output_is_bluetooth, first);
+  append_bool(json, "endpoints_related", negotiated.endpoints_related, first);
+  append_bool(json, "output_mono_fallback", negotiated.output_mono_fallback, first);
+  append_map(json, "active_output_map", negotiated.output_channels, first);
+  append_number(json, "capture_latency_frames", negotiated.latency.capture_frames, first);
+  append_number(json, "playback_latency_frames", negotiated.latency.playback_frames, first);
+  append_number(json, "processing_latency_frames", negotiated.latency.processing_frames, first);
+  append_bool(json, "latency_complete", negotiated.latency.complete, first);
+  append_number(json, "input_converter_latency_frames",
+                final_io_route.latency.input_converter_frames.value_or(0), first);
+  append_number(json, "output_converter_latency_frames",
+                final_io_route.latency.output_converter_frames.value_or(0), first);
+  append_number(json, "callbacks", callback.callbacks(), first);
+  append_number(json, "callback_frames", callback.callback_frames(), first);
+  append_number(json, "input_callbacks", callback.input_callbacks(), first);
+  append_number(json, "input_frames", callback.input_frames(), first);
+  append_number(json, "input_render_failures", telemetry.input_render_failures, first);
+  append_number(json, "input_fifo_overruns", telemetry.input_fifo_overruns, first);
+  append_number(json, "input_fifo_underruns", telemetry.input_fifo_underruns, first);
+  append_number(json, "input_conversion_failures", telemetry.input_conversion_failures, first);
+  append_number(json, "output_conversion_failures", telemetry.output_conversion_failures, first);
+  append_string(json, "route_outcome", route_outcome_name(route_outcome), first);
+  append_number(json, "input_peak", callback.peak(), first);
+  append_number(json, "zero_crossing_frequency_hz", zero_crossing_frequency, first);
+  if (options.expected_input_tone_hz.has_value()) {
+    append_number(json, "expected_input_tone_hz", *options.expected_input_tone_hz, first);
+    append_bool(json, "input_tone_in_tolerance", tone_in_tolerance, first);
+  }
+  append_bool(json, "passed", passed, first);
+  json << "}\n";
+  std::cout << json.str();
+  return passed ? 0 : 6;
+}
+
+#else
+int main() {
+  return 1;
+}
+#endif


### PR DESCRIPTION
## Summary
- add direction-specific CoreAudio physical/client rate planning and a bounded realtime converter for `RequestExactRateOrConvert`
- expose settled rate, channel-width, converter-latency, Bluetooth/relation, mono-fallback, and callback-health route facts
- add strict-or-explicit mono output behavior for related Bluetooth duplex routes, plus CoreAudio hardware acceptance CLI
- update the SDK feature version to 0.8.0 and record the FTR085 adoption boundary

## Verification
- `cmake --preset sdk-debug && cmake --build --preset sdk-debug && ctest --test-dir build-sdk-debug --output-on-failure` — 80/80 passed
- `cmake --preset sdk-release && cmake --build --preset sdk-release --target orpheus_coreaudio_hardware_acceptance` — passed
- `ctest --test-dir build-sdk-release --output-on-failure -R "version_contract|cmake_find_package|cmake_package_runtime_consumer"` — 3/3 passed
- output-only CoreAudio acceptance against BuiltInSpeakerDevice at 48 kHz passed; negative expected-input-tone invocation failed as designed

## Physical Bluetooth gate
No CLbuds endpoint was present in the captured hardware inventory. The deterministic/source/package work is complete; physical CLbuds acceptance remains explicitly blocked. This PR does not claim FTR085 completion, a release tag, or a production FourTrack repin.