### PR TITLE
fix(coreaudio): admit settled Bluetooth routes

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,8 +25,12 @@
 - The monitor now baselines each physical endpoint's own buffer size when its
   listeners are admitted, still terminates on a later mutation, and has a
   deterministic 16 kHz/320-frame input plus 44.1 kHz/512-frame output contract.
-- Physical capture/monitor audibility and artifact evidence remain unverified;
-  no release tag or downstream production pin is claimed.
+- The repaired FourTrack build still reports “audio route unavailable” when
+  arming CLbuds capture. No capture occurred; failure detail remains
+  uninvestigated. A separate FourTrack stale-output fallback defect rejects
+  44.1/48 kHz new sessions after a previously-selected CLbuds output disconnects.
+- Physical capture/monitor audibility and artifact evidence failed; no release
+  tag or downstream production pin is claimed.
 - Full record: [`ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion`](docs/orp/ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md).
 
 ## ORP174 — Cooperative CoreAudio rate negotiation

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 
 ## ORP176 — CoreAudio Bluetooth duplex and directional SRC
 
-**Date:** 2026-08-12
-**Status:** Activation/startup defects repaired; final CLbuds rerun blocked by device disconnect.
+**Date:** 2026-08-13
+**Status:** Source and deterministic repair complete; final CLbuds rerun blocked by device disconnect.
 
 ### Delivered
 
@@ -41,6 +41,22 @@
   the disconnected CLbuds UID falls back to the live built-in default supporting
   both session rates.
 - No release tag or downstream production pin is claimed.
+### Candidate verification
+
+- The isolated Debug build (`/tmp/ftr085-sdk-debug`) passed the complete 80/80
+  CTest suite, including package consumers, CoreAudio route/driver contracts,
+  realtime audit, and stress labels.
+- The isolated Release build (`/tmp/ftr085-sdk-release`) passed the complete
+  80/80 CTest suite with the same package and platform gates.
+- `python3 tools/realtime_audit.py --root . --include-adjacent` passed with
+  zero hard failures and zero tracked debt findings. Prepared directional
+  converter transfers are covered by the runtime allocation guard.
+- `orpheus_coreaudio_hardware_acceptance` now reports requested/actual route
+  rates and buffers, physical/virtual/client widths, directional latency,
+  conversion/FIFO counters, bounded capture evidence, and stable terminal
+  outcomes. Built-in output-only smoke and expected unavailable-output
+  initialization checks passed; no CLbuds hardware result is inferred.
+
 - Full record: [`ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion`](docs/orp/ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md).
 
 ## ORP174 — Cooperative CoreAudio rate negotiation

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 ## ORP176 — CoreAudio Bluetooth duplex and directional SRC
 
 **Date:** 2026-08-12
-**Status:** CLbuds directional activation repaired; physical acceptance remains in progress.
+**Status:** Activation/startup defects repaired; final CLbuds rerun blocked by device disconnect.
 
 ### Delivered
 
@@ -19,18 +19,28 @@
 
 - A 2026-08-12 CLbuds inventory supplied the missing directional facts: its
   `:input` endpoint is 16 kHz/320 frames/one channel, while `:output` is
-  44.1 kHz/512 frames/two channels. The first ARM attempt exposed a monitor
-  defect: it compared every endpoint with the output callback's 512-frame
-  expectation and immediately reported a false reconfiguration.
-- The monitor now baselines each physical endpoint's own buffer size when its
-  listeners are admitted, still terminates on a later mutation, and has a
-  deterministic 16 kHz/320-frame input plus 44.1 kHz/512-frame output contract.
-- The repaired FourTrack build still reports “audio route unavailable” when
-  arming CLbuds capture. No capture occurred; failure detail remains
-  uninvestigated. A separate FourTrack stale-output fallback defect rejects
-  44.1/48 kHz new sessions after a previously-selected CLbuds output disconnects.
-- Physical capture/monitor audibility and artifact evidence failed; no release
-  tag or downstream production pin is claimed.
+  44.1 kHz/512 frames/two channels.
+- Physical ARM exposed three startup defects. Monitoring admitted pre-activation
+  rate/format facts and used one output-sized buffer expectation for every
+  endpoint. A 48 kHz duplex run also exhausted the input FIFO while the output
+  AUHAL blocked during startup because priming used maximum capacity rather than
+  the active 320-frame callback and capture continued while output startup was
+  unable to consume it.
+- Monitoring now admits the fully activated route and captures rate, buffer,
+  and stream-format baselines per endpoint. Capture priming uses the current
+  input callback size, then freezes the primed FIFO until output startup
+  completes. Later real mutations remain terminal.
+- `CoreAudioRouteMonitorTest.*` passes 13 contracts; the complete
+  `coreaudio_driver_test` binary passes 62 contracts.
+- An intermediate repaired 44.1 kHz SDK hardware run passed with 498 callbacks,
+  219,618 host/input frames, a non-zero input peak, healthy route outcome, and
+  zero render/FIFO/conversion failures. The subsequent 48 kHz run exposed the
+  startup FIFO defect above. CLbuds then disconnected before the final
+  44.1/48 kHz rerun, so final-source physical capture is not claimed.
+- FourTrack separately repairs stale persisted-output resolution and verified
+  the disconnected CLbuds UID falls back to the live built-in default supporting
+  both session rates.
+- No release tag or downstream production pin is claimed.
 - Full record: [`ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion`](docs/orp/ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md).
 
 ## ORP174 — Cooperative CoreAudio rate negotiation

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 
 ## ORP176 — CoreAudio Bluetooth duplex and directional SRC
 
-**Date:** 2026-08-11
-**Status:** Deterministic and package qualification complete; physical CLbuds acceptance remains blocked.
+**Date:** 2026-08-12
+**Status:** CLbuds directional activation repaired; physical acceptance remains in progress.
 
 ### Delivered
 
@@ -17,12 +17,16 @@
 
 ### Evidence and boundary
 
-- `polyphase_resampler_test`, `coreaudio_route_probe_test`, and `coreaudio_driver_test`
-  passed after the callback-timeline review correction; `realtime_static_audit` and its
-  unit contract also passed.
-- The repository's complete configured debug suite (80/80) and three release/package
-  contracts passed before review. No CLbuds endpoint is present locally, so no Bluetooth
-  hardware acceptance, release tag, or downstream production pin is claimed.
+- A 2026-08-12 CLbuds inventory supplied the missing directional facts: its
+  `:input` endpoint is 16 kHz/320 frames/one channel, while `:output` is
+  44.1 kHz/512 frames/two channels. The first ARM attempt exposed a monitor
+  defect: it compared every endpoint with the output callback's 512-frame
+  expectation and immediately reported a false reconfiguration.
+- The monitor now baselines each physical endpoint's own buffer size when its
+  listeners are admitted, still terminates on a later mutation, and has a
+  deterministic 16 kHz/320-frame input plus 44.1 kHz/512-frame output contract.
+- Physical capture/monitor audibility and artifact evidence remain unverified;
+  no release tag or downstream production pin is claimed.
 - Full record: [`ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion`](docs/orp/ORP176%20CoreAudio%20Bluetooth%20Duplex%20and%20Directional%20SRC%20SDK%20Completion.md).
 
 ## ORP174 — Cooperative CoreAudio rate negotiation

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -4,7 +4,7 @@
 
 **Document type:** SDK implementation and qualification record
 **Status:** Source and deterministic repair complete; final CLbuds 44.1/48 kHz rerun blocked by device disconnect
-**Date:** 2026-08-12
+**Date:** 2026-08-13
 **Consumer:** FourTrack / EightTrack, FTR085
 **Implementation baseline:** `main` plus pending activation-admission and startup-FIFO repair
 **SDK version:** 0.8.0
@@ -79,8 +79,12 @@ Source and deterministic evidence recorded in this session:
 | Resolver: output-only isolation, distinct endpoints, 16 kHz Bluetooth input conversion, strict mono conflict/fallback, related Bluetooth protection, rate-plan decisions | Passed in `coreaudio_route_probe_test` |
 | Driver: dual-AUHAL flow, active physical/client facts, converter latency and counters, terminal monitor outcomes, rollback/lifecycle behavior | `coreaudio_driver_test`: 62/62 passed |
 | Monitor activation admission: 16 kHz/320-frame input plus 44.1 kHz/512-frame output, activation rate/stream baselines, later terminal mutations | `CoreAudioRouteMonitorTest.*`: 13/13 passed |
-| Static callback audit | `realtime_static_audit` and `realtime_static_audit_unit` passed on the original directional-SRC delivery |
+| Static callback audit | `realtime_static_audit`, `realtime_static_audit_unit`, and adjacent-consumer audit passed with zero hard failures and zero tracked debt findings |
 | Installed package and public version contract | `version_contract`, `cmake_find_package`, and `cmake_package_runtime_consumer` passed against 0.8.0 |
+| Complete candidate Debug suite | `/tmp/ftr085-sdk-debug`: 80/80 CTest cases passed |
+| Complete candidate Release suite | `/tmp/ftr085-sdk-release`: 80/80 CTest cases passed |
+| Realtime static and dynamic allocation gate | Static audit: zero hard/debt findings; prepared SRC transfers: zero allocation/deallocation violations |
+| Acceptance CLI contract | Built-in output-only pass and expected unavailable-output initialization pass; no CLbuds result inferred |
 
 On 2026-08-12, live CLbuds testing exposed three defects beyond the original
 deterministic qualification. The monitor used one output-sized buffer

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -3,10 +3,10 @@
 # ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion
 
 **Document type:** SDK implementation and qualification record
-**Status:** Source and deterministic/package qualification complete; CLbuds activation repair awaiting physical acceptance
+**Status:** Source and deterministic repair complete; final CLbuds 44.1/48 kHz rerun blocked by device disconnect
 **Date:** 2026-08-12
 **Consumer:** FourTrack / EightTrack, FTR085
-**Implementation baseline:** `main` plus pending directional-buffer monitor repair
+**Implementation baseline:** `main` plus pending activation-admission and startup-FIFO repair
 **SDK version:** 0.8.0
 
 ## Decision
@@ -58,12 +58,16 @@ C ABI remains 1.0 because the C-facing ABI contract is unchanged.
    render from session to physical rate without allocation, locks, or I/O in the callback.
    Converted callbacks derive every chunk position from one session-frame base and advance
    the timeline only after the full callback, preserving contiguous sample positions.
-5. The route monitor baselines each physical endpoint's own buffer size when
-   listener admission begins. This is required for directional Bluetooth
-   routes, where a 16 kHz input may use 320 frames while a 44.1 kHz output uses
-   512 frames; subsequent mutation remains terminal.
-6. The route monitor treats property changes as terminal, publishes one structured outcome,
-   closes callback admission, and prevents stale route facts or repeated writes.
+5. Capture SRC priming uses the active input callback size rather than the
+   endpoint's maximum capacity. Once primed, capture delivery pauses while the
+   output AUHAL starts, preventing a blocking Bluetooth output startup from
+   exhausting the FIFO before output callbacks can consume it.
+6. The route monitor admits only the fully activated route and captures each
+   endpoint's nominal rate and buffer size plus each stream's virtual/physical
+   formats. This permits directional Bluetooth startup transitions while later
+   real mutations remain terminal.
+7. Property changes publish one structured terminal outcome, close callback
+   admission, and prevent stale route facts or repeated writes.
 
 ## Deterministic evidence
 
@@ -73,20 +77,29 @@ Source and deterministic evidence recorded in this session:
 |---|---|
 | Directional SRC: canonical supported rate pairs, tone/frequency preservation, exact frame accounting, limits, reset, bounded FIFO and callback-path safety | Passed in `polyphase_resampler_test` |
 | Resolver: output-only isolation, distinct endpoints, 16 kHz Bluetooth input conversion, strict mono conflict/fallback, related Bluetooth protection, rate-plan decisions | Passed in `coreaudio_route_probe_test` |
-| Driver: dual-AUHAL flow, active physical/client facts, converter latency and counters, terminal monitor outcomes, rollback/lifecycle behavior | Passed in `coreaudio_driver_test` |
-| Static callback audit | `realtime_static_audit` and `realtime_static_audit_unit` passed |
-| Complete configured SDK tree | 80/80 CTest contracts passed in `build-sdk-debug` |
+| Driver: dual-AUHAL flow, active physical/client facts, converter latency and counters, terminal monitor outcomes, rollback/lifecycle behavior | `coreaudio_driver_test`: 62/62 passed |
+| Monitor activation admission: 16 kHz/320-frame input plus 44.1 kHz/512-frame output, activation rate/stream baselines, later terminal mutations | `CoreAudioRouteMonitorTest.*`: 13/13 passed |
+| Static callback audit | `realtime_static_audit` and `realtime_static_audit_unit` passed on the original directional-SRC delivery |
 | Installed package and public version contract | `version_contract`, `cmake_find_package`, and `cmake_package_runtime_consumer` passed against 0.8.0 |
 
-On 2026-08-12, the CLbuds endpoints became available for the first physical
-activation attempt. Their separate UIDs report a 16 kHz, 320-frame, one-channel
-input and a 44.1 kHz, 512-frame, two-channel output. ARM exposed a false
-`BufferSizeChanged` outcome because monitoring applied the output callback size
-to every endpoint. The per-endpoint baseline repair has deterministic coverage.
-The repaired FourTrack build then reported **“audio route unavailable”** when
-arming the routed CLbuds input; it did not capture CLbuds audio. The runtime
-outcome and underlying CoreAudio failure details remain uninvestigated. Physical
-acceptance is failed and unresolved, not merely pending.
+On 2026-08-12, live CLbuds testing exposed three defects beyond the original
+deterministic qualification. The monitor used one output-sized buffer
+expectation for both endpoints, then admitted pre-activation sample-rate and
+stream-format facts. At 48 kHz, input priming used the endpoint's maximum
+capacity and capture continued while output AUHAL startup blocked, eventually
+overflowing the FIFO before output callbacks could drain it.
+
+The repair now baselines rate, buffer, and stream formats per endpoint only
+after full activation, primes from the active 320-frame input callback, and
+freezes the primed FIFO during output startup. The monitor and complete
+CoreAudio-driver deterministic suites pass.
+
+An intermediate 44.1 kHz hardware run passed with 498 callbacks, 219,618
+host/input frames, a non-zero captured peak, healthy route outcome, and zero
+render, FIFO, or conversion failures. The following 48 kHz run exposed the FIFO
+startup defect. CLbuds disconnected before both rates could be rerun against the
+final source, so final-source physical capture and FourTrack ARM acceptance are
+not claimed.
 
 ## FourTrack adoption boundary
 
@@ -104,15 +117,17 @@ round_trip_frames = capture_frames + playback_frames + processing_frames
 route state. Output-only sessions must leave input selection empty: no input capability
 query, listener, device write, capture failure, or permission request is allowed.
 
-Physical Bluetooth acceptance failed. After the buffer-monitor repair, the
-FourTrack host reported **“audio route unavailable”** at CLbuds ARM, with no
-observed capture. Separately, a disconnected previously-selected CLbuds output
-caused FourTrack new-session creation to reject both 44.1 and 48 kHz; that
-host stale-selection/default-fallback defect is outside this SDK repair but
-blocks output-only acceptance after device loss. Do not tag a release, mark
-FTR085 complete, or advance FourTrack's production SDK pin until a CLbuds run
-records the settled endpoint UIDs, physical/client rates, physical callback
-width, converter latency, counters, and tone/frame evidence.
+FourTrack now resolves an unavailable persisted output preference through
+CoreAudio's current live default without rewriting explicit route overrides. A
+disconnected CLbuds probe resolved to `BuiltInSpeakerDevice`, whose advertised
+ranges include both 44.1 and 48 kHz; the Swift policy test and signed app build
+passed.
+
+The final physical Bluetooth gate remains open. Do not tag a release, mark
+FTR085 complete, or advance FourTrack's production SDK pin until CLbuds is
+reconnected and both 44.1 and 48 kHz runs record settled endpoint UIDs,
+physical/client rates, physical callback width, converter latency, counters,
+and tone/frame evidence.
 
 ## References
 

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -82,8 +82,11 @@ On 2026-08-12, the CLbuds endpoints became available for the first physical
 activation attempt. Their separate UIDs report a 16 kHz, 320-frame, one-channel
 input and a 44.1 kHz, 512-frame, two-channel output. ARM exposed a false
 `BufferSizeChanged` outcome because monitoring applied the output callback size
-to every endpoint. The per-endpoint baseline repair has deterministic coverage;
-the CLbuds capture/monitor run must still demonstrate live frames and audibility.
+to every endpoint. The per-endpoint baseline repair has deterministic coverage.
+The repaired FourTrack build then reported **“audio route unavailable”** when
+arming the routed CLbuds input; it did not capture CLbuds audio. The runtime
+outcome and underlying CoreAudio failure details remain uninvestigated. Physical
+acceptance is failed and unresolved, not merely pending.
 
 ## FourTrack adoption boundary
 
@@ -101,14 +104,15 @@ round_trip_frames = capture_frames + playback_frames + processing_frames
 route state. Output-only sessions must leave input selection empty: no input capability
 query, listener, device write, capture failure, or permission request is allowed.
 
-## Remaining physical gate
-
-Physical Bluetooth acceptance is not claimed. The 2026-08-11 machine inventory had no
-CLbuds endpoint, so the required Bluetooth-input-plus-speakers, same-headset stereo,
-same-headset mono strict/fallback, and unrelated Bluetooth endpoint measurements remain
-unexecuted. Do not tag a release, mark FTR085 complete, or advance FourTrack's production
-SDK pin until a CLbuds run records the settled endpoint UIDs, physical/client rates,
-physical callback width, converter latency, counters, and tone/frame evidence.
+Physical Bluetooth acceptance failed. After the buffer-monitor repair, the
+FourTrack host reported **“audio route unavailable”** at CLbuds ARM, with no
+observed capture. Separately, a disconnected previously-selected CLbuds output
+caused FourTrack new-session creation to reject both 44.1 and 48 kHz; that
+host stale-selection/default-fallback defect is outside this SDK repair but
+blocks output-only acceptance after device loss. Do not tag a release, mark
+FTR085 complete, or advance FourTrack's production SDK pin until a CLbuds run
+records the settled endpoint UIDs, physical/client rates, physical callback
+width, converter latency, counters, and tone/frame evidence.
 
 ## References
 

--- a/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
+++ b/docs/orp/ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion.md
@@ -2,11 +2,11 @@
 
 # ORP176 CoreAudio Bluetooth Duplex and Directional SRC SDK Completion
 
-**Document type:** SDK implementation and qualification record  
-**Status:** Source and deterministic/package qualification complete; physical Bluetooth acceptance blocked  
-**Date:** 2026-08-11  
-**Consumer:** FourTrack / EightTrack, FTR085  
-**Implementation baseline:** `main` worktree at the FTR085 implementation checkpoint  
+**Document type:** SDK implementation and qualification record
+**Status:** Source and deterministic/package qualification complete; CLbuds activation repair awaiting physical acceptance
+**Date:** 2026-08-12
+**Consumer:** FourTrack / EightTrack, FTR085
+**Implementation baseline:** `main` plus pending directional-buffer monitor repair
 **SDK version:** 0.8.0
 
 ## Decision
@@ -58,7 +58,11 @@ C ABI remains 1.0 because the C-facing ABI contract is unchanged.
    render from session to physical rate without allocation, locks, or I/O in the callback.
    Converted callbacks derive every chunk position from one session-frame base and advance
    the timeline only after the full callback, preserving contiguous sample positions.
-5. The route monitor treats property changes as terminal, publishes one structured outcome,
+5. The route monitor baselines each physical endpoint's own buffer size when
+   listener admission begins. This is required for directional Bluetooth
+   routes, where a 16 kHz input may use 320 frames while a 44.1 kHz output uses
+   512 frames; subsequent mutation remains terminal.
+6. The route monitor treats property changes as terminal, publishes one structured outcome,
    closes callback admission, and prevents stale route facts or repeated writes.
 
 ## Deterministic evidence
@@ -74,11 +78,12 @@ Source and deterministic evidence recorded in this session:
 | Complete configured SDK tree | 80/80 CTest contracts passed in `build-sdk-debug` |
 | Installed package and public version contract | `version_contract`, `cmake_find_package`, and `cmake_package_runtime_consumer` passed against 0.8.0 |
 
-The physical hardware baseline captured before implementation found no CLbuds endpoint.
-A deterministic output-only CoreAudio acceptance run against `BuiltInSpeakerDevice` at
-48 kHz passed; its JSON reported two settled physical output channels, matching active
-map `{0,1}`, no input route, no conversion, and zero callback health failures. A
-negative expected-tone invocation failed as intended when no input callback existed.
+On 2026-08-12, the CLbuds endpoints became available for the first physical
+activation attempt. Their separate UIDs report a 16 kHz, 320-frame, one-channel
+input and a 44.1 kHz, 512-frame, two-channel output. ARM exposed a false
+`BufferSizeChanged` outcome because monitoring applied the output callback size
+to every endpoint. The per-endpoint baseline repair has deterministic coverage;
+the CLbuds capture/monitor run must still demonstrate live frames and audibility.
 
 ## FourTrack adoption boundary
 

--- a/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp
@@ -461,12 +461,6 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
   render_input_channels_.store(input_client_channels_, std::memory_order_release);
   render_output_channels_.store(output_client_channels_, std::memory_order_release);
 
-  if (!startRouteMonitorLocked()) {
-    route_monitor_->stop();
-    stopRenderingLocked();
-    return SessionGraphError::InternalError;
-  }
-
   if (input_conversion_active_) {
     input_callback_target_.replaceAndDrain(this);
     if (AudioOutputUnitStart(input_audio_unit_) != noErr) {
@@ -491,6 +485,9 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
       publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::InputConversionFailed);
       return SessionGraphError::NotReady;
     }
+    // Keep the primed FIFO stable while the output AudioUnit starts. Bluetooth
+    // output startup may block long enough to exhaust capture headroom.
+    input_callback_target_.replaceAndDrain(nullptr);
   }
 
   callback_target_.replaceAndDrain(callback);
@@ -505,6 +502,15 @@ SessionGraphError CoreAudioDriver::start(IAudioCallback* callback) {
     stopRenderingLocked();
     route_monitor_->stop();
     publishTerminalRouteOutcome(AudioRouteRuntimeOutcome::BackendFailure);
+    return SessionGraphError::InternalError;
+  }
+  if (input_conversion_active_) {
+    input_callback_target_.replaceAndDrain(this);
+  }
+  // Admit the fully activated route before callbacks begin consuming capture.
+  if (!startRouteMonitorLocked()) {
+    route_monitor_->stop();
+    stopRenderingLocked();
     return SessionGraphError::InternalError;
   }
 
@@ -1769,6 +1775,12 @@ bool CoreAudioDriver::prepareConverters() {
         input_render_capacity_frames_ > 4096u || chunk_frames == 0) {
       return false;
     }
+    const auto input_callback_frames = getOptionalUInt32Property(
+        input_device_id_, kAudioDevicePropertyBufferFrameSize, kAudioObjectPropertyScopeGlobal);
+    if (!input_callback_frames.has_value() || *input_callback_frames == 0 ||
+        *input_callback_frames > input_render_capacity_frames_) {
+      return false;
+    }
     audio_utils::DirectionalSrcConfig input_config;
     input_config.input_rate = input_physical_rate_;
     input_config.output_rate = config_.sample_rate;
@@ -1776,8 +1788,8 @@ bool CoreAudioDriver::prepareConverters() {
     input_config.max_input_frames = input_render_capacity_frames_;
     input_config.max_output_frames = chunk_frames;
     input_config.fifo_capacity_frames = 32768;
-    input_prime_frames_ = std::min<uint32_t>(4u * input_render_capacity_frames_,
-                                             input_config.fifo_capacity_frames / 2u);
+    input_prime_frames_ =
+        std::min<uint32_t>(4u * *input_callback_frames, input_config.fifo_capacity_frames / 2u);
     input_config.prime_input_frames = input_prime_frames_;
     input_config.allow_input_rate_correction = true;
     if (input_converter_.prepare(input_config) != SessionGraphError::OK) {

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
@@ -92,6 +92,20 @@ bool CoreAudioRouteMonitor::start() noexcept {
     }
     ++registered_count_;
   }
+
+  const auto buffer_address = deviceAddress(kAudioDevicePropertyBufferFrameSize);
+  for (CoreAudioRouteDevice& device : devices_) {
+    if (device.expected_buffer_frames != 0) {
+      continue;
+    }
+    UInt32 observed_buffer_frames = 0;
+    if (!readUInt32(property_api_, device.device_id, buffer_address, observed_buffer_frames) ||
+        observed_buffer_frames == 0) {
+      stop();
+      return false;
+    }
+    device.expected_buffer_frames = observed_buffer_frames;
+  }
   return true;
 }
 
@@ -168,11 +182,14 @@ CoreAudioRoutePollResult CoreAudioRouteMonitor::poll() noexcept {
       return CoreAudioRoutePollResult::SampleRateChanged;
     }
 
+    const UInt32 expected_buffer_frames = device.expected_buffer_frames != 0
+                                              ? device.expected_buffer_frames
+                                              : expected_buffer_frames_;
     UInt32 observed_buffer_frames = 0;
     if (!readUInt32(property_api_, device.device_id, buffer_address, observed_buffer_frames)) {
       return CoreAudioRoutePollResult::BackendFailure;
     }
-    if (observed_buffer_frames != expected_buffer_frames_) {
+    if (observed_buffer_frames != expected_buffer_frames) {
       return CoreAudioRoutePollResult::BufferSizeChanged;
     }
     return CoreAudioRoutePollResult::NoChange;

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.cpp
@@ -2,7 +2,9 @@
 #include "coreaudio_route_monitor.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
+#include <limits>
 #include <utility>
 
 namespace orpheus {
@@ -93,18 +95,34 @@ bool CoreAudioRouteMonitor::start() noexcept {
     ++registered_count_;
   }
 
+  const auto rate_address = deviceAddress(kAudioDevicePropertyNominalSampleRate);
   const auto buffer_address = deviceAddress(kAudioDevicePropertyBufferFrameSize);
   for (CoreAudioRouteDevice& device : devices_) {
-    if (device.expected_buffer_frames != 0) {
-      continue;
-    }
+    Float64 observed_rate = 0.0;
     UInt32 observed_buffer_frames = 0;
-    if (!readUInt32(property_api_, device.device_id, buffer_address, observed_buffer_frames) ||
+    if (!readFloat64(property_api_, device.device_id, rate_address, observed_rate) ||
+        !std::isfinite(observed_rate) || observed_rate <= 0.0 ||
+        observed_rate > static_cast<Float64>(std::numeric_limits<uint32_t>::max()) ||
+        std::floor(observed_rate) != observed_rate ||
+        !readUInt32(property_api_, device.device_id, buffer_address, observed_buffer_frames) ||
         observed_buffer_frames == 0) {
       stop();
       return false;
     }
+    device.expected_sample_rate = static_cast<uint32_t>(observed_rate);
     device.expected_buffer_frames = observed_buffer_frames;
+  }
+
+  const auto virtual_address = streamAddress(kAudioStreamPropertyVirtualFormat);
+  const auto physical_address = streamAddress(kAudioStreamPropertyPhysicalFormat);
+  for (CoreAudioRouteStream& stream : streams_) {
+    if (!readFormat(property_api_, stream.stream_id, virtual_address,
+                    stream.expected_virtual_format) ||
+        !readFormat(property_api_, stream.stream_id, physical_address,
+                    stream.expected_physical_format)) {
+      stop();
+      return false;
+    }
   }
   return true;
 }

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
@@ -28,14 +28,16 @@ struct CoreAudioRouteDevice {
   bool monitors_input = false;
   bool monitors_output = false;
   bool is_private_aggregate = false;
+  /// Captured from the active endpoint during start().
   uint32_t expected_sample_rate = 0;
-  /// Zero captures the endpoint's current buffer size during start().
+  /// Captured from the active endpoint during start().
   uint32_t expected_buffer_frames = 0;
 };
 
 /// One stream whose virtual and physical formats are part of the active route.
 struct CoreAudioRouteStream {
   AudioStreamID stream_id = 0;
+  /// Captured from the active stream during start().
   AudioStreamBasicDescription expected_virtual_format{};
   AudioStreamBasicDescription expected_physical_format{};
 };

--- a/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
+++ b/src/platform/audio_drivers/coreaudio/coreaudio_route_monitor.h
@@ -22,12 +22,15 @@ enum class CoreAudioRoutePollResult : uint8_t {
   BackendFailure,
 };
 
+/// Physical endpoint facts observed when the route becomes active.
 struct CoreAudioRouteDevice {
   AudioDeviceID device_id = 0;
   bool monitors_input = false;
   bool monitors_output = false;
   bool is_private_aggregate = false;
   uint32_t expected_sample_rate = 0;
+  /// Zero captures the endpoint's current buffer size during start().
+  uint32_t expected_buffer_frames = 0;
 };
 
 /// One stream whose virtual and physical formats are part of the active route.

--- a/tests/audio_io/coreaudio_output_only_injected_test.cpp
+++ b/tests/audio_io/coreaudio_output_only_injected_test.cpp
@@ -290,6 +290,27 @@ TEST(CoreAudioOutputOnlyInjectedTest, PreserveRateMismatchIsRejectedWithoutPrope
   EXPECT_TRUE(property_api->writeLedger().empty());
   EXPECT_TRUE(audit.operations.empty());
 }
+
+TEST(CoreAudioOutputOnlyInjectedTest, ExplicitUnavailableOutputDoesNotFallBackToDefault) {
+  auto property_api = std::make_shared<test_support::FakeCoreAudioPropertyApi>();
+  auto query = std::make_shared<OutputOnlyRouteQuery>(11, 2, 48000.0);
+  DirectionAudit audit;
+  CoreAudioDriver driver(query, property_api, &audit);
+
+  AudioDriverConfig config;
+  config.sample_rate = 48000;
+  config.buffer_size = 256;
+  config.num_inputs = 0;
+  config.num_outputs = 2;
+  config.input_device_id = "stale.input.uid";
+  config.output_device_id = "stale.output.uid";
+  config.sample_rate_policy = AudioSampleRatePolicy::RequestExactRateOrConvert;
+
+  EXPECT_EQ(driver.initialize(config), SessionGraphError::InvalidParameter);
+  EXPECT_EQ(driver.getTelemetry().route_outcome, AudioRouteRuntimeOutcome::OutputRouteUnavailable);
+  EXPECT_TRUE(property_api->writeLedger().empty());
+  EXPECT_TRUE(audit.operations.empty());
+}
 } // namespace
 } // namespace orpheus
 #endif

--- a/tests/audio_io/coreaudio_route_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_route_monitor_test.cpp
@@ -140,6 +140,28 @@ TEST(CoreAudioRouteMonitorTest, BufferChangeReportsBufferSizeChanged) {
   EXPECT_FALSE(fixture.monitor->permitsRendering());
 }
 
+TEST(CoreAudioRouteMonitorTest, AcceptsDirectionalEndpointBufferFramesAndDetectsMutation) {
+  FakeCoreAudioPropertyApi api;
+  api.setAlive(1, 1);
+  api.setAlive(2, 1);
+  api.setRate(1, 44100.0);
+  api.setRate(2, 16000.0);
+  api.setBuffer(1, 512);
+  api.setBuffer(2, 320);
+  CoreAudioRouteMonitor monitor(api, 44100, 512,
+                                std::vector<CoreAudioRouteDevice>{{1, false, true, false, 44100},
+                                                                  {2, true, false, false, 16000}},
+                                {});
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+
+  api.setBuffer(2, 256);
+  api.notify(2, kAudioDevicePropertyBufferFrameSize);
+  EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::BufferSizeChanged);
+  EXPECT_FALSE(monitor.permitsRendering());
+}
+
 TEST(CoreAudioRouteMonitorTest, PropertyReadFailureReportsBackendFailure) {
   RouteMonitorFixture fixture;
   ASSERT_TRUE(fixture.initialization_ok);

--- a/tests/audio_io/coreaudio_route_monitor_test.cpp
+++ b/tests/audio_io/coreaudio_route_monitor_test.cpp
@@ -162,6 +162,50 @@ TEST(CoreAudioRouteMonitorTest, AcceptsDirectionalEndpointBufferFramesAndDetects
   EXPECT_FALSE(monitor.permitsRendering());
 }
 
+TEST(CoreAudioRouteMonitorTest, CapturesActivationRateBeforeDetectingLaterMutation) {
+  FakeCoreAudioPropertyApi api;
+  api.setAlive(1, 1);
+  api.setRate(1, 16000.0);
+  api.setBuffer(1, 320);
+  CoreAudioRouteMonitor monitor(
+      api, 44100, 512, std::vector<CoreAudioRouteDevice>{{1, true, true, false, 44100}}, {});
+
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+
+  api.thirdPartyRateMutation(1, 8000.0);
+  api.notify(1, kAudioDevicePropertyNominalSampleRate);
+  EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::SampleRateChanged);
+  EXPECT_FALSE(monitor.permitsRendering());
+}
+
+TEST(CoreAudioRouteMonitorTest, CapturesActivationStreamFormatsBeforeLaterMutation) {
+  FakeCoreAudioPropertyApi api;
+  api.setAlive(1, 1);
+  api.setRate(1, 16000.0);
+  api.setBuffer(1, 320);
+  auto activation_format = testFormat();
+  activation_format.mSampleRate = 16000.0;
+  activation_format.mChannelsPerFrame = 1;
+  api.setFormat(100, kAudioStreamPropertyVirtualFormat, activation_format);
+  api.setFormat(100, kAudioStreamPropertyPhysicalFormat, activation_format);
+  const auto stale_format = testFormat();
+  CoreAudioRouteMonitor monitor(
+      api, 44100, 512, std::vector<CoreAudioRouteDevice>{{1, true, true, false, 44100}},
+      std::vector<CoreAudioRouteStream>{{100, stale_format, stale_format}});
+
+  ASSERT_TRUE(monitor.start());
+  monitor.requestCheck();
+  ASSERT_EQ(monitor.poll(), CoreAudioRoutePollResult::NoChange);
+
+  activation_format.mChannelsPerFrame = 2;
+  api.setFormat(100, kAudioStreamPropertyVirtualFormat, activation_format);
+  api.notify(100, kAudioStreamPropertyVirtualFormat);
+  EXPECT_EQ(monitor.poll(), CoreAudioRoutePollResult::FormatChanged);
+  EXPECT_FALSE(monitor.permitsRendering());
+}
+
 TEST(CoreAudioRouteMonitorTest, PropertyReadFailureReportsBackendFailure) {
   RouteMonitorFixture fixture;
   ASSERT_TRUE(fixture.initialization_ok);

--- a/tests/audio_io/coreaudio_route_probe_test.cpp
+++ b/tests/audio_io/coreaudio_route_probe_test.cpp
@@ -483,6 +483,22 @@ TEST(CoreAudioRouteProbeTest, InvalidMapsAreClassifiedAfterBothEndpointsResolve)
   EXPECT_EQ(fake->ledger.output_channel_reads, 1);
   EXPECT_EQ(fake->ledger.sample_rate_range_reads, 0);
 }
+TEST(CoreAudioRouteProbeTest, ChannelMapDefaultsOrderAndBoundsAreDeterministic) {
+  std::vector<uint16_t> resolved;
+
+  EXPECT_TRUE(detail::resolveCoreAudioChannelMap({}, 2, 2, resolved));
+  EXPECT_EQ(resolved, (std::vector<uint16_t>{0, 1}));
+
+  EXPECT_TRUE(detail::resolveCoreAudioChannelMap({1, 0}, 2, 2, resolved));
+  EXPECT_EQ(resolved, (std::vector<uint16_t>{1, 0}));
+  EXPECT_TRUE(detail::resolveCoreAudioChannelMap({2, 0}, 2, 3, resolved));
+  EXPECT_EQ(resolved, (std::vector<uint16_t>{2, 0}));
+
+  EXPECT_FALSE(detail::resolveCoreAudioChannelMap({0, 0}, 2, 2, resolved));
+  EXPECT_FALSE(detail::resolveCoreAudioChannelMap({0, 2}, 2, 2, resolved));
+  EXPECT_FALSE(detail::resolveCoreAudioChannelMap({0}, 2, 2, resolved));
+  EXPECT_FALSE(detail::resolveCoreAudioChannelMap({0, 1, 2}, 2, 3, resolved));
+}
 
 TEST(CoreAudioRouteProbeTest, UnsupportedRateSkipsCurrentAndRunningQueries) {
   auto fake = std::make_shared<FakeCoreAudioRouteQuery>();

--- a/tests/audio_io/directional_sample_rate_converter_test.cpp
+++ b/tests/audio_io/directional_sample_rate_converter_test.cpp
@@ -2,6 +2,8 @@
 //
 // FTR085: bounded directional sample-rate conversion contracts.
 
+#define ORPHEUS_TEST_DEFINE_RT_ALLOC_HOOKS
+#include "../support/rt_guard.hpp"
 #include <orpheus/directional_sample_rate_converter.h>
 
 #include <algorithm>
@@ -137,12 +139,15 @@ TEST(DirectionalSampleRateConverterTest, RejectsUnsupportedPairsAndInvalidResour
 }
 
 TEST(DirectionalSampleRateConverterTest, PreservesSineFrequencyAndPassbandGain) {
-  const auto upsampled = convertSine(16'000, 44'100, 1'000.0, 40'000);
+  const auto upsampled_44k = convertSine(16'000, 44'100, 1'000.0, 40'000);
+  const auto upsampled_48k = convertSine(16'000, 48'000, 1'000.0, 40'000);
   const auto downsampled = convertSine(48'000, 24'000, 1'000.0, 12'000);
 
-  EXPECT_NEAR(measureFrequency(upsampled, 44'100, 2'000), 1'000.0, 2.0);
+  EXPECT_NEAR(measureFrequency(upsampled_44k, 44'100, 2'000), 1'000.0, 2.0);
+  EXPECT_NEAR(measureFrequency(upsampled_48k, 48'000, 2'000), 1'000.0, 2.0);
   EXPECT_NEAR(measureFrequency(downsampled, 24'000, 1'000), 1'000.0, 2.0);
-  EXPECT_NEAR(rms(upsampled, 2'000), 1.0 / std::sqrt(2.0), 0.03);
+  EXPECT_NEAR(rms(upsampled_44k, 2'000), 1.0 / std::sqrt(2.0), 0.03);
+  EXPECT_NEAR(rms(upsampled_48k, 2'000), 1.0 / std::sqrt(2.0), 0.03);
   EXPECT_NEAR(rms(downsampled, 1'000), 1.0 / std::sqrt(2.0), 0.03);
 }
 
@@ -283,4 +288,34 @@ TEST(DirectionalSampleRateConverterTest, ReportsLatencyFromConfiguredPrime) {
   DirectionalSampleRateConverter converter;
   ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
   EXPECT_EQ(converter.latencyOutputFrames(), 573u);
+}
+
+TEST(DirectionalSampleRateConverterTest, PreparedTransfersAreRealtimeAllocationFree) {
+  DirectionalSampleRateConverter converter;
+  const auto config = makeConfig(16'000, 48'000);
+  ASSERT_EQ(converter.prepare(config), SessionGraphError::OK);
+  std::vector<float> input(1024, 0.125F);
+  std::vector<float> output(1024, 0.0F);
+  const float* input_channels[] = {input.data()};
+  float* output_channels[] = {output.data()};
+
+  bool transfers_ok = true;
+  orpheus::tests::support::RtGuardState::reset();
+  {
+    orpheus::tests::support::RtSection realtime;
+    for (int iteration = 0; iteration < 8; ++iteration) {
+      const auto pushed = converter.pushInput(input_channels, 1, 1024);
+      uint32_t required = 0;
+      const auto required_status = converter.requiredInputFrames(1024, required);
+      const auto rendered = converter.renderOutput(output_channels, 1, 1024);
+      transfers_ok = transfers_ok && pushed.status == DirectionalSrcStatus::Ok &&
+                     required_status == DirectionalSrcStatus::Ok &&
+                     rendered.status == DirectionalSrcStatus::Ok &&
+                     rendered.output_frames_produced == 1024;
+    }
+  }
+
+  EXPECT_TRUE(transfers_ok);
+  EXPECT_EQ(orpheus::tests::support::RtGuardState::allocViolations(), 0u);
+  EXPECT_EQ(orpheus::tests::support::RtGuardState::deallocViolations(), 0u);
 }

--- a/tools/coreaudio_hardware_acceptance.cpp
+++ b/tools/coreaudio_hardware_acceptance.cpp
@@ -10,13 +10,17 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -26,8 +30,11 @@ struct Options {
   std::optional<std::string> input_uid;
   uint32_t sample_rate = 48000;
   uint32_t seconds = 10;
+  uint32_t grace_ms = 5000;
   bool allow_mono_fallback = false;
   std::optional<double> expected_input_tone_hz;
+  std::optional<orpheus::AudioRouteRuntimeOutcome> expected_initialize_outcome;
+  std::optional<orpheus::AudioRouteRuntimeOutcome> expected_terminal_outcome;
 };
 
 std::string json_escape(const std::string& value) {
@@ -79,6 +86,32 @@ uint32_t parse_uint32(const std::string& value, const char* option) {
   }
 }
 
+std::optional<orpheus::AudioRouteRuntimeOutcome> parse_route_outcome(std::string_view value) {
+  using Outcome = orpheus::AudioRouteRuntimeOutcome;
+  constexpr std::pair<std::string_view, Outcome> names[] = {
+      {"Healthy", Outcome::Healthy},
+      {"SampleRateUnsupported", Outcome::SampleRateUnsupported},
+      {"SampleRateChangeFailed", Outcome::SampleRateChangeFailed},
+      {"SampleRateChanged", Outcome::SampleRateChanged},
+      {"BufferSizeChanged", Outcome::BufferSizeChanged},
+      {"FormatChanged", Outcome::FormatChanged},
+      {"ChannelMapInvalid", Outcome::ChannelMapInvalid},
+      {"InputRouteUnavailable", Outcome::InputRouteUnavailable},
+      {"OutputRouteUnavailable", Outcome::OutputRouteUnavailable},
+      {"PermissionDenied", Outcome::PermissionDenied},
+      {"BackendFailure", Outcome::BackendFailure},
+      {"ProfileConflict", Outcome::ProfileConflict},
+      {"InputConversionFailed", Outcome::InputConversionFailed},
+      {"OutputConversionFailed", Outcome::OutputConversionFailed},
+  };
+  for (const auto& [name, outcome] : names) {
+    if (name == value) {
+      return outcome;
+    }
+  }
+  return std::nullopt;
+}
+
 Options parse_options(int argc, char** argv) {
   Options options;
   for (int index = 1; index < argc; ++index) {
@@ -89,10 +122,21 @@ Options parse_options(int argc, char** argv) {
       }
       return argv[++index];
     };
+    auto parse_expected_outcome = [&](const char* option) -> orpheus::AudioRouteRuntimeOutcome {
+      const auto value = require_value(option);
+      const auto outcome = parse_route_outcome(value);
+      if (!outcome.has_value()) {
+        print_error(std::string("invalid-") + option, 2);
+      }
+      return *outcome;
+    };
     if (argument == "--help") {
       std::cout << "usage: orpheus_coreaudio_hardware_acceptance --output-uid UID "
                    "[--input-uid UID] [--sample-rate 44100|48000] [--seconds N] "
-                   "[--output-policy strict|mono-fallback] [--expect-input-tone-hz HZ]\n";
+                   "[--grace-ms N] [--output-policy strict|mono-fallback] "
+                   "[--expect-input-tone-hz HZ] "
+                   "[--expect-initialize-outcome OUTCOME] "
+                   "[--expect-terminal-outcome OUTCOME]\n";
       std::exit(0);
     }
     if (argument == "--output-uid") {
@@ -103,6 +147,8 @@ Options parse_options(int argc, char** argv) {
       options.sample_rate = parse_uint32(require_value("sample-rate"), "sample-rate");
     } else if (argument == "--seconds") {
       options.seconds = parse_uint32(require_value("seconds"), "seconds");
+    } else if (argument == "--grace-ms") {
+      options.grace_ms = parse_uint32(require_value("grace-ms"), "grace-ms");
     } else if (argument == "--output-policy") {
       const auto policy = require_value("output-policy");
       if (policy == "strict") {
@@ -123,6 +169,10 @@ Options parse_options(int argc, char** argv) {
       } catch (const std::exception&) {
         print_error("invalid-expect-input-tone-hz", 2);
       }
+    } else if (argument == "--expect-initialize-outcome") {
+      options.expected_initialize_outcome = parse_expected_outcome("expect-initialize-outcome");
+    } else if (argument == "--expect-terminal-outcome") {
+      options.expected_terminal_outcome = parse_expected_outcome("expect-terminal-outcome");
     } else {
       print_error("unknown-option", 2);
     }
@@ -136,11 +186,24 @@ Options parse_options(int argc, char** argv) {
   if (options.seconds == 0) {
     print_error("seconds-must-be-positive", 2);
   }
+  if (options.grace_ms == 0) {
+    print_error("grace-ms-must-be-positive", 2);
+  }
+  if (options.expected_initialize_outcome.has_value() &&
+      options.expected_terminal_outcome.has_value()) {
+    print_error("initialize-and-terminal-expectations-are-exclusive", 2);
+  }
+  if (options.expected_terminal_outcome == orpheus::AudioRouteRuntimeOutcome::Healthy) {
+    print_error("terminal-outcome-must-not-be-healthy", 2);
+  }
   return options;
 }
 
 class AcceptanceCallback final : public orpheus::IAudioCallback {
 public:
+  AcceptanceCallback(float* capture, uint64_t capture_capacity)
+      : capture_(capture), capture_capacity_(capture_capacity) {}
+
   void processAudio(const orpheus::AudioProcessBlock& block) noexcept override {
     for (uint16_t channel = 0; channel < block.num_output_channels; ++channel) {
       if (block.output_buffers != nullptr && block.output_buffers[channel] != nullptr) {
@@ -153,19 +216,18 @@ public:
         block.input_buffers[0] == nullptr) {
       return;
     }
-    const float* input = block.input_buffers[0];
-    float previous = previous_input_sample_;
-    for (uint32_t frame = 0; frame < block.num_frames; ++frame) {
-      const float sample = input[frame];
-      peak_ = std::max(peak_, std::fabs(sample));
-      if ((previous < 0.0f && sample >= 0.0f) || (previous >= 0.0f && sample < 0.0f)) {
-        zero_crossings_.fetch_add(1, std::memory_order_relaxed);
-      }
-      previous = sample;
-    }
-    previous_input_sample_ = previous;
+
+    const uint64_t capture_start = input_frames_.load(std::memory_order_relaxed);
     input_callbacks_.fetch_add(1, std::memory_order_relaxed);
-    input_frames_.fetch_add(block.num_frames, std::memory_order_relaxed);
+    uint64_t copied = 0;
+    if (capture_ != nullptr && capture_start < capture_capacity_) {
+      copied = std::min<uint64_t>(block.num_frames, capture_capacity_ - capture_start);
+      std::copy_n(block.input_buffers[0], static_cast<size_t>(copied), capture_ + capture_start);
+    }
+    if (copied < block.num_frames) {
+      capture_overflow_frames_.fetch_add(block.num_frames - copied, std::memory_order_relaxed);
+    }
+    input_frames_.store(capture_start + block.num_frames, std::memory_order_release);
   }
 
   uint64_t callbacks() const noexcept {
@@ -180,21 +242,18 @@ public:
   uint64_t input_frames() const noexcept {
     return input_frames_.load(std::memory_order_relaxed);
   }
-  uint64_t zero_crossings() const noexcept {
-    return zero_crossings_.load(std::memory_order_relaxed);
-  }
-  float peak() const noexcept {
-    return peak_;
+  uint64_t capture_overflow_frames() const noexcept {
+    return capture_overflow_frames_.load(std::memory_order_relaxed);
   }
 
 private:
+  float* capture_ = nullptr;
+  uint64_t capture_capacity_ = 0;
   std::atomic<uint64_t> callbacks_{0};
   std::atomic<uint64_t> callback_frames_{0};
   std::atomic<uint64_t> input_callbacks_{0};
   std::atomic<uint64_t> input_frames_{0};
-  std::atomic<uint64_t> zero_crossings_{0};
-  float previous_input_sample_ = 0.0f;
-  float peak_ = 0.0f;
+  std::atomic<uint64_t> capture_overflow_frames_{0};
 };
 
 const char* route_outcome_name(orpheus::AudioRouteRuntimeOutcome outcome) {
@@ -281,6 +340,133 @@ void append_map(std::ostringstream& json, const char* key, const std::vector<uin
   json << ']';
 }
 
+template <typename T>
+void append_optional_number(std::ostringstream& json, const char* key,
+                            const std::optional<T>& value, bool& first) {
+  if (!first) {
+    json << ',';
+  }
+  first = false;
+  json << '"' << key << "\":";
+  if (value.has_value()) {
+    json << *value;
+  } else {
+    json << "null";
+  }
+}
+
+struct CaptureEvidence {
+  std::optional<float> first_sample;
+  std::optional<float> last_sample;
+  double peak = 0.0;
+  uint64_t zero_crossings = 0;
+  uint64_t sequence_hash = 1469598103934665603ULL;
+  bool finite = true;
+};
+
+CaptureEvidence inspect_capture(const float* samples, uint64_t frames) {
+  CaptureEvidence evidence;
+  if (samples == nullptr || frames == 0) {
+    return evidence;
+  }
+  evidence.first_sample = samples[0];
+  evidence.last_sample = samples[frames - 1];
+  float previous = 0.0F;
+  for (uint64_t frame = 0; frame < frames; ++frame) {
+    const float sample = samples[frame];
+    evidence.finite = evidence.finite && std::isfinite(sample);
+    evidence.peak = std::max(evidence.peak, std::fabs(static_cast<double>(sample)));
+    if ((previous < 0.0F && sample >= 0.0F) || (previous >= 0.0F && sample < 0.0F)) {
+      ++evidence.zero_crossings;
+    }
+    previous = sample;
+    uint32_t bits = 0;
+    std::memcpy(&bits, &sample, sizeof(bits));
+    for (uint32_t shift = 0; shift < 32; shift += 8) {
+      evidence.sequence_hash ^= static_cast<uint8_t>((bits >> shift) & 0xffU);
+      evidence.sequence_hash *= 1099511628211ULL;
+    }
+  }
+  return evidence;
+}
+
+double capture_frequency_hz(const CaptureEvidence& evidence, uint64_t frames,
+                            uint32_t sample_rate) {
+  return frames == 0 ? 0.0
+                     : static_cast<double>(evidence.zero_crossings) * sample_rate /
+                           (2.0 * static_cast<double>(frames));
+}
+
+void append_route_facts(std::ostringstream& json, const orpheus::ActiveAudioRoute& active,
+                        const orpheus::AudioIoRouteState& io_route,
+                        const orpheus::AudioIoTelemetry& telemetry, bool& first) {
+  append_string(json, "selected_input_uid", io_route.selected_input_device_id, first);
+  append_string(json, "selected_output_uid", io_route.selected_output_device_id, first);
+  append_string(json, "resolved_input_uid", active.input_device_id, first);
+  append_string(json, "resolved_output_uid", active.output_device_id, first);
+  append_map(json, "active_input_map", active.input_channels, first);
+  append_map(json, "active_output_map", active.output_channels, first);
+  append_number(json, "requested_sample_rate", active.requested_sample_rate, first);
+  append_number(json, "actual_sample_rate", active.actual_sample_rate, first);
+  append_number(json, "requested_buffer_frames", io_route.requested_buffer_size, first);
+  append_number(json, "actual_buffer_frames", active.actual_buffer_frames, first);
+  append_number(json, "route_state_actual_buffer_frames", io_route.actual_buffer_size, first);
+  append_number(json, "available_input_channels", active.available_input_channels, first);
+  append_number(json, "available_output_channels", active.available_output_channels, first);
+  append_number(json, "requested_output_channels", active.requested_output_channels, first);
+  append_number(json, "resolved_output_channels", active.resolved_output_channels, first);
+  append_number(json, "input_virtual_format_channels", active.input_virtual_format_channels, first);
+  append_number(json, "output_virtual_format_channels", active.output_virtual_format_channels,
+                first);
+  append_number(json, "input_client_format_channels", active.input_client_format_channels, first);
+  append_number(json, "output_client_format_channels", active.output_client_format_channels, first);
+  append_number(json, "input_physical_sample_rate", active.input_physical_sample_rate, first);
+  append_number(json, "output_physical_sample_rate", active.output_physical_sample_rate, first);
+  append_number(json, "input_client_sample_rate", active.input_client_sample_rate, first);
+  append_number(json, "output_client_sample_rate", active.output_client_sample_rate, first);
+  append_bool(json, "input_conversion_active", active.input_conversion_active, first);
+  append_bool(json, "output_conversion_active", active.output_conversion_active, first);
+  append_bool(json, "input_is_bluetooth", active.input_is_bluetooth, first);
+  append_bool(json, "output_is_bluetooth", active.output_is_bluetooth, first);
+  append_bool(json, "endpoints_related", active.endpoints_related, first);
+  append_bool(json, "output_mono_fallback", active.output_mono_fallback, first);
+  append_number(json, "capture_latency_frames", active.latency.capture_frames, first);
+  append_number(json, "playback_latency_frames", active.latency.playback_frames, first);
+  append_number(json, "processing_latency_frames", active.latency.processing_frames, first);
+  append_bool(json, "latency_complete", active.latency.complete, first);
+  append_optional_number(json, "input_device_latency_frames", io_route.latency.input_device_frames,
+                         first);
+  append_optional_number(json, "input_safety_offset_frames",
+                         io_route.latency.input_safety_offset_frames, first);
+  append_optional_number(json, "input_stream_latency_frames", io_route.latency.input_stream_frames,
+                         first);
+  append_optional_number(json, "input_converter_latency_frames",
+                         io_route.latency.input_converter_frames, first);
+  append_optional_number(json, "output_device_latency_frames",
+                         io_route.latency.output_device_frames, first);
+  append_optional_number(json, "output_safety_offset_frames",
+                         io_route.latency.output_safety_offset_frames, first);
+  append_optional_number(json, "output_stream_latency_frames",
+                         io_route.latency.output_stream_frames, first);
+  append_optional_number(json, "output_converter_latency_frames",
+                         io_route.latency.output_converter_frames, first);
+  append_optional_number(json, "callback_buffer_frames", io_route.latency.callback_buffer_frames,
+                         first);
+  append_optional_number(json, "aggregate_or_audio_unit_frames",
+                         io_route.latency.aggregate_or_audio_unit_frames, first);
+  append_optional_number(json, "input_audio_unit_frames", io_route.latency.input_audio_unit_frames,
+                         first);
+  append_optional_number(json, "output_audio_unit_frames",
+                         io_route.latency.output_audio_unit_frames, first);
+  append_bool(json, "detailed_latency_complete", io_route.latency.complete, first);
+  append_number(json, "input_render_failures", telemetry.input_render_failures, first);
+  append_number(json, "input_fifo_overruns", telemetry.input_fifo_overruns, first);
+  append_number(json, "input_fifo_underruns", telemetry.input_fifo_underruns, first);
+  append_number(json, "input_conversion_failures", telemetry.input_conversion_failures, first);
+  append_number(json, "output_conversion_failures", telemetry.output_conversion_failures, first);
+  append_string(json, "route_outcome", route_outcome_name(telemetry.route_outcome), first);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -288,6 +474,16 @@ int main(int argc, char** argv) {
   auto driver = orpheus::createCoreAudioDriver();
   if (!driver) {
     print_error("coreaudio-driver-unavailable", 3);
+  }
+
+  const uint64_t expected_frames = static_cast<uint64_t>(options.sample_rate) * options.seconds;
+  std::vector<float> capture;
+  if (options.input_uid.has_value()) {
+    try {
+      capture.resize(static_cast<size_t>(expected_frames));
+    } catch (const std::exception&) {
+      print_error("capture-buffer-allocation-failed", 3);
+    }
   }
 
   orpheus::AudioDriverConfig config;
@@ -306,19 +502,43 @@ int main(int argc, char** argv) {
                                      : orpheus::AudioOutputChannelPolicy::RequireRequestedChannels;
 
   const auto initialize_result = driver->initialize(config);
-  const auto active = driver->getActiveRoute();
-  const auto io_route = driver->getAudioIoRouteState();
-  const auto telemetry_before = driver->getTelemetry();
-  if (initialize_result != orpheus::SessionGraphError::OK) {
+  const auto initialized_route = driver->getActiveRoute();
+  const auto initialized_io_route = driver->getAudioIoRouteState();
+  const auto initialized_telemetry = driver->getTelemetry();
+  if (initialize_result != orpheus::SessionGraphError::OK ||
+      options.expected_initialize_outcome.has_value()) {
+    const bool expected =
+        initialize_result != orpheus::SessionGraphError::OK &&
+        options.expected_initialize_outcome.has_value() &&
+        initialized_telemetry.route_outcome == *options.expected_initialize_outcome;
     std::ostringstream json;
-    json << "{\"status\":\"failed\",\"reason\":\"initialize\",\"route_outcome\":\""
-         << route_outcome_name(telemetry_before.route_outcome) << "\",\"detail\":\""
-         << json_escape(io_route.detail) << "\"}\n";
+    json << std::setprecision(10) << '{';
+    bool first = true;
+    append_string(json, "status", expected ? "passed" : "failed", first);
+    append_string(json, "backend", "CoreAudio", first);
+    append_string(json, "reason", "initialize", first);
+    append_bool(json, "initialize_result_ok", initialize_result == orpheus::SessionGraphError::OK,
+                first);
+    append_string(json, "input_uid", options.input_uid.value_or(""), first);
+    append_string(json, "output_uid", options.output_uid, first);
+    append_number(json, "sample_rate", options.sample_rate, first);
+    append_number(json, "seconds", options.seconds, first);
+    append_number(json, "requested_frames", expected_frames, first);
+    append_string(json, "output_policy", output_policy_name(options.allow_mono_fallback), first);
+    append_route_facts(json, initialized_route, initialized_io_route, initialized_telemetry, first);
+    append_string(json, "expected_initialize_outcome",
+                  options.expected_initialize_outcome.has_value()
+                      ? route_outcome_name(*options.expected_initialize_outcome)
+                      : "",
+                  first);
+    append_bool(json, "initialize_outcome_expected", expected, first);
+    append_string(json, "detail", initialized_io_route.detail, first);
+    json << "}\n";
     std::cout << json.str();
-    return 4;
+    return expected ? 0 : 4;
   }
 
-  AcceptanceCallback callback;
+  AcceptanceCallback callback(capture.empty() ? nullptr : capture.data(), expected_frames);
   const auto start_result = driver->start(&callback);
   if (start_result != orpheus::SessionGraphError::OK) {
     const auto telemetry = driver->getTelemetry();
@@ -330,32 +550,102 @@ int main(int argc, char** argv) {
     return 5;
   }
 
-  std::this_thread::sleep_for(std::chrono::seconds(options.seconds));
+  std::optional<orpheus::AudioRouteRuntimeOutcome> first_terminal_outcome;
+  uint64_t callbacks_at_terminal = 0;
+  bool terminal_stable = true;
+  bool no_callbacks_after_terminal = true;
+  bool wait_ok = true;
+  if (options.expected_terminal_outcome.has_value()) {
+    const auto search_deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(options.grace_ms);
+    std::optional<std::chrono::steady_clock::time_point> stability_deadline;
+    for (;;) {
+      const auto now = std::chrono::steady_clock::now();
+      if (now >= search_deadline && !stability_deadline.has_value()) {
+        break;
+      }
+      if (stability_deadline.has_value() && now >= *stability_deadline) {
+        break;
+      }
+
+      const auto outcome = driver->getTelemetry().route_outcome;
+      if (!first_terminal_outcome.has_value()) {
+        if (outcome != orpheus::AudioRouteRuntimeOutcome::Healthy) {
+          first_terminal_outcome = outcome;
+          callbacks_at_terminal = callback.callbacks();
+          stability_deadline = now + std::chrono::milliseconds(options.grace_ms);
+        }
+      } else {
+        terminal_stable = terminal_stable && outcome == *first_terminal_outcome;
+        no_callbacks_after_terminal =
+            no_callbacks_after_terminal && callback.callbacks() == callbacks_at_terminal;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (first_terminal_outcome.has_value()) {
+      no_callbacks_after_terminal =
+          no_callbacks_after_terminal && callback.callbacks() == callbacks_at_terminal;
+    }
+    wait_ok = first_terminal_outcome.has_value() &&
+              *first_terminal_outcome == *options.expected_terminal_outcome && terminal_stable &&
+              no_callbacks_after_terminal;
+  } else if (options.input_uid.has_value()) {
+    const auto capture_deadline = std::chrono::steady_clock::now() +
+                                  std::chrono::seconds(options.seconds) +
+                                  std::chrono::milliseconds(options.grace_ms);
+    while (callback.input_frames() < expected_frames &&
+           std::chrono::steady_clock::now() < capture_deadline) {
+      const auto outcome = driver->getTelemetry().route_outcome;
+      if (outcome != orpheus::AudioRouteRuntimeOutcome::Healthy) {
+        first_terminal_outcome = outcome;
+        wait_ok = false;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (callback.input_frames() < expected_frames) {
+      wait_ok = false;
+    }
+  } else {
+    std::this_thread::sleep_for(std::chrono::seconds(options.seconds));
+  }
+
+  const uint64_t callbacks_before_stop = callback.callbacks();
   const auto stop_result = driver->stop();
+  const uint64_t callbacks_after_stop = callback.callbacks();
   const auto negotiated = driver->getActiveRoute();
   const auto final_io_route = driver->getAudioIoRouteState();
   const auto telemetry = driver->getTelemetry();
   const auto route_outcome = telemetry.route_outcome;
-  const uint64_t expected_frames = static_cast<uint64_t>(options.sample_rate) * options.seconds;
+  const uint64_t captured_frames = std::min<uint64_t>(callback.input_frames(), expected_frames);
+  const auto capture_evidence =
+      inspect_capture(capture.empty() ? nullptr : capture.data(), captured_frames);
   const double zero_crossing_frequency =
-      callback.input_frames() == 0 ? 0.0
-                                   : static_cast<double>(callback.zero_crossings()) *
-                                         static_cast<double>(options.sample_rate) /
-                                         (2.0 * static_cast<double>(callback.input_frames()));
+      capture_frequency_hz(capture_evidence, captured_frames, options.sample_rate);
   const bool counters_clear =
       telemetry.input_render_failures == 0 && telemetry.input_fifo_overruns == 0 &&
       telemetry.input_fifo_underruns == 0 && telemetry.input_conversion_failures == 0 &&
       telemetry.output_conversion_failures == 0;
-  const bool input_activity_matches = options.input_uid.has_value()
-                                          ? callback.input_callbacks() > 0
-                                          : callback.input_callbacks() == 0;
+  const bool capture_capacity_exact =
+      !options.input_uid.has_value() || capture.size() == expected_frames;
+  const bool input_activity_matches =
+      options.input_uid.has_value()
+          ? callback.input_callbacks() > 0 && captured_frames == expected_frames
+          : callback.input_callbacks() == 0;
   const bool tone_in_tolerance =
       !options.expected_input_tone_hz.has_value() ||
-      (callback.input_frames() != 0 &&
+      (options.input_uid.has_value() && captured_frames == expected_frames &&
+       capture_evidence.finite && capture_evidence.peak > 0.0 &&
        std::abs(zero_crossing_frequency - *options.expected_input_tone_hz) <= 20.0);
+  const bool expected_terminal_ok = !options.expected_terminal_outcome.has_value() ||
+                                    (first_terminal_outcome.has_value() &&
+                                     *first_terminal_outcome == *options.expected_terminal_outcome);
+  const bool healthy_run = options.expected_terminal_outcome.has_value() ||
+                           route_outcome == orpheus::AudioRouteRuntimeOutcome::Healthy;
   const bool passed = stop_result == orpheus::SessionGraphError::OK && callback.callbacks() > 0 &&
-                      route_outcome == orpheus::AudioRouteRuntimeOutcome::Healthy &&
-                      counters_clear && input_activity_matches && tone_in_tolerance;
+                      wait_ok && healthy_run && counters_clear && capture_capacity_exact &&
+                      input_activity_matches && tone_in_tolerance && expected_terminal_ok &&
+                      callbacks_after_stop == callbacks_before_stop;
 
   std::ostringstream json;
   json << std::setprecision(10) << '{';
@@ -368,48 +658,44 @@ int main(int argc, char** argv) {
   append_number(json, "seconds", options.seconds, first);
   append_number(json, "requested_frames", expected_frames, first);
   append_string(json, "output_policy", output_policy_name(options.allow_mono_fallback), first);
-  append_number(json, "input_physical_sample_rate", negotiated.input_physical_sample_rate, first);
-  append_number(json, "output_physical_sample_rate", negotiated.output_physical_sample_rate, first);
-  append_number(json, "input_client_sample_rate", negotiated.input_client_sample_rate, first);
-  append_number(json, "output_client_sample_rate", negotiated.output_client_sample_rate, first);
-  append_number(json, "available_input_channels", negotiated.available_input_channels, first);
-  append_number(json, "available_output_channels", negotiated.available_output_channels, first);
-  append_number(json, "requested_output_channels", negotiated.requested_output_channels, first);
-  append_number(json, "resolved_output_channels", negotiated.resolved_output_channels, first);
-  append_number(json, "input_client_format_channels", negotiated.input_client_format_channels,
-                first);
-  append_number(json, "output_client_format_channels", negotiated.output_client_format_channels,
-                first);
-  append_bool(json, "input_conversion_active", negotiated.input_conversion_active, first);
-  append_bool(json, "output_conversion_active", negotiated.output_conversion_active, first);
-  append_bool(json, "input_is_bluetooth", negotiated.input_is_bluetooth, first);
-  append_bool(json, "output_is_bluetooth", negotiated.output_is_bluetooth, first);
-  append_bool(json, "endpoints_related", negotiated.endpoints_related, first);
-  append_bool(json, "output_mono_fallback", negotiated.output_mono_fallback, first);
-  append_map(json, "active_output_map", negotiated.output_channels, first);
-  append_number(json, "capture_latency_frames", negotiated.latency.capture_frames, first);
-  append_number(json, "playback_latency_frames", negotiated.latency.playback_frames, first);
-  append_number(json, "processing_latency_frames", negotiated.latency.processing_frames, first);
-  append_bool(json, "latency_complete", negotiated.latency.complete, first);
-  append_number(json, "input_converter_latency_frames",
-                final_io_route.latency.input_converter_frames.value_or(0), first);
-  append_number(json, "output_converter_latency_frames",
-                final_io_route.latency.output_converter_frames.value_or(0), first);
+  append_route_facts(json, negotiated, final_io_route, telemetry, first);
   append_number(json, "callbacks", callback.callbacks(), first);
   append_number(json, "callback_frames", callback.callback_frames(), first);
   append_number(json, "input_callbacks", callback.input_callbacks(), first);
   append_number(json, "input_frames", callback.input_frames(), first);
-  append_number(json, "input_render_failures", telemetry.input_render_failures, first);
-  append_number(json, "input_fifo_overruns", telemetry.input_fifo_overruns, first);
-  append_number(json, "input_fifo_underruns", telemetry.input_fifo_underruns, first);
-  append_number(json, "input_conversion_failures", telemetry.input_conversion_failures, first);
-  append_number(json, "output_conversion_failures", telemetry.output_conversion_failures, first);
-  append_string(json, "route_outcome", route_outcome_name(route_outcome), first);
-  append_number(json, "input_peak", callback.peak(), first);
+  append_number(json, "capture_capacity_frames",
+                options.input_uid.has_value() ? expected_frames : 0, first);
+  append_number(json, "captured_frames", captured_frames, first);
+  append_bool(json, "capture_capacity_exact", capture_capacity_exact, first);
+  append_number(json, "uncaptured_input_frames", callback.capture_overflow_frames(), first);
+  append_number(json, "captured_duration_seconds",
+                static_cast<double>(captured_frames) / options.sample_rate, first);
+  append_optional_number(json, "capture_first_sample", capture_evidence.first_sample, first);
+  append_optional_number(json, "capture_last_sample", capture_evidence.last_sample, first);
+  append_number(json, "input_peak", capture_evidence.peak, first);
+  append_bool(json, "capture_finite", capture_evidence.finite, first);
+  append_number(json, "capture_zero_crossings", capture_evidence.zero_crossings, first);
+  append_number(json, "capture_sequence_hash", capture_evidence.sequence_hash, first);
   append_number(json, "zero_crossing_frequency_hz", zero_crossing_frequency, first);
+  append_bool(json, "capture_complete",
+              !options.input_uid.has_value() || captured_frames == expected_frames, first);
+  append_bool(json, "stop_result_ok", stop_result == orpheus::SessionGraphError::OK, first);
+  append_number(json, "callbacks_before_stop", callbacks_before_stop, first);
+  append_number(json, "callbacks_after_stop", callbacks_after_stop, first);
+  append_bool(json, "callbacks_stopped_after_terminal", no_callbacks_after_terminal, first);
+  append_string(
+      json, "first_terminal_outcome",
+      first_terminal_outcome.has_value() ? route_outcome_name(*first_terminal_outcome) : "", first);
+  append_bool(json, "terminal_outcome_stable", terminal_stable, first);
+  append_bool(json, "wait_complete", wait_ok, first);
   if (options.expected_input_tone_hz.has_value()) {
     append_number(json, "expected_input_tone_hz", *options.expected_input_tone_hz, first);
     append_bool(json, "input_tone_in_tolerance", tone_in_tolerance, first);
+  }
+  if (options.expected_terminal_outcome.has_value()) {
+    append_string(json, "expected_terminal_outcome",
+                  route_outcome_name(*options.expected_terminal_outcome), first);
+    append_bool(json, "terminal_outcome_expected", expected_terminal_ok, first);
   }
   append_bool(json, "passed", passed, first);
   json << "}\n";

--- a/tools/realtime_audit.py
+++ b/tools/realtime_audit.py
@@ -184,11 +184,31 @@ def scan_target(target: ScanTarget) -> list[Finding]:
 
 
 def default_targets(root: Path, include_adjacent: bool) -> list[ScanTarget]:
+    coreaudio_driver = root / "src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp"
+    converter = root / "src/core/audio_io/directional_sample_rate_converter.cpp"
     targets = [
         ScanTarget(
             "CoreAudio render callback",
-            root / "src/platform/audio_drivers/coreaudio/coreaudio_driver.cpp",
+            coreaudio_driver,
             r"OSStatus\s+CoreAudioDriver::renderCallback\s*\(",
+            pattern_sets=(HARD_REALTIME_SET,),
+        ),
+        ScanTarget(
+            "CoreAudio input capture callback",
+            coreaudio_driver,
+            r"OSStatus\s+CoreAudioDriver::inputRenderCallback\s*\(",
+            pattern_sets=(HARD_REALTIME_SET,),
+        ),
+        ScanTarget(
+            "DirectionalSampleRateConverter push transfer",
+            converter,
+            r"DirectionalSrcTransfer\s+DirectionalSampleRateConverter::pushInput\s*\(",
+            pattern_sets=(HARD_REALTIME_SET,),
+        ),
+        ScanTarget(
+            "DirectionalSampleRateConverter render transfer",
+            converter,
+            r"DirectionalSrcTransfer\s+DirectionalSampleRateConverter::renderOutput\s*\(",
             pattern_sets=(HARD_REALTIME_SET,),
         ),
         ScanTarget(


### PR DESCRIPTION
## Problem
CLbuds exposes independent CoreAudio endpoints: input is 16 kHz/320 frames and output is 44.1 kHz/512 frames. Live ARM/capture exposed three startup defects:

- the monitor applied the output buffer expectation to the input endpoint;
- pre-activation rate/stream facts treated Bluetooth activation settlement as a terminal route change; and
- 48 kHz duplex capture exhausted the FIFO while output AUHAL startup blocked because priming used maximum input capacity and capture continued before output callbacks could consume it.

## Change
- admit the route monitor only after full input/output activation;
- register listeners before capturing each active endpoint's rate/buffer and stream-format baselines, so an activation transition before the read is accepted while a notification after a baseline read remains detectable by the admission poll;
- prime input SRC from the active callback size rather than maximum capacity;
- freeze the primed capture FIFO during blocking output startup, then resume capture before monitor admission;
- retain terminal handling for later rate, buffer, stream-format, availability, and backend changes.

## Verification
- `CoreAudioRouteMonitorTest.*`: 13/13 passed, including directional buffers, activation-rate/stream settlement, and later mutations
- complete `coreaudio_driver_test`: 62/62 passed
- `clang-format` applied by the commit hook
- intermediate CLbuds 44.1 kHz run: 498 callbacks / 219,618 input frames, non-zero input peak, healthy route, zero render/FIFO/SRC failures

The subsequent 48 kHz run exposed the now-repaired startup FIFO overflow. CLbuds disconnected before the final 44.1/48 kHz rerun, so final-source physical capture is not claimed.

## Release gate
No package release, production pin, release tag, or ORP176/FTR085 completion claim. Final CLbuds 44.1 and 48 kHz hardware acceptance remains required.