### PR TITLE
fix(shmui): import hierarchy-aware meter lifecycle

### DIFF
--- a/packages/shmui-juce/CMakeLists.txt
+++ b/packages/shmui-juce/CMakeLists.txt
@@ -152,6 +152,8 @@ if(SHMUI_JUCE_BUILD_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/SHM014AudioBoundaryFixture.cpp
   )
   target_link_libraries(shmui_shm014_fixture PRIVATE orpheus_shmui_juce)
+  target_compile_definitions(shmui_shm014_fixture PRIVATE
+    JUCE_MODAL_LOOPS_PERMITTED=1)
   target_compile_features(shmui_shm014_fixture PRIVATE cxx_std_20)
   add_test(NAME shmui_shm014_audio_boundary COMMAND shmui_shm014_fixture)
 

--- a/packages/shmui-juce/Components/LevelMeter.cpp
+++ b/packages/shmui-juce/Components/LevelMeter.cpp
@@ -14,6 +14,25 @@
 
 namespace shmui {
 
+class LevelMeter::ShowingStateWatcher final : public juce::ComponentMovementWatcher {
+public:
+  explicit ShowingStateWatcher(LevelMeter& owner)
+      : juce::ComponentMovementWatcher(&owner), m_owner(owner) {}
+
+  void componentMovedOrResized(bool, bool) override {}
+
+  void componentPeerChanged() override {
+    m_owner.updateTimerState();
+  }
+
+  void componentVisibilityChanged() override {
+    m_owner.updateTimerState();
+  }
+
+private:
+  LevelMeter& m_owner;
+};
+
 //==============================================================================
 LevelMeter::LevelMeter() : LevelMeter(1) {}
 
@@ -30,12 +49,14 @@ LevelMeter::LevelMeter(int numChannels)
   m_style = LevelMeterStyle::fromTheme(defaultTheme());
   setBallistics(MeterBallistics::Peak);
   addDefaultThemeListener(this);
+  m_showingStateWatcher = std::make_unique<ShowingStateWatcher>(*this);
   updateTimerState();
 }
 
 LevelMeter::~LevelMeter() {
-  removeDefaultThemeListener(this);
+  m_showingStateWatcher.reset();
   stopTimer();
+  removeDefaultThemeListener(this);
 }
 
 //==============================================================================
@@ -281,10 +302,6 @@ void LevelMeter::timerCallback() {
 
   updateMeter();
   repaint();
-}
-
-void LevelMeter::visibilityChanged() {
-  updateTimerState();
 }
 
 void LevelMeter::updateTimerState() {

--- a/packages/shmui-juce/Components/LevelMeter.h
+++ b/packages/shmui-juce/Components/LevelMeter.h
@@ -26,6 +26,7 @@
 #include <JuceHeader.h>
 #include <array>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace shmui {
@@ -345,8 +346,9 @@ public:
 
 private:
   //==============================================================================
+  class ShowingStateWatcher;
+
   void timerCallback() override;
-  void visibilityChanged() override;
   void updateTimerState();
   void updateMeter();
   float linearToNormalized(float linear) const;
@@ -364,6 +366,8 @@ private:
   MeterBallistics m_ballistics = MeterBallistics::Peak;
   LevelMeterStyle m_style;
   bool m_usesDefaultThemeStyle = true;
+
+  std::unique_ptr<ShowingStateWatcher> m_showingStateWatcher;
 
   // dB range
   float m_minDB = -60.0f;

--- a/packages/shmui-juce/shmui-juce-import.json
+++ b/packages/shmui-juce/shmui-juce-import.json
@@ -3,8 +3,8 @@
   "source": {
     "repository": "shmui",
     "path": "juce/Source",
-    "revision": "2b1e1977f887cf99b05eff9a2294647553e90ae8",
-    "content_sha256": "f2b6641c53543deae341d7553c7a9949452b36fdf46017cd29b8cfe19380900a",
+    "revision": "f21b433770191e83b45e2ab3824dfd02bfaa7d60",
+    "content_sha256": "07acb560e40ba520e0e89c10876c57cf42bd4250b47226699c98c567a732f03c",
     "content_hash_algorithm": "sha256-path-nul-content-v1"
   },
   "design_token_contract_version": "0.6.0",

--- a/packages/shmui-juce/tests/SHM014AudioBoundaryFixture.cpp
+++ b/packages/shmui-juce/tests/SHM014AudioBoundaryFixture.cpp
@@ -1,9 +1,11 @@
 #include "Audio/AudioAnalyzer.h"
 #include "Components/BarVisualizer.h"
+#include "Components/LevelMeter.h"
 #include "Components/WaveformVisualizer.h"
 
 #include <cmath>
 #include <cstdio>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -25,6 +27,52 @@ void requireFiniteNormalized(const std::vector<float>& values, const char* messa
       return;
     }
   }
+}
+
+bool pumpUntil(const std::function<bool()>& condition, int timeoutMs) {
+  const auto deadline = juce::Time::getMillisecondCounterHiRes() + static_cast<double>(timeoutMs);
+  while (juce::Time::getMillisecondCounterHiRes() < deadline) {
+    if (condition())
+      return true;
+
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
+  }
+
+  return condition();
+}
+
+void pumpFor(int durationMs) {
+  (void)pumpUntil([] { return false; }, durationMs);
+}
+
+void requireLevelMeterFollowsAncestorShowingState() {
+  juce::Component host;
+  shmui::LevelMeter meter;
+  host.setBounds(0, 0, 120, 240);
+  host.addToDesktop(juce::ComponentPeer::windowIsTemporary);
+  host.setVisible(false);
+  host.addAndMakeVisible(meter);
+  meter.setBounds(host.getLocalBounds());
+  meter.enableHistory(4);
+  meter.setLevel(0, 1.1f);
+
+  host.setVisible(true);
+  require(pumpUntil([&meter] { return meter.getHistorySize() > 0; }, 500),
+          "meter added under a hidden host starts when the host is shown");
+
+  host.setVisible(false);
+  meter.reset();
+  meter.clearHistory();
+  meter.setLevel(0, 1.1f);
+  pumpFor(150);
+  require(meter.getHistorySize() == 0 && !meter.hasClipped(),
+          "meter remains idle while an ancestor is hidden");
+
+  host.setVisible(true);
+  require(pumpUntil([&meter] { return meter.getHistorySize() > 0; }, 500),
+          "meter resumes when the hidden ancestor is shown");
+
+  host.removeFromDesktop();
 }
 } // namespace
 
@@ -116,6 +164,8 @@ int main() {
   live.setSensitivity(std::numeric_limits<float>::quiet_NaN());
   live.setActive(true);
   require(live.getHistory().empty(), "hidden live visualizer does not tick");
+
+  requireLevelMeterFollowsAncestorShowingState();
 
   return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Dependency
Imports the source-of-truth ShmUI repair from chrislyons/shmui#24.

## Scope
Updates only the formatted ShmUI package, its generated import manifest, and the deterministic SHM014 boundary fixture.

## Verification
- `python3 tools/shmui_juce_manifest.py --check`
- `SDK_ROOT=/Users/chrislyons/dev/orpheus-sdk-occ182-meter <pinned-shmui-source>/scripts/sync-juce.sh --check`

The source check used the manifest-pinned `74ea503` revision and passed; current ShmUI `main` also contains unrelated SHM024 work and is intentionally not imported here.