### PR TITLE
fix(shmui): import level meter gradient repair

### DIFF
--- a/packages/shmui-juce/Components/LevelMeter.cpp
+++ b/packages/shmui-juce/Components/LevelMeter.cpp
@@ -373,21 +373,20 @@ float LevelMeter::normalizedToDB(float normalized) const {
 }
 
 juce::Colour LevelMeter::getColorForLevel(float normalized) const {
-  float dB = normalizedToDB(normalized);
+  const float dB = normalizedToDB(normalized);
 
-  if (dB >= m_style.redThreshold) {
+  if (dB >= m_style.clipThreshold)
+    return m_style.clipColor;
+  if (dB >= m_style.redThreshold)
     return m_style.meterColorHigh;
-  } else if (dB >= m_style.yellowThreshold) {
-    // Interpolate between yellow and red
-    float t = (dB - m_style.yellowThreshold) / (m_style.redThreshold - m_style.yellowThreshold);
+  if (dB >= m_style.yellowThreshold) {
+    const float t =
+        (dB - m_style.yellowThreshold) / (m_style.redThreshold - m_style.yellowThreshold);
     return m_style.meterColorMid.interpolatedWith(m_style.meterColorHigh, t);
-  } else {
-    // Interpolate between green and yellow
-    float lowDB = m_minDB;
-    float t = (dB - lowDB) / (m_style.yellowThreshold - lowDB);
-    return m_style.meterColorLow.interpolatedWith(m_style.meterColorMid,
-                                                  t * t); // Quadratic for smoother green
   }
+
+  const float t = (dB - m_minDB) / (m_style.yellowThreshold - m_minDB);
+  return m_style.meterColorLow.interpolatedWith(m_style.meterColorMid, t * t);
 }
 
 void LevelMeter::drawMeter(juce::Graphics& g, juce::Rectangle<float> bounds, int channel) {
@@ -401,32 +400,38 @@ void LevelMeter::drawMeter(juce::Graphics& g, juce::Rectangle<float> bounds, int
 
   // Draw level fill with gradient
   juce::Rectangle<float> fillBounds;
-
   if (m_isVertical) {
-    float fillHeight = bounds.getHeight() * displayLevel;
-    fillBounds = bounds.removeFromBottom(fillHeight);
+    const float fillHeight = bounds.getHeight() * displayLevel;
+    fillBounds = {bounds.getX(), bounds.getBottom() - fillHeight, bounds.getWidth(), fillHeight};
   } else {
-    float fillWidth = bounds.getWidth() * displayLevel;
-    fillBounds = bounds.removeFromLeft(fillWidth);
+    const float fillWidth = bounds.getWidth() * displayLevel;
+    fillBounds = {bounds.getX(), bounds.getY(), fillWidth, bounds.getHeight()};
   }
 
-  // Create gradient for level
+  // Thresholds are defined in the same normalized signal space as displayLevel.
+  // Vertical meters increase upward; horizontal meters increase rightward.
+  const float yellowNorm = dbToNormalized(m_style.yellowThreshold);
+  const float redNorm = dbToNormalized(m_style.redThreshold);
+  const float clipNorm = dbToNormalized(m_style.clipThreshold);
+
   juce::ColourGradient gradient;
   if (m_isVertical) {
-    gradient = juce::ColourGradient::vertical(m_style.meterColorHigh, bounds.getY(),
+    gradient = juce::ColourGradient::vertical(m_style.clipColor, bounds.getY(),
                                               m_style.meterColorLow, bounds.getBottom());
+    gradient.addColour(0.0, m_style.clipColor);
+    gradient.addColour(1.0 - clipNorm, m_style.clipColor);
+    gradient.addColour(1.0 - redNorm, m_style.meterColorHigh);
+    gradient.addColour(1.0 - yellowNorm, m_style.meterColorMid);
+    gradient.addColour(1.0, m_style.meterColorLow);
   } else {
     gradient = juce::ColourGradient::horizontal(m_style.meterColorLow, bounds.getX(),
-                                                m_style.meterColorHigh, bounds.getRight());
+                                                m_style.clipColor, bounds.getRight());
+    gradient.addColour(0.0, m_style.meterColorLow);
+    gradient.addColour(yellowNorm, m_style.meterColorMid);
+    gradient.addColour(redNorm, m_style.meterColorHigh);
+    gradient.addColour(clipNorm, m_style.clipColor);
+    gradient.addColour(1.0, m_style.clipColor);
   }
-
-  // Add color stops
-  float yellowNorm = dbToNormalized(m_style.yellowThreshold);
-  float redNorm = dbToNormalized(m_style.redThreshold);
-
-  gradient.addColour(0.0, m_style.meterColorLow);
-  gradient.addColour(yellowNorm, m_style.meterColorMid);
-  gradient.addColour(redNorm, m_style.meterColorHigh);
 
   g.setGradientFill(gradient);
   g.fillRoundedRectangle(fillBounds, m_style.cornerRadius);

--- a/packages/shmui-juce/Components/LevelMeter.h
+++ b/packages/shmui-juce/Components/LevelMeter.h
@@ -13,7 +13,7 @@
     - VU, PPM, and Peak ballistics
     - Clip indicator with latch
     - dB scale markings
-    - Gradient coloring (green -> yellow -> red)
+    - Gradient coloring (green -> yellow -> orange -> red)
 
   ==============================================================================
 */
@@ -74,8 +74,8 @@ struct LevelMeterStyle {
 
   // Thresholds (in dB)
   float yellowThreshold = -12.0f; // Start yellow here
-  float redThreshold = -3.0f;     // Start red here
-  float clipThreshold = 0.0f;     // Clip indicator threshold
+  float redThreshold = -3.0f;     // Start orange warning here
+  float clipThreshold = 0.0f;     // Start red clip here
 
   // Appearance
   float meterWidth = 8.0f; // Width of each meter bar

--- a/packages/shmui-juce/shmui-juce-import.json
+++ b/packages/shmui-juce/shmui-juce-import.json
@@ -3,8 +3,8 @@
   "source": {
     "repository": "shmui",
     "path": "juce/Source",
-    "revision": "f21b433770191e83b45e2ab3824dfd02bfaa7d60",
-    "content_sha256": "07acb560e40ba520e0e89c10876c57cf42bd4250b47226699c98c567a732f03c",
+    "revision": "c0562a94475eae97a31f3a881a886fbb50c8ae1c",
+    "content_sha256": "3902f564baccc93c1b02cc6031a5f89994dc236d63550500bc16336844c18714",
     "content_hash_algorithm": "sha256-path-nul-content-v1"
   },
   "design_token_contract_version": "0.6.0",

--- a/packages/shmui-juce/tests/SHM014AudioBoundaryFixture.cpp
+++ b/packages/shmui-juce/tests/SHM014AudioBoundaryFixture.cpp
@@ -74,6 +74,80 @@ void requireLevelMeterFollowsAncestorShowingState() {
 
   host.removeFromDesktop();
 }
+
+int colourDistance(juce::Colour left, juce::Colour right) {
+  return std::abs(static_cast<int>(left.getRed()) - static_cast<int>(right.getRed())) +
+         std::abs(static_cast<int>(left.getGreen()) - static_cast<int>(right.getGreen())) +
+         std::abs(static_cast<int>(left.getBlue()) - static_cast<int>(right.getBlue()));
+}
+
+void requireColourNear(juce::Colour actual, juce::Colour expected, const char* message) {
+  if (colourDistance(actual, expected) <= 12)
+    return;
+
+  ++failures;
+  std::fprintf(stderr, "SHM014 failure: %s (actual #%02X%02X%02X, expected #%02X%02X%02X)\n",
+               message, actual.getRed(), actual.getGreen(), actual.getBlue(), expected.getRed(),
+               expected.getGreen(), expected.getBlue());
+}
+
+void requireLevelMeterUsesThresholdGradient(bool vertical) {
+  const int width = vertical ? 40 : 240;
+  const int height = vertical ? 240 : 40;
+
+  juce::Component host;
+  shmui::LevelMeter meter;
+  host.addToDesktop(juce::ComponentPeer::windowIsTemporary);
+  host.setBounds(0, 0, width, height);
+  host.setVisible(true);
+  host.addAndMakeVisible(meter);
+  meter.setBounds(host.getLocalBounds());
+  meter.setVertical(vertical);
+  meter.setBallistics(shmui::MeterBallistics::Peak);
+  meter.setDBRange(-60.0f, 6.0f);
+
+  auto style =
+      shmui::LevelMeterStyle::fromPresentation(shmui::tokens::meter::consolePresentation());
+  style.meterWidth = 24.0f;
+  style.cornerRadius = 0.0f;
+  style.showPeakHold = false;
+  style.showClipIndicator = false;
+  style.showScale = false;
+  style.showTicks = false;
+  meter.setStyle(style);
+
+  meter.setLevelDB(0, 6.0f);
+  const auto displayed = pumpUntil([&meter] { return meter.hasClipped(); }, 500);
+  require(displayed, "full-scale meter input reaches the presentation state");
+  if (!displayed) {
+    host.removeFromDesktop();
+    return;
+  }
+
+  auto image = meter.createComponentSnapshot(meter.getLocalBounds(), true);
+  const auto normalisedForDb = [](float dB) { return (dB + 60.0f) / 66.0f; };
+  const auto sample = [&image](float normalised) {
+    const auto coordinate = juce::jlimit(0, 239, juce::roundToInt(normalised * 239.0f));
+    return image.getPixelAt(20, coordinate);
+  };
+
+  const auto sampleAtDb = [&](float dB) {
+    const auto normalised = normalisedForDb(dB);
+    return vertical
+               ? sample(1.0f - normalised)
+               : image.getPixelAt(juce::jlimit(0, 239, juce::roundToInt(normalised * 239.0f)), 20);
+  };
+
+  requireColourNear(sampleAtDb(-12.0f), style.meterColorMid,
+                    "meter caution threshold uses the yellow stop");
+  requireColourNear(sampleAtDb(-60.0f), style.meterColorLow,
+                    "meter safe floor uses the green stop");
+  requireColourNear(sampleAtDb(-3.0f), style.meterColorHigh,
+                    "meter warning threshold uses the orange stop");
+  requireColourNear(sampleAtDb(0.0f), style.clipColor, "meter clip threshold uses the red stop");
+
+  host.removeFromDesktop();
+}
 } // namespace
 
 int main() {
@@ -165,6 +239,8 @@ int main() {
   live.setActive(true);
   require(live.getHistory().empty(), "hidden live visualizer does not tick");
 
+  requireLevelMeterUsesThresholdGradient(true);
+  requireLevelMeterUsesThresholdGradient(false);
   requireLevelMeterFollowsAncestorShowingState();
 
   return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Dependency
Depends on chrislyons/shmui#25. The import manifest records source revision `c0562a94475eae97a31f3a881a886fbb50c8ae1c`.

## Change
Synchronizes the SHM015 LevelMeter repair: preserve full meter bounds before creating the active fill, restore all four Console semantic stops, and add vertical/horizontal rendered-pixel coverage.

## Verification
- `python3 tools/shmui_juce_manifest.py --check`
- `SDK_ROOT=/Users/chrislyons/dev/orpheus-sdk-shm015-meter-gradient-import /Users/chrislyons/dev/shmui-shm015-meter-gradient/scripts/sync-juce.sh --check`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target shmui_shm014_fixture --parallel 6 && ./build/shmui-juce/shmui_shm014_fixture` in `/private/tmp/shm015-gradient-consumer`